### PR TITLE
Fix Sandcastle review prompt args

### DIFF
--- a/.sandcastle/main.mts
+++ b/.sandcastle/main.mts
@@ -76,7 +76,6 @@ const shellQuote = (value: string) => `'${value.replace(/'/g, "'\\''")}'`;
 
 const hostRepoDir = process.cwd();
 const hostSandboxGitConfigPath = join(hostRepoDir, sandboxGitConfigPath);
-const sourceBranch = execText("git", ["branch", "--show-current"]);
 
 const copySandboxGitConfigHook = [
   "mkdir -p .sandcastle",
@@ -235,7 +234,6 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
             agent: sandcastle.codex("gpt-5.5", { effort: "medium" }),
             promptFile: "./.sandcastle/review-prompt.md",
             promptArgs: {
-              SOURCE_BRANCH: sourceBranch,
               BRANCH: issue.branch,
             },
           });


### PR DESCRIPTION
## Summary
- Remove the manual `SOURCE_BRANCH` prompt arg override from the Sandcastle reviewer run.
- Let Sandcastle provide its built-in `SOURCE_BRANCH`/`TARGET_BRANCH` values so review prompt substitution does not fail after implementation.

## Verification
- `pnpm exec tsc --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck .sandcastle/main.mts`
- `pnpm exec prettier --check .sandcastle/main.mts`
- `git diff --check`
- `pnpm run sandcastle` got past the previous post-implementation `PromptError` and exited cleanly.