### PR TITLE
Prevent Sandcastle sandbox dependency installs

### DIFF
--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -51,7 +51,11 @@ Do not invent product decisions or architecture changes that are not supported b
 
 Before committing, run `pnpm verify:sandcastle`.
 
-Run additional targeted tests when the issue clearly touches a test-covered behavior. Do not require local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests unless the issue explicitly depends on those surfaces.
+Do not run `pnpm install`, `npm install`, `corepack install`, or any other dependency install/refresh command inside the sandbox.
+
+Do not run `pnpm test`, `pnpm test:*`, Playwright, local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests unless the issue explicitly requires those surfaces and the needed dependencies/services already work without install repair.
+
+If a targeted test is blocked by missing optional native packages, browser binaries, Supabase, Docker, or another sandbox dependency issue, stop that check and record it as a verification limitation in the commit message. Do not try to repair sandbox dependencies.
 
 # COMMIT
 

--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -11,6 +11,10 @@ For each branch:
 3. After resolving conflicts, run `pnpm verify:sandcastle` to verify the merged result
 4. If tests fail, fix the issues before proceeding to the next branch
 
+Do not run `pnpm install`, `npm install`, `corepack install`, or any other dependency install/refresh command inside the sandbox.
+
+Do not run `pnpm test`, `pnpm test:*`, Playwright, local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests. If verification is blocked by missing optional native packages, browser binaries, Supabase, Docker, or another sandbox dependency issue, report it as a verification limitation and do not try to repair sandbox dependencies.
+
 After all branches are merged, make a single commit summarizing the merge.
 
 # CLOSE ISSUES

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -57,8 +57,14 @@ Review the code changes on branch `{{BRANCH}}` and improve code clarity, consist
 If you find improvements to make:
 
 1. Make the changes directly on this branch
-2. Run `pnpm verify:sandcastle` and any relevant targeted checks
+2. Run `pnpm verify:sandcastle`
 3. Commit describing the refinements
+
+Do not run `pnpm install`, `npm install`, `corepack install`, or any other dependency install/refresh command inside the sandbox.
+
+Do not run `pnpm test`, `pnpm test:*`, Playwright, local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests unless the review finding explicitly depends on those surfaces and the needed dependencies/services already work without install repair.
+
+If a targeted check is blocked by missing optional native packages, browser binaries, Supabase, Docker, or another sandbox dependency issue, report it as a verification limitation. Do not try to repair sandbox dependencies.
 
 If the code is already clean and well-structured, do nothing.
 


### PR DESCRIPTION
## Summary
- Tell implement, review, and merge agents not to run dependency install or refresh commands inside Sandcastle sandboxes.
- Restrict sandbox verification to `pnpm verify:sandcastle` by default.
- Require missing native packages, browser binaries, Supabase, Docker, and similar sandbox dependency problems to be reported as verification limitations instead of repaired with `pnpm install`.

## Why
The copied host `node_modules` can make Vitest/Playwright hit Linux-native optional dependency gaps. The agent was responding by running `pnpm install` inside the sandbox, which makes Sandcastle runs far too slow and noisy.

## Verification
- `git diff --check`
- Prompt-only change reviewed locally.