### PR TITLE
Restrict Sandcastle direct test commands

### DIFF
--- a/.sandcastle/implement-prompt.md
+++ b/.sandcastle/implement-prompt.md
@@ -53,7 +53,7 @@ Before committing, run `pnpm verify:sandcastle`.
 
 Do not run `pnpm install`, `npm install`, `corepack install`, or any other dependency install/refresh command inside the sandbox.
 
-Do not run `pnpm test`, `pnpm test:*`, Playwright, local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests unless the issue explicitly requires those surfaces and the needed dependencies/services already work without install repair.
+Do not run `pnpm test`, `pnpm test:*`, `pnpm exec vitest`, `pnpm exec playwright`, Playwright, local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests unless the issue explicitly requires those surfaces and the needed dependencies/services already work without install repair.
 
 If a targeted test is blocked by missing optional native packages, browser binaries, Supabase, Docker, or another sandbox dependency issue, stop that check and record it as a verification limitation in the commit message. Do not try to repair sandbox dependencies.
 

--- a/.sandcastle/merge-prompt.md
+++ b/.sandcastle/merge-prompt.md
@@ -13,7 +13,7 @@ For each branch:
 
 Do not run `pnpm install`, `npm install`, `corepack install`, or any other dependency install/refresh command inside the sandbox.
 
-Do not run `pnpm test`, `pnpm test:*`, Playwright, local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests. If verification is blocked by missing optional native packages, browser binaries, Supabase, Docker, or another sandbox dependency issue, report it as a verification limitation and do not try to repair sandbox dependencies.
+Do not run `pnpm test`, `pnpm test:*`, `pnpm exec vitest`, `pnpm exec playwright`, Playwright, local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests. If verification is blocked by missing optional native packages, browser binaries, Supabase, Docker, or another sandbox dependency issue, report it as a verification limitation and do not try to repair sandbox dependencies.
 
 After all branches are merged, make a single commit summarizing the merge.
 

--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -62,7 +62,7 @@ If you find improvements to make:
 
 Do not run `pnpm install`, `npm install`, `corepack install`, or any other dependency install/refresh command inside the sandbox.
 
-Do not run `pnpm test`, `pnpm test:*`, Playwright, local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests unless the review finding explicitly depends on those surfaces and the needed dependencies/services already work without install repair.
+Do not run `pnpm test`, `pnpm test:*`, `pnpm exec vitest`, `pnpm exec playwright`, Playwright, local Supabase, Docker-in-Docker, RLS tests, or broad end-to-end tests unless the review finding explicitly depends on those surfaces and the needed dependencies/services already work without install repair.
 
 If a targeted check is blocked by missing optional native packages, browser binaries, Supabase, Docker, or another sandbox dependency issue, report it as a verification limitation. Do not try to repair sandbox dependencies.
 


### PR DESCRIPTION
## Summary
- Tighten Sandcastle implement/review/merge prompts to also forbid direct `pnpm exec vitest` and `pnpm exec playwright` checks by default.
- Keep Sandcastle verification centered on `pnpm verify:sandcastle` so copied node_modules/native optional dependency issues do not trigger slow sandbox work.

## Verification
- `git diff --check`
- Prompt-only change reviewed locally.