### PR TITLE
Fix Sandcastle review target diff

### DIFF
--- a/.sandcastle/review-prompt.md
+++ b/.sandcastle/review-prompt.md
@@ -6,11 +6,11 @@ Review the code changes on branch `{{BRANCH}}` and improve code clarity, consist
 
 ## Branch diff
 
-!`git diff {{SOURCE_BRANCH}}...{{BRANCH}}`
+!`git diff {{TARGET_BRANCH}}...{{BRANCH}}`
 
 ## Commits on this branch
 
-!`git log {{SOURCE_BRANCH}}..{{BRANCH}} --oneline`
+!`git log {{TARGET_BRANCH}}..{{BRANCH}} --oneline`
 
 # REVIEW PROCESS
 


### PR DESCRIPTION
## Summary
- Change the review prompt diff/log commands to compare `{{TARGET_BRANCH}}` against `{{BRANCH}}`.
- Avoid the self-diff produced by `{{SOURCE_BRANCH}}` when using `createSandbox({ branch })`.

## Verification
- `git diff --check`
- Observed reviewer log showed `SOURCE_BRANCH` resolved to the issue branch, producing a zero-token self-diff; this prompt now uses Sandcastle's host target branch built-in.