### PR TITLE
[codex] Fix audit unit of work boundary

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,12 @@ The audit logger boundary is app-owned. Product modules emit meaningful events
 through audit application services and repository ports; routes, UI components,
 and future provider adapters must not insert audit records directly.
 
+When a product workflow must persist domain state and audit history atomically,
+use the app-owned database unit-of-work boundary. The unit of work provides
+transaction-scoped repositories, including the domain repository and the audit
+repository, inside one authenticated database session. Domain repositories must
+not grow `withAuditEvent` methods or write `audit_events` directly.
+
 Hand receipt lifecycle behavior is owned by the hand receipts module. Archive
 and restore are reversible application-service behaviors, emit audit events, and
 must not be reimplemented in route components or UI-only code. See

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,9 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     "mocks/**",
     ".agents/skills/**",
+    ".sandcastle/worktrees/**",
+    ".sandcastle/npm-cache/**",
+    ".sandcastle/logs/**",
   ]),
 ]);
 

--- a/scripts/check-trpc-foundation.ts
+++ b/scripts/check-trpc-foundation.ts
@@ -27,7 +27,7 @@ async function main() {
       },
     },
     handReceiptRepository: {
-      async createWithAuditEvent() {
+      async create() {
         throw new Error("Foundation check should not create hand receipts.");
       },
       async findByAccountId() {
@@ -36,11 +36,16 @@ async function main() {
       async findById() {
         return null;
       },
-      async updateWithAuditEvent() {
+      async update() {
         throw new Error("Foundation check should not update hand receipts.");
       },
       async countActiveByAccountId() {
         return 0;
+      },
+    },
+    unitOfWork: {
+      async run() {
+        throw new Error("Foundation check should not start a unit of work.");
       },
     },
   });

--- a/src/modules/audit/README.md
+++ b/src/modules/audit/README.md
@@ -18,6 +18,10 @@ changes happen; routes and UI components do not write audit rows directly.
   session so RLS evaluates the app-owned `app.current_auth_subject` setting.
   Do not remove that boundary or replace it with direct privileged database
   access.
+- Workflows that need the domain write and audit event to commit atomically
+  should run through the app-owned unit-of-work boundary. The unit of work
+  supplies a transaction-scoped `AuditRepository`; domain repositories should
+  not insert `audit_events` directly.
 
 ## Actions
 

--- a/src/modules/audit/infrastructure/drizzle-audit-repository.ts
+++ b/src/modules/audit/infrastructure/drizzle-audit-repository.ts
@@ -9,11 +9,15 @@ import type {
 } from "@/modules/audit/application/types";
 import { normalizeRecentActivityLimit } from "@/modules/audit/application/list-activity";
 import type { AuthenticatedDatabaseSession } from "@/modules/provider-boundaries/database/authenticated-session";
+import type { AuthenticatedDatabaseTransaction } from "@/modules/provider-boundaries/database/authenticated-session";
 import { runWithAuthenticatedDatabaseSession } from "@/modules/provider-boundaries/database/authenticated-session";
 import type { createDrizzleClient } from "@/modules/provider-boundaries/database/drizzle";
 
 type DrizzleClient = ReturnType<typeof createDrizzleClient>;
 type AuditEventRow = typeof auditEvents.$inferSelect;
+type AuditOperation = <T>(
+  operation: (transaction: AuthenticatedDatabaseTransaction) => Promise<T>,
+) => Promise<T>;
 
 function toAuditEventRecord(row: AuditEventRow): AuditEventRecord {
   return {
@@ -29,17 +33,11 @@ function toAuditEventRecord(row: AuditEventRow): AuditEventRecord {
   };
 }
 
-export function createDrizzleAuditRepository(
-  db: DrizzleClient,
-  session: AuthenticatedDatabaseSession,
-): AuditRepository {
+function createAuditRepository(run: AuditOperation): AuditRepository {
   return {
     async record(event) {
-      const [createdEvent] = await runWithAuthenticatedDatabaseSession(
-        db,
-        session,
-        (transaction) =>
-          transaction.insert(auditEvents).values(event).returning(),
+      const [createdEvent] = await run((transaction) =>
+        transaction.insert(auditEvents).values(event).returning(),
       );
 
       if (!createdEvent) {
@@ -50,41 +48,50 @@ export function createDrizzleAuditRepository(
     },
     async listByAccountId(accountId, options = {}) {
       const limit = normalizeRecentActivityLimit(options.limit);
-      const rows = await runWithAuthenticatedDatabaseSession(
-        db,
-        session,
-        (transaction) =>
-          transaction
-            .select()
-            .from(auditEvents)
-            .where(eq(auditEvents.accountId, accountId))
-            .orderBy(desc(auditEvents.occurredAt))
-            .limit(limit),
+      const rows = await run((transaction) =>
+        transaction
+          .select()
+          .from(auditEvents)
+          .where(eq(auditEvents.accountId, accountId))
+          .orderBy(desc(auditEvents.occurredAt))
+          .limit(limit),
       );
 
       return rows.map(toAuditEventRecord);
     },
     async listByTarget(accountId, target, options = {}) {
       const limit = normalizeRecentActivityLimit(options.limit);
-      const rows = await runWithAuthenticatedDatabaseSession(
-        db,
-        session,
-        (transaction) =>
-          transaction
-            .select()
-            .from(auditEvents)
-            .where(
-              and(
-                eq(auditEvents.accountId, accountId),
-                eq(auditEvents.targetType, target.targetType),
-                eq(auditEvents.targetId, target.targetId),
-              ),
-            )
-            .orderBy(desc(auditEvents.occurredAt))
-            .limit(limit),
+      const rows = await run((transaction) =>
+        transaction
+          .select()
+          .from(auditEvents)
+          .where(
+            and(
+              eq(auditEvents.accountId, accountId),
+              eq(auditEvents.targetType, target.targetType),
+              eq(auditEvents.targetId, target.targetId),
+            ),
+          )
+          .orderBy(desc(auditEvents.occurredAt))
+          .limit(limit),
       );
 
       return rows.map(toAuditEventRecord);
     },
   };
+}
+
+export function createDrizzleAuditRepository(
+  db: DrizzleClient,
+  session: AuthenticatedDatabaseSession,
+): AuditRepository {
+  return createAuditRepository((operation) =>
+    runWithAuthenticatedDatabaseSession(db, session, operation),
+  );
+}
+
+export function createTransactionalDrizzleAuditRepository(
+  transaction: AuthenticatedDatabaseTransaction,
+): AuditRepository {
+  return createAuditRepository((operation) => operation(transaction));
 }

--- a/src/modules/hand-receipts/application/archive-hand-receipt.ts
+++ b/src/modules/hand-receipts/application/archive-hand-receipt.ts
@@ -1,4 +1,5 @@
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import { recordAuditEvent, type AuditRepository } from "@/modules/audit";
 import {
   canArchiveHandReceipt,
   canRestoreHandReceipt,
@@ -11,6 +12,7 @@ type LifecycleHandReceiptInput = {
   actorId: string;
   handReceiptId: string;
   handReceiptRepository: HandReceiptRepository;
+  auditRepository: AuditRepository;
   now?: Date;
 };
 
@@ -19,6 +21,7 @@ export async function archiveHandReceipt({
   actorId,
   handReceiptId,
   handReceiptRepository,
+  auditRepository,
   now = new Date(),
 }: LifecycleHandReceiptInput) {
   const capabilities = deriveAccountCapabilities(account, now);
@@ -40,7 +43,7 @@ export async function archiveHandReceipt({
     throw new Error("Hand receipt is already archived.");
   }
 
-  return handReceiptRepository.updateWithAuditEvent(
+  const archived = await handReceiptRepository.update(
     account.id,
     handReceiptId,
     {
@@ -48,18 +51,28 @@ export async function archiveHandReceipt({
       status: "archived",
       updatedAt: now,
     },
-    {
-      accountId: account.id,
-      actorId,
-      action: "hand_receipt.archived",
-      targetType: "hand_receipt",
-      targetId: handReceiptId,
-      metadata: {
-        name: existing.name,
-      },
-      occurredAt: now,
-    },
   );
+
+  if (!archived) {
+    return null;
+  }
+
+  await recordAuditEvent({
+    accountId: account.id,
+    actorId,
+    action: "hand_receipt.archived",
+    target: {
+      type: "hand_receipt",
+      id: handReceiptId,
+    },
+    metadata: {
+      name: existing.name,
+    },
+    occurredAt: now,
+    repository: auditRepository,
+  });
+
+  return archived;
 }
 
 export async function restoreHandReceipt({
@@ -67,6 +80,7 @@ export async function restoreHandReceipt({
   actorId,
   handReceiptId,
   handReceiptRepository,
+  auditRepository,
   now = new Date(),
 }: LifecycleHandReceiptInput) {
   const capabilities = deriveAccountCapabilities(account, now);
@@ -96,7 +110,7 @@ export async function restoreHandReceipt({
     throw new Error("Active hand receipt limit reached.");
   }
 
-  return handReceiptRepository.updateWithAuditEvent(
+  const restored = await handReceiptRepository.update(
     account.id,
     handReceiptId,
     {
@@ -104,16 +118,26 @@ export async function restoreHandReceipt({
       status: "active",
       updatedAt: now,
     },
-    {
-      accountId: account.id,
-      actorId,
-      action: "hand_receipt.restored",
-      targetType: "hand_receipt",
-      targetId: handReceiptId,
-      metadata: {
-        name: existing.name,
-      },
-      occurredAt: now,
-    },
   );
+
+  if (!restored) {
+    return null;
+  }
+
+  await recordAuditEvent({
+    accountId: account.id,
+    actorId,
+    action: "hand_receipt.restored",
+    target: {
+      type: "hand_receipt",
+      id: handReceiptId,
+    },
+    metadata: {
+      name: existing.name,
+    },
+    occurredAt: now,
+    repository: auditRepository,
+  });
+
+  return restored;
 }

--- a/src/modules/hand-receipts/application/create-hand-receipt.ts
+++ b/src/modules/hand-receipts/application/create-hand-receipt.ts
@@ -3,6 +3,7 @@ import {
   canCreateHandReceipt,
   deriveAccountCapabilities,
 } from "@/modules/billing";
+import { recordAuditEvent, type AuditRepository } from "@/modules/audit";
 import type { HandReceiptRepository } from "./hand-receipt-repository";
 import type { HandReceiptMetadataInput } from "./types";
 
@@ -13,6 +14,7 @@ type CreateHandReceiptInput = {
     name: string;
   };
   handReceiptRepository: HandReceiptRepository;
+  auditRepository: AuditRepository;
   now?: Date;
   createHandReceiptId?: () => string;
 };
@@ -27,6 +29,7 @@ export async function createHandReceipt({
   actorId,
   input,
   handReceiptRepository,
+  auditRepository,
   now = new Date(),
   createHandReceiptId = () => globalThis.crypto.randomUUID(),
 }: CreateHandReceiptInput) {
@@ -50,33 +53,35 @@ export async function createHandReceipt({
   }
 
   const handReceiptId = createHandReceiptId();
-  const handReceipt = await handReceiptRepository.createWithAuditEvent(
-    {
+  const handReceipt = await handReceiptRepository.create({
+    id: handReceiptId,
+    accountId: account.id,
+    name,
+    notes: cleanOptionalText(input.notes),
+    handReceiptNumber: cleanOptionalText(input.handReceiptNumber),
+    holderName: cleanOptionalText(input.holderName),
+    unitName: cleanOptionalText(input.unitName),
+    uic: cleanOptionalText(input.uic),
+    effectiveDate: cleanOptionalText(input.effectiveDate),
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await recordAuditEvent({
+    accountId: account.id,
+    actorId,
+    action: "hand_receipt.created",
+    target: {
+      type: "hand_receipt",
       id: handReceiptId,
-      accountId: account.id,
+    },
+    metadata: {
       name,
-      notes: cleanOptionalText(input.notes),
-      handReceiptNumber: cleanOptionalText(input.handReceiptNumber),
-      holderName: cleanOptionalText(input.holderName),
-      unitName: cleanOptionalText(input.unitName),
-      uic: cleanOptionalText(input.uic),
-      effectiveDate: cleanOptionalText(input.effectiveDate),
-      status: "active",
-      createdAt: now,
-      updatedAt: now,
     },
-    {
-      accountId: account.id,
-      actorId,
-      action: "hand_receipt.created",
-      targetType: "hand_receipt",
-      targetId: handReceiptId,
-      metadata: {
-        name,
-      },
-      occurredAt: now,
-    },
-  );
+    occurredAt: now,
+    repository: auditRepository,
+  });
 
   return handReceipt;
 }

--- a/src/modules/hand-receipts/application/hand-receipt-repository.ts
+++ b/src/modules/hand-receipts/application/hand-receipt-repository.ts
@@ -1,4 +1,3 @@
-import type { NewAuditEventRecord } from "@/modules/audit";
 import type {
   HandReceiptRecord,
   HandReceiptStatus,
@@ -7,10 +6,7 @@ import type {
 } from "./types";
 
 export interface HandReceiptRepository {
-  createWithAuditEvent(
-    handReceipt: NewHandReceiptRecord,
-    auditEvent: NewAuditEventRecord,
-  ): Promise<HandReceiptRecord>;
+  create(handReceipt: NewHandReceiptRecord): Promise<HandReceiptRecord>;
   findByAccountId(
     accountId: string,
     options?: { status?: HandReceiptStatus },
@@ -19,18 +15,17 @@ export interface HandReceiptRepository {
     accountId: string,
     handReceiptId: string,
   ): Promise<HandReceiptRecord | null>;
-  updateWithAuditEvent(
+  update(
     accountId: string,
     handReceiptId: string,
     updates: UpdateHandReceiptRecord,
-    auditEvent: NewAuditEventRecord,
   ): Promise<HandReceiptRecord | null>;
   countActiveByAccountId(accountId: string): Promise<number>;
 }
 
 export function createUnavailableHandReceiptRepository(): HandReceiptRepository {
   return {
-    async createWithAuditEvent() {
+    async create() {
       throw new Error("An authenticated database session is required.");
     },
     async findByAccountId() {
@@ -39,7 +34,7 @@ export function createUnavailableHandReceiptRepository(): HandReceiptRepository 
     async findById() {
       throw new Error("An authenticated database session is required.");
     },
-    async updateWithAuditEvent() {
+    async update() {
       throw new Error("An authenticated database session is required.");
     },
     async countActiveByAccountId() {

--- a/src/modules/hand-receipts/application/update-hand-receipt.ts
+++ b/src/modules/hand-receipts/application/update-hand-receipt.ts
@@ -1,4 +1,5 @@
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import { recordAuditEvent, type AuditRepository } from "@/modules/audit";
 import { deriveAccountCapabilities } from "@/modules/billing";
 import type { HandReceiptRepository } from "./hand-receipt-repository";
 import type { HandReceiptMetadataInput, HandReceiptRecord } from "./types";
@@ -11,6 +12,7 @@ type UpdateHandReceiptInput = {
     name: string;
   };
   handReceiptRepository: HandReceiptRepository;
+  auditRepository: AuditRepository;
   now?: Date;
 };
 
@@ -50,6 +52,7 @@ export async function updateHandReceipt({
   handReceiptId,
   input,
   handReceiptRepository,
+  auditRepository,
   now = new Date(),
 }: UpdateHandReceiptInput) {
   const name = input.name.trim();
@@ -88,23 +91,33 @@ export async function updateHandReceipt({
     return existing;
   }
 
-  return handReceiptRepository.updateWithAuditEvent(
+  const updated = await handReceiptRepository.update(
     account.id,
     handReceiptId,
     {
       ...updates,
       updatedAt: now,
     },
-    {
-      accountId: account.id,
-      actorId,
-      action: "hand_receipt.updated",
-      targetType: "hand_receipt",
-      targetId: handReceiptId,
-      metadata: {
-        changedFields: changedFieldNames,
-      },
-      occurredAt: now,
-    },
   );
+
+  if (!updated) {
+    return null;
+  }
+
+  await recordAuditEvent({
+    accountId: account.id,
+    actorId,
+    action: "hand_receipt.updated",
+    target: {
+      type: "hand_receipt",
+      id: handReceiptId,
+    },
+    metadata: {
+      changedFields: changedFieldNames,
+    },
+    occurredAt: now,
+    repository: auditRepository,
+  });
+
+  return updated;
 }

--- a/src/modules/hand-receipts/infrastructure/drizzle-hand-receipt-repository.ts
+++ b/src/modules/hand-receipts/infrastructure/drizzle-hand-receipt-repository.ts
@@ -1,17 +1,21 @@
 import { and, count, desc, eq } from "drizzle-orm";
 
-import { auditEvents, handReceipts } from "@/db/schema";
+import { handReceipts } from "@/db/schema";
 import type { HandReceiptRepository } from "@/modules/hand-receipts";
 import type {
   HandReceiptRecord,
   HandReceiptStatus,
 } from "@/modules/hand-receipts/application/types";
 import type { AuthenticatedDatabaseSession } from "@/modules/provider-boundaries/database/authenticated-session";
+import type { AuthenticatedDatabaseTransaction } from "@/modules/provider-boundaries/database/authenticated-session";
 import { runWithAuthenticatedDatabaseSession } from "@/modules/provider-boundaries/database/authenticated-session";
 import type { createDrizzleClient } from "@/modules/provider-boundaries/database/drizzle";
 
 type DrizzleClient = ReturnType<typeof createDrizzleClient>;
 type HandReceiptRow = typeof handReceipts.$inferSelect;
+type HandReceiptOperation = <T>(
+  operation: (transaction: AuthenticatedDatabaseTransaction) => Promise<T>,
+) => Promise<T>;
 
 function toHandReceiptRecord(row: HandReceiptRow): HandReceiptRecord {
   return {
@@ -30,30 +34,23 @@ function toHandReceiptRecord(row: HandReceiptRow): HandReceiptRecord {
   };
 }
 
-export function createDrizzleHandReceiptRepository(
-  db: DrizzleClient,
-  session: AuthenticatedDatabaseSession,
+function createHandReceiptRepository(
+  run: HandReceiptOperation,
 ): HandReceiptRepository {
   return {
-    async createWithAuditEvent(handReceipt, auditEvent) {
-      const [createdHandReceipt] = await runWithAuthenticatedDatabaseSession(
-        db,
-        session,
-        async (transaction) => {
-          const [created] = await transaction
-            .insert(handReceipts)
-            .values(handReceipt)
-            .returning();
+    async create(handReceipt) {
+      const [createdHandReceipt] = await run(async (transaction) => {
+        const [created] = await transaction
+          .insert(handReceipts)
+          .values(handReceipt)
+          .returning();
 
-          if (!created) {
-            throw new Error("Hand receipt was not created.");
-          }
+        if (!created) {
+          throw new Error("Hand receipt was not created.");
+        }
 
-          await transaction.insert(auditEvents).values(auditEvent);
-
-          return [created];
-        },
-      );
+        return [created];
+      });
 
       return toHandReceiptRecord(createdHandReceipt);
     },
@@ -64,85 +61,85 @@ export function createDrizzleHandReceiptRepository(
         filters.push(eq(handReceipts.status, options.status));
       }
 
-      const rows = await runWithAuthenticatedDatabaseSession(
-        db,
-        session,
-        (transaction) =>
-          transaction
-            .select()
-            .from(handReceipts)
-            .where(and(...filters))
-            .orderBy(desc(handReceipts.createdAt)),
+      const rows = await run((transaction) =>
+        transaction
+          .select()
+          .from(handReceipts)
+          .where(and(...filters))
+          .orderBy(desc(handReceipts.createdAt)),
       );
 
       return rows.map(toHandReceiptRecord);
     },
     async findById(accountId, handReceiptId) {
-      const [row] = await runWithAuthenticatedDatabaseSession(
-        db,
-        session,
-        (transaction) =>
-          transaction
-            .select()
-            .from(handReceipts)
-            .where(
-              and(
-                eq(handReceipts.accountId, accountId),
-                eq(handReceipts.id, handReceiptId),
-              ),
-            )
-            .limit(1),
+      const [row] = await run((transaction) =>
+        transaction
+          .select()
+          .from(handReceipts)
+          .where(
+            and(
+              eq(handReceipts.accountId, accountId),
+              eq(handReceipts.id, handReceiptId),
+            ),
+          )
+          .limit(1),
       );
 
       return row ? toHandReceiptRecord(row) : null;
     },
-    async updateWithAuditEvent(accountId, handReceiptId, updates, auditEvent) {
-      const [updatedHandReceipt] = await runWithAuthenticatedDatabaseSession(
-        db,
-        session,
-        async (transaction) => {
-          const [updated] = await transaction
-            .update(handReceipts)
-            .set(updates)
-            .where(
-              and(
-                eq(handReceipts.accountId, accountId),
-                eq(handReceipts.id, handReceiptId),
-              ),
-            )
-            .returning();
+    async update(accountId, handReceiptId, updates) {
+      const [updatedHandReceipt] = await run(async (transaction) => {
+        const [updated] = await transaction
+          .update(handReceipts)
+          .set(updates)
+          .where(
+            and(
+              eq(handReceipts.accountId, accountId),
+              eq(handReceipts.id, handReceiptId),
+            ),
+          )
+          .returning();
 
-          if (!updated) {
-            return [null];
-          }
+        if (!updated) {
+          return [null];
+        }
 
-          await transaction.insert(auditEvents).values(auditEvent);
-
-          return [updated];
-        },
-      );
+        return [updated];
+      });
 
       return updatedHandReceipt
         ? toHandReceiptRecord(updatedHandReceipt)
         : null;
     },
     async countActiveByAccountId(accountId) {
-      const [row] = await runWithAuthenticatedDatabaseSession(
-        db,
-        session,
-        (transaction) =>
-          transaction
-            .select({ count: count() })
-            .from(handReceipts)
-            .where(
-              and(
-                eq(handReceipts.accountId, accountId),
-                eq(handReceipts.status, "active"),
-              ),
+      const [row] = await run((transaction) =>
+        transaction
+          .select({ count: count() })
+          .from(handReceipts)
+          .where(
+            and(
+              eq(handReceipts.accountId, accountId),
+              eq(handReceipts.status, "active"),
             ),
+          ),
       );
 
       return row?.count ?? 0;
     },
   };
+}
+
+export function createDrizzleHandReceiptRepository(
+  db: DrizzleClient,
+  session: AuthenticatedDatabaseSession,
+): HandReceiptRepository {
+  return createHandReceiptRepository((operation) =>
+    runWithAuthenticatedDatabaseSession(db, session, operation),
+  );
+}
+
+export function createTransactionalDrizzleHandReceiptRepository(
+  transaction: AuthenticatedDatabaseTransaction,
+): HandReceiptRepository {
+  return createHandReceiptRepository((operation) => operation(transaction));
 }

--- a/src/modules/provider-boundaries/database/app-unit-of-work.ts
+++ b/src/modules/provider-boundaries/database/app-unit-of-work.ts
@@ -1,0 +1,46 @@
+import type { AuditRepository } from "@/modules/audit";
+import { createTransactionalDrizzleAuditRepository } from "@/modules/audit/infrastructure/drizzle-audit-repository";
+import type { HandReceiptRepository } from "@/modules/hand-receipts";
+import { createTransactionalDrizzleHandReceiptRepository } from "@/modules/hand-receipts/infrastructure/drizzle-hand-receipt-repository";
+import type { AuthenticatedDatabaseSession } from "./authenticated-session";
+import { runWithAuthenticatedDatabaseSession } from "./authenticated-session";
+import type { createDrizzleClient } from "./drizzle";
+
+type DrizzleClient = ReturnType<typeof createDrizzleClient>;
+
+export type AppUnitOfWorkRepositories = {
+  auditRepository: AuditRepository;
+  handReceiptRepository: HandReceiptRepository;
+};
+
+export type AppUnitOfWork = {
+  run<T>(
+    operation: (repositories: AppUnitOfWorkRepositories) => Promise<T>,
+  ): Promise<T>;
+};
+
+export function createUnavailableAppUnitOfWork(): AppUnitOfWork {
+  return {
+    async run() {
+      throw new Error("An authenticated database session is required.");
+    },
+  };
+}
+
+export function createDrizzleAppUnitOfWork(
+  db: DrizzleClient,
+  session: AuthenticatedDatabaseSession,
+): AppUnitOfWork {
+  return {
+    run(operation) {
+      return runWithAuthenticatedDatabaseSession(db, session, (transaction) =>
+        operation({
+          auditRepository:
+            createTransactionalDrizzleAuditRepository(transaction),
+          handReceiptRepository:
+            createTransactionalDrizzleHandReceiptRepository(transaction),
+        }),
+      );
+    },
+  };
+}

--- a/src/modules/provider-boundaries/database/authenticated-session.ts
+++ b/src/modules/provider-boundaries/database/authenticated-session.ts
@@ -3,7 +3,7 @@ import { sql } from "drizzle-orm";
 import type { createDrizzleClient } from "./drizzle";
 
 type DrizzleClient = ReturnType<typeof createDrizzleClient>;
-type DrizzleTransaction = Parameters<
+export type AuthenticatedDatabaseTransaction = Parameters<
   Parameters<DrizzleClient["transaction"]>[0]
 >[0];
 
@@ -14,7 +14,7 @@ export type AuthenticatedDatabaseSession = {
 export async function runWithAuthenticatedDatabaseSession<T>(
   db: DrizzleClient,
   session: AuthenticatedDatabaseSession,
-  operation: (transaction: DrizzleTransaction) => Promise<T>,
+  operation: (transaction: AuthenticatedDatabaseTransaction) => Promise<T>,
 ) {
   if (!session.authSubject.trim()) {
     throw new Error(

--- a/src/server/trpc/context.ts
+++ b/src/server/trpc/context.ts
@@ -15,6 +15,11 @@ import {
 import { createDrizzleHandReceiptRepository } from "@/modules/hand-receipts/infrastructure/drizzle-hand-receipt-repository";
 import { type AppSession } from "@/modules/provider-boundaries/auth";
 import { getCurrentServerAppSession } from "@/modules/provider-boundaries/auth/server-session";
+import {
+  createDrizzleAppUnitOfWork,
+  createUnavailableAppUnitOfWork,
+  type AppUnitOfWork,
+} from "@/modules/provider-boundaries/database/app-unit-of-work";
 import { getDrizzleClient } from "@/modules/provider-boundaries/database/drizzle";
 
 export async function createTRPCContext(): Promise<{
@@ -23,6 +28,7 @@ export async function createTRPCContext(): Promise<{
   accountRepository: ReturnType<typeof createDrizzleAccountRepository>;
   auditRepository: AuditRepository;
   handReceiptRepository: HandReceiptRepository;
+  unitOfWork: AppUnitOfWork;
 }> {
   const db = getDrizzleClient();
   const accountRepository = createDrizzleAccountRepository(db);
@@ -35,6 +41,7 @@ export async function createTRPCContext(): Promise<{
       accountRepository,
       auditRepository: createUnavailableAuditRepository(),
       handReceiptRepository: createUnavailableHandReceiptRepository(),
+      unitOfWork: createUnavailableAppUnitOfWork(),
     };
   }
 
@@ -51,6 +58,9 @@ export async function createTRPCContext(): Promise<{
       authSubject: session.userId,
     }),
     handReceiptRepository: createDrizzleHandReceiptRepository(db, {
+      authSubject: session.userId,
+    }),
+    unitOfWork: createDrizzleAppUnitOfWork(db, {
       authSubject: session.userId,
     }),
   };

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -25,6 +25,7 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
       accountRepository: ctx.accountRepository,
       auditRepository: ctx.auditRepository,
       handReceiptRepository: ctx.handReceiptRepository,
+      unitOfWork: ctx.unitOfWork,
     },
   });
 });

--- a/src/server/trpc/routers/hand-receipts.ts
+++ b/src/server/trpc/routers/hand-receipts.ts
@@ -128,20 +128,23 @@ export const handReceiptsRouter = createTRPCRouter({
     .input(createHandReceiptInput)
     .mutation(async ({ ctx, input }) => {
       try {
-        return await createHandReceipt({
-          account: ctx.account,
-          actorId: ctx.session.userId,
-          input: {
-            name: input.name,
-            notes: input.notes,
-            handReceiptNumber: input.handReceiptNumber,
-            holderName: input.holderName,
-            unitName: input.unitName,
-            uic: input.uic,
-            effectiveDate: input.effectiveDate,
-          },
-          handReceiptRepository: ctx.handReceiptRepository,
-        });
+        return await ctx.unitOfWork.run((repositories) =>
+          createHandReceipt({
+            account: ctx.account,
+            actorId: ctx.session.userId,
+            input: {
+              name: input.name,
+              notes: input.notes,
+              handReceiptNumber: input.handReceiptNumber,
+              holderName: input.holderName,
+              unitName: input.unitName,
+              uic: input.uic,
+              effectiveDate: input.effectiveDate,
+            },
+            handReceiptRepository: repositories.handReceiptRepository,
+            auditRepository: repositories.auditRepository,
+          }),
+        );
       } catch (error) {
         toTRPCError(error);
       }
@@ -150,21 +153,24 @@ export const handReceiptsRouter = createTRPCRouter({
     .input(updateHandReceiptInput)
     .mutation(async ({ ctx, input }) => {
       try {
-        const updated = await updateHandReceipt({
-          account: ctx.account,
-          actorId: ctx.session.userId,
-          handReceiptId: input.id,
-          input: {
-            name: input.name,
-            notes: input.notes,
-            handReceiptNumber: input.handReceiptNumber,
-            holderName: input.holderName,
-            unitName: input.unitName,
-            uic: input.uic,
-            effectiveDate: input.effectiveDate,
-          },
-          handReceiptRepository: ctx.handReceiptRepository,
-        });
+        const updated = await ctx.unitOfWork.run((repositories) =>
+          updateHandReceipt({
+            account: ctx.account,
+            actorId: ctx.session.userId,
+            handReceiptId: input.id,
+            input: {
+              name: input.name,
+              notes: input.notes,
+              handReceiptNumber: input.handReceiptNumber,
+              holderName: input.holderName,
+              unitName: input.unitName,
+              uic: input.uic,
+              effectiveDate: input.effectiveDate,
+            },
+            handReceiptRepository: repositories.handReceiptRepository,
+            auditRepository: repositories.auditRepository,
+          }),
+        );
 
         if (!updated) {
           throw new TRPCError({
@@ -186,12 +192,15 @@ export const handReceiptsRouter = createTRPCRouter({
     .input(handReceiptIdInput)
     .mutation(async ({ ctx, input }) => {
       try {
-        const archived = await archiveHandReceipt({
-          account: ctx.account,
-          actorId: ctx.session.userId,
-          handReceiptId: input.id,
-          handReceiptRepository: ctx.handReceiptRepository,
-        });
+        const archived = await ctx.unitOfWork.run((repositories) =>
+          archiveHandReceipt({
+            account: ctx.account,
+            actorId: ctx.session.userId,
+            handReceiptId: input.id,
+            handReceiptRepository: repositories.handReceiptRepository,
+            auditRepository: repositories.auditRepository,
+          }),
+        );
 
         if (!archived) {
           throw new TRPCError({
@@ -213,12 +222,15 @@ export const handReceiptsRouter = createTRPCRouter({
     .input(handReceiptIdInput)
     .mutation(async ({ ctx, input }) => {
       try {
-        const restored = await restoreHandReceipt({
-          account: ctx.account,
-          actorId: ctx.session.userId,
-          handReceiptId: input.id,
-          handReceiptRepository: ctx.handReceiptRepository,
-        });
+        const restored = await ctx.unitOfWork.run((repositories) =>
+          restoreHandReceipt({
+            account: ctx.account,
+            actorId: ctx.session.userId,
+            handReceiptId: input.id,
+            handReceiptRepository: repositories.handReceiptRepository,
+            auditRepository: repositories.auditRepository,
+          }),
+        );
 
         if (!restored) {
           throw new TRPCError({

--- a/src/server/trpc/routers/hand-receipts.ts
+++ b/src/server/trpc/routers/hand-receipts.ts
@@ -10,6 +10,10 @@ import {
   restoreHandReceipt,
   updateHandReceipt,
 } from "@/modules/hand-receipts";
+import type {
+  AppUnitOfWork,
+  AppUnitOfWorkRepositories,
+} from "@/modules/provider-boundaries/database/app-unit-of-work";
 import { createTRPCRouter, protectedProcedure } from "@/server/trpc/init";
 
 const optionalText = z
@@ -90,6 +94,21 @@ function toTRPCError(error: unknown): never {
   });
 }
 
+async function runInUnitOfWork<T>(
+  ctx: { unitOfWork: AppUnitOfWork },
+  operation: (repositories: AppUnitOfWorkRepositories) => Promise<T>,
+): Promise<T> {
+  try {
+    return await ctx.unitOfWork.run(operation);
+  } catch (error) {
+    if (error instanceof TRPCError) {
+      throw error;
+    }
+
+    toTRPCError(error);
+  }
+}
+
 export const handReceiptsRouter = createTRPCRouter({
   list: protectedProcedure
     .input(listHandReceiptsInput)
@@ -126,126 +145,98 @@ export const handReceiptsRouter = createTRPCRouter({
     }),
   create: protectedProcedure
     .input(createHandReceiptInput)
-    .mutation(async ({ ctx, input }) => {
-      try {
-        return await ctx.unitOfWork.run((repositories) =>
-          createHandReceipt({
-            account: ctx.account,
-            actorId: ctx.session.userId,
-            input: {
-              name: input.name,
-              notes: input.notes,
-              handReceiptNumber: input.handReceiptNumber,
-              holderName: input.holderName,
-              unitName: input.unitName,
-              uic: input.uic,
-              effectiveDate: input.effectiveDate,
-            },
-            handReceiptRepository: repositories.handReceiptRepository,
-            auditRepository: repositories.auditRepository,
-          }),
-        );
-      } catch (error) {
-        toTRPCError(error);
-      }
-    }),
+    .mutation(({ ctx, input }) =>
+      runInUnitOfWork(ctx, (repositories) =>
+        createHandReceipt({
+          account: ctx.account,
+          actorId: ctx.session.userId,
+          input: {
+            name: input.name,
+            notes: input.notes,
+            handReceiptNumber: input.handReceiptNumber,
+            holderName: input.holderName,
+            unitName: input.unitName,
+            uic: input.uic,
+            effectiveDate: input.effectiveDate,
+          },
+          handReceiptRepository: repositories.handReceiptRepository,
+          auditRepository: repositories.auditRepository,
+        }),
+      ),
+    ),
   update: protectedProcedure
     .input(updateHandReceiptInput)
     .mutation(async ({ ctx, input }) => {
-      try {
-        const updated = await ctx.unitOfWork.run((repositories) =>
-          updateHandReceipt({
-            account: ctx.account,
-            actorId: ctx.session.userId,
-            handReceiptId: input.id,
-            input: {
-              name: input.name,
-              notes: input.notes,
-              handReceiptNumber: input.handReceiptNumber,
-              holderName: input.holderName,
-              unitName: input.unitName,
-              uic: input.uic,
-              effectiveDate: input.effectiveDate,
-            },
-            handReceiptRepository: repositories.handReceiptRepository,
-            auditRepository: repositories.auditRepository,
-          }),
-        );
+      const updated = await runInUnitOfWork(ctx, (repositories) =>
+        updateHandReceipt({
+          account: ctx.account,
+          actorId: ctx.session.userId,
+          handReceiptId: input.id,
+          input: {
+            name: input.name,
+            notes: input.notes,
+            handReceiptNumber: input.handReceiptNumber,
+            holderName: input.holderName,
+            unitName: input.unitName,
+            uic: input.uic,
+            effectiveDate: input.effectiveDate,
+          },
+          handReceiptRepository: repositories.handReceiptRepository,
+          auditRepository: repositories.auditRepository,
+        }),
+      );
 
-        if (!updated) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Hand receipt was not found.",
-          });
-        }
-
-        return updated;
-      } catch (error) {
-        if (error instanceof TRPCError) {
-          throw error;
-        }
-
-        toTRPCError(error);
+      if (!updated) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Hand receipt was not found.",
+        });
       }
+
+      return updated;
     }),
   archive: protectedProcedure
     .input(handReceiptIdInput)
     .mutation(async ({ ctx, input }) => {
-      try {
-        const archived = await ctx.unitOfWork.run((repositories) =>
-          archiveHandReceipt({
-            account: ctx.account,
-            actorId: ctx.session.userId,
-            handReceiptId: input.id,
-            handReceiptRepository: repositories.handReceiptRepository,
-            auditRepository: repositories.auditRepository,
-          }),
-        );
+      const archived = await runInUnitOfWork(ctx, (repositories) =>
+        archiveHandReceipt({
+          account: ctx.account,
+          actorId: ctx.session.userId,
+          handReceiptId: input.id,
+          handReceiptRepository: repositories.handReceiptRepository,
+          auditRepository: repositories.auditRepository,
+        }),
+      );
 
-        if (!archived) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Hand receipt was not found.",
-          });
-        }
-
-        return archived;
-      } catch (error) {
-        if (error instanceof TRPCError) {
-          throw error;
-        }
-
-        toTRPCError(error);
+      if (!archived) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Hand receipt was not found.",
+        });
       }
+
+      return archived;
     }),
   restore: protectedProcedure
     .input(handReceiptIdInput)
     .mutation(async ({ ctx, input }) => {
-      try {
-        const restored = await ctx.unitOfWork.run((repositories) =>
-          restoreHandReceipt({
-            account: ctx.account,
-            actorId: ctx.session.userId,
-            handReceiptId: input.id,
-            handReceiptRepository: repositories.handReceiptRepository,
-            auditRepository: repositories.auditRepository,
-          }),
-        );
+      const restored = await runInUnitOfWork(ctx, (repositories) =>
+        restoreHandReceipt({
+          account: ctx.account,
+          actorId: ctx.session.userId,
+          handReceiptId: input.id,
+          handReceiptRepository: repositories.handReceiptRepository,
+          auditRepository: repositories.auditRepository,
+        }),
+      );
 
-        if (!restored) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Hand receipt was not found.",
-          });
-        }
-
-        return restored;
-      } catch (error) {
-        if (error instanceof TRPCError) {
-          throw error;
-        }
-
-        toTRPCError(error);
+      if (!restored) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Hand receipt was not found.",
+        });
       }
+
+      return restored;
     }),
 });

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -22,8 +22,12 @@ async function acknowledgeOnboardingIfPresent(page: Page) {
 
   try {
     await expect(notice).toBeVisible({ timeout: 8_000 });
-  } catch {
-    return;
+  } catch (error) {
+    if (error instanceof Error && /timed out/i.test(error.message)) {
+      return;
+    }
+
+    throw error;
   }
 
   await acknowledgment.click();

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -4,7 +4,7 @@ async function signInLocalUser(page: Page) {
   const suffix = `${Date.now()}-${test.info().workerIndex}-${Math.random().toString(36).slice(2)}`;
   const email = `shell-${suffix}@example.test`;
 
-  await page.goto("/auth/login?next=/app");
+  await page.goto("/auth/login?next=/app/dashboard");
   await page.getByRole("tab", { name: "Register" }).click();
   await page.getByLabel("Email").fill(email);
   await page.getByLabel("Password").fill("password123");
@@ -20,7 +20,12 @@ async function acknowledgeOnboardingIfPresent(page: Page) {
   });
   const acknowledgment = page.getByRole("button", { name: "I understand" });
 
-  await expect(notice).toBeVisible();
+  try {
+    await expect(notice).toBeVisible({ timeout: 8_000 });
+  } catch {
+    return;
+  }
+
   await acknowledgment.click();
   await expect(notice).toBeHidden();
 }

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -4,7 +4,7 @@ test("signed-in users can sign out from the app shell", async ({ page }) => {
   const suffix = `${Date.now()}-${test.info().workerIndex}-${Math.random().toString(36).slice(2)}`;
   const email = `signout-${suffix}@example.test`;
 
-  await page.goto("/auth/login?next=/app");
+  await page.goto("/auth/login?next=/app/dashboard");
   await page.getByRole("tab", { name: "Register" }).click();
   await page.getByLabel("Email").fill(email);
   await page.getByLabel("Password").fill("password123");

--- a/tests/integration/auth/protected-procedure.test.ts
+++ b/tests/integration/auth/protected-procedure.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { createTRPCRouter, protectedProcedure } from "@/server/trpc/init";
 import { createEmptyAccountRepository } from "../../support/account-repository";
 import { createEmptyAuditRepository } from "../../support/audit-repository";
+import { createInMemoryAppUnitOfWork } from "../../support/app-unit-of-work";
 import { createEmptyHandReceiptRepository } from "../../support/hand-receipt-repository";
 
 const authProbeRouter = createTRPCRouter({
@@ -18,6 +19,7 @@ describe("protectedProcedure", () => {
       accountRepository: createEmptyAccountRepository(),
       auditRepository: createEmptyAuditRepository(),
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork(),
     });
 
     await expect(caller.currentUserEmail()).rejects.toMatchObject({
@@ -35,6 +37,7 @@ describe("protectedProcedure", () => {
       accountRepository: createEmptyAccountRepository(),
       auditRepository: createEmptyAuditRepository(),
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork(),
     });
 
     await expect(caller.currentUserEmail()).rejects.toMatchObject({
@@ -59,6 +62,7 @@ describe("protectedProcedure", () => {
       accountRepository: createEmptyAccountRepository(),
       auditRepository: createEmptyAuditRepository(),
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork(),
     });
 
     await expect(caller.currentUserEmail()).resolves.toBe("owner@example.com");

--- a/tests/integration/trpc/accounts-router.test.ts
+++ b/tests/integration/trpc/accounts-router.test.ts
@@ -4,6 +4,7 @@ import { appRouter } from "@/server/trpc/router";
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
 import { InMemoryAccountRepository } from "../../support/account-repository";
 import { createEmptyAuditRepository } from "../../support/audit-repository";
+import { createInMemoryAppUnitOfWork } from "../../support/app-unit-of-work";
 import { createEmptyHandReceiptRepository } from "../../support/hand-receipt-repository";
 
 function createAccount(): AccountRecord {
@@ -30,6 +31,7 @@ describe("accountsRouter", () => {
       accountRepository: new InMemoryAccountRepository([account]),
       auditRepository: createEmptyAuditRepository(),
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork(),
     });
 
     await expect(caller.accounts.getOnboardingStatus()).resolves.toMatchObject({

--- a/tests/integration/trpc/audit-router.test.ts
+++ b/tests/integration/trpc/audit-router.test.ts
@@ -4,6 +4,7 @@ import type { AccountRecord } from "@/modules/accounts/application/ensure-accoun
 import { appRouter } from "@/server/trpc/router";
 import { createEmptyAccountRepository } from "../../support/account-repository";
 import { InMemoryAuditRepository } from "../../support/audit-repository";
+import { createInMemoryAppUnitOfWork } from "../../support/app-unit-of-work";
 import { createEmptyHandReceiptRepository } from "../../support/hand-receipt-repository";
 
 function createAccount(): AccountRecord {
@@ -30,6 +31,7 @@ describe("auditRouter", () => {
       accountRepository: createEmptyAccountRepository(),
       auditRepository: new InMemoryAuditRepository(),
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork(),
     });
 
     await expect(caller.audit.listRecentActivity()).resolves.toEqual([]);
@@ -70,6 +72,7 @@ describe("auditRouter", () => {
       accountRepository: createEmptyAccountRepository(),
       auditRepository,
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork({ auditRepository }),
     });
 
     await expect(caller.audit.listRecentActivity()).resolves.toMatchObject([
@@ -135,6 +138,7 @@ describe("auditRouter", () => {
       accountRepository: createEmptyAccountRepository(),
       auditRepository,
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork({ auditRepository }),
     });
 
     await expect(
@@ -186,6 +190,7 @@ describe("auditRouter", () => {
       accountRepository: createEmptyAccountRepository(),
       auditRepository,
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork({ auditRepository }),
     });
 
     await expect(

--- a/tests/integration/trpc/billing-router.test.ts
+++ b/tests/integration/trpc/billing-router.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { appRouter } from "@/server/trpc/router";
 import { createEmptyAccountRepository } from "../../support/account-repository";
 import { createEmptyAuditRepository } from "../../support/audit-repository";
+import { createInMemoryAppUnitOfWork } from "../../support/app-unit-of-work";
 import { createEmptyHandReceiptRepository } from "../../support/hand-receipt-repository";
 
 describe("billingRouter", () => {
@@ -24,6 +25,7 @@ describe("billingRouter", () => {
       accountRepository: createEmptyAccountRepository(),
       auditRepository: createEmptyAuditRepository(),
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork(),
     });
 
     await expect(caller.billing.capabilities()).resolves.toMatchObject({

--- a/tests/integration/trpc/foundation-router.test.ts
+++ b/tests/integration/trpc/foundation-router.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { appRouter } from "@/server/trpc/router";
 import { createEmptyAccountRepository } from "../../support/account-repository";
 import { createEmptyAuditRepository } from "../../support/audit-repository";
+import { createInMemoryAppUnitOfWork } from "../../support/app-unit-of-work";
 import { createEmptyHandReceiptRepository } from "../../support/hand-receipt-repository";
 
 describe("foundationRouter", () => {
@@ -13,6 +14,7 @@ describe("foundationRouter", () => {
       accountRepository: createEmptyAccountRepository(),
       auditRepository: createEmptyAuditRepository(),
       handReceiptRepository: createEmptyHandReceiptRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork(),
     });
 
     await expect(caller.foundation.health()).resolves.toMatchObject({

--- a/tests/integration/trpc/hand-receipts-router.test.ts
+++ b/tests/integration/trpc/hand-receipts-router.test.ts
@@ -5,6 +5,7 @@ import type { AccountRecord } from "@/modules/accounts/application/ensure-accoun
 import { appRouter } from "@/server/trpc/router";
 import { createEmptyAccountRepository } from "../../support/account-repository";
 import { InMemoryAuditRepository } from "../../support/audit-repository";
+import { createInMemoryAppUnitOfWork } from "../../support/app-unit-of-work";
 import { InMemoryHandReceiptRepository } from "../../support/hand-receipt-repository";
 
 function createAccount(overrides: Partial<AccountRecord> = {}): AccountRecord {
@@ -38,6 +39,10 @@ function createCaller({
     accountRepository: createEmptyAccountRepository(),
     auditRepository,
     handReceiptRepository,
+    unitOfWork: createInMemoryAppUnitOfWork({
+      auditRepository,
+      handReceiptRepository,
+    }),
   });
 }
 
@@ -127,6 +132,26 @@ describe("handReceiptsRouter", () => {
         name: "",
       }),
     ).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  it("rolls back hand receipt creation when audit recording fails in the unit of work", async () => {
+    const repository = new InMemoryHandReceiptRepository();
+    const auditRepository = new InMemoryAuditRepository();
+    auditRepository.failRecording = true;
+
+    await expect(
+      createCaller({
+        auditRepository,
+        handReceiptRepository: repository,
+      }).handReceipts.create({
+        name: "Unaudited receipt",
+      }),
+    ).rejects.toMatchObject({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Audit event was not recorded.",
+    });
+    expect(repository.handReceipts).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("enforces capability limits through the typed procedure", async () => {
@@ -246,6 +271,7 @@ describe("handReceiptsRouter", () => {
 
   it("updates hand receipt details and records update audit history", async () => {
     const handReceiptId = "895c4267-19a7-4629-a873-3e7224d00528";
+    const auditRepository = new InMemoryAuditRepository();
     const repository = new InMemoryHandReceiptRepository([
       {
         id: handReceiptId,
@@ -265,6 +291,7 @@ describe("handReceiptsRouter", () => {
 
     const updated = await createCaller({
       handReceiptRepository: repository,
+      auditRepository,
     }).handReceipts.update({
       id: handReceiptId,
       name: "Updated receipt",
@@ -278,7 +305,7 @@ describe("handReceiptsRouter", () => {
       notes: "Edited in detail.",
       holderName: "SSG Rivera",
     });
-    expect(repository.auditEvents).toMatchObject([
+    expect(auditRepository.events).toMatchObject([
       {
         accountId: "account-1",
         actorId: "owner-1",
@@ -330,6 +357,7 @@ describe("handReceiptsRouter", () => {
 
   it("archives and restores through the typed procedures with audit history", async () => {
     const handReceiptId = "ce34705f-369b-45f0-91fd-c5f03f18b952";
+    const auditRepository = new InMemoryAuditRepository();
     const repository = new InMemoryHandReceiptRepository([
       {
         id: handReceiptId,
@@ -346,7 +374,10 @@ describe("handReceiptsRouter", () => {
         updatedAt: new Date("2026-04-30T12:00:00.000Z"),
       },
     ]);
-    const caller = createCaller({ handReceiptRepository: repository });
+    const caller = createCaller({
+      auditRepository,
+      handReceiptRepository: repository,
+    });
 
     await expect(
       caller.handReceipts.archive({ id: handReceiptId }),
@@ -368,7 +399,7 @@ describe("handReceiptsRouter", () => {
       id: handReceiptId,
       status: "active",
     });
-    expect(repository.auditEvents).toMatchObject([
+    expect(auditRepository.events).toMatchObject([
       {
         action: "hand_receipt.archived",
         targetId: handReceiptId,
@@ -389,6 +420,7 @@ describe("handReceiptsRouter", () => {
   it("blocks archive and restore mutations for read-only accounts without audit history", async () => {
     const activeId = "b09c3dc7-02fe-4205-80ec-712dd7567347";
     const archivedId = "b12b070b-4f35-48db-b3d2-ddc36f5ee5cd";
+    const auditRepository = new InMemoryAuditRepository();
     const repository = new InMemoryHandReceiptRepository([
       {
         id: activeId,
@@ -424,6 +456,7 @@ describe("handReceiptsRouter", () => {
         accessState: "paused_read_only",
         subscriptionTier: "pro",
       }),
+      auditRepository,
       handReceiptRepository: repository,
     });
 
@@ -439,6 +472,6 @@ describe("handReceiptsRouter", () => {
       code: "FORBIDDEN",
       message: "This account is read-only.",
     });
-    expect(repository.auditEvents).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
   });
 });

--- a/tests/rls/hand-receipts/hand-receipt-repository-rls.test.ts
+++ b/tests/rls/hand-receipts/hand-receipt-repository-rls.test.ts
@@ -82,30 +82,17 @@ describe("hand receipt repository RLS boundary", () => {
     });
 
     await expect(
-      repository.createWithAuditEvent(
-        {
-          accountId: ownerTwoAccountId,
-          name: "Blocked receipt",
-          notes: null,
-          handReceiptNumber: null,
-          holderName: null,
-          unitName: null,
-          uic: null,
-          effectiveDate: null,
-          status: "active",
-        },
-        {
-          accountId: ownerTwoAccountId,
-          actorId: ownerOneId,
-          action: "hand_receipt.created",
-          targetType: "hand_receipt",
-          targetId: "blocked-receipt",
-          occurredAt: new Date("2026-04-30T14:00:00.000Z"),
-          metadata: {
-            name: "Blocked receipt",
-          },
-        },
-      ),
+      repository.create({
+        accountId: ownerTwoAccountId,
+        name: "Blocked receipt",
+        notes: null,
+        handReceiptNumber: null,
+        holderName: null,
+        unitName: null,
+        uic: null,
+        effectiveDate: null,
+        status: "active",
+      }),
     ).rejects.toThrow();
   });
 
@@ -115,48 +102,18 @@ describe("hand receipt repository RLS boundary", () => {
     });
 
     await expect(
-      repository.updateWithAuditEvent(
-        ownerOneAccountId,
-        ownerOneHandReceiptId,
-        {
-          name: "Updated owner one receipt",
-        },
-        {
-          accountId: ownerOneAccountId,
-          actorId: ownerOneId,
-          action: "hand_receipt.updated",
-          targetType: "hand_receipt",
-          targetId: ownerOneHandReceiptId,
-          occurredAt: new Date("2026-04-30T14:30:00.000Z"),
-          metadata: {
-            changedFields: ["name"],
-          },
-        },
-      ),
+      repository.update(ownerOneAccountId, ownerOneHandReceiptId, {
+        name: "Updated owner one receipt",
+      }),
     ).resolves.toMatchObject({
       id: ownerOneHandReceiptId,
       name: "Updated owner one receipt",
     });
 
     await expect(
-      repository.updateWithAuditEvent(
-        ownerTwoAccountId,
-        ownerTwoHandReceiptId,
-        {
-          name: "Blocked owner two update",
-        },
-        {
-          accountId: ownerTwoAccountId,
-          actorId: ownerOneId,
-          action: "hand_receipt.updated",
-          targetType: "hand_receipt",
-          targetId: ownerTwoHandReceiptId,
-          occurredAt: new Date("2026-04-30T14:35:00.000Z"),
-          metadata: {
-            changedFields: ["name"],
-          },
-        },
-      ),
+      repository.update(ownerTwoAccountId, ownerTwoHandReceiptId, {
+        name: "Blocked owner two update",
+      }),
     ).resolves.toBeNull();
   });
 });

--- a/tests/support/app-unit-of-work.ts
+++ b/tests/support/app-unit-of-work.ts
@@ -1,0 +1,53 @@
+import type {
+  AppUnitOfWork,
+  AppUnitOfWorkRepositories,
+} from "@/modules/provider-boundaries/database/app-unit-of-work";
+import { InMemoryAuditRepository } from "./audit-repository";
+import { InMemoryHandReceiptRepository } from "./hand-receipt-repository";
+
+export function createInMemoryAppUnitOfWork(
+  repositories: Partial<AppUnitOfWorkRepositories> = {},
+): AppUnitOfWork {
+  const handReceiptRepository =
+    repositories.handReceiptRepository ?? new InMemoryHandReceiptRepository();
+  const auditRepository =
+    repositories.auditRepository ?? new InMemoryAuditRepository();
+
+  return {
+    async run(operation) {
+      const inMemoryHandReceiptRepository =
+        handReceiptRepository instanceof InMemoryHandReceiptRepository
+          ? handReceiptRepository
+          : null;
+      const inMemoryAuditRepository =
+        auditRepository instanceof InMemoryAuditRepository
+          ? auditRepository
+          : null;
+      const handReceiptSnapshot =
+        inMemoryHandReceiptRepository !== null
+          ? [...inMemoryHandReceiptRepository.handReceipts]
+          : null;
+      const auditSnapshot =
+        inMemoryAuditRepository !== null
+          ? [...inMemoryAuditRepository.events]
+          : null;
+
+      try {
+        return await operation({
+          auditRepository,
+          handReceiptRepository,
+        });
+      } catch (error) {
+        if (inMemoryHandReceiptRepository && handReceiptSnapshot) {
+          inMemoryHandReceiptRepository.handReceipts = handReceiptSnapshot;
+        }
+
+        if (inMemoryAuditRepository && auditSnapshot) {
+          inMemoryAuditRepository.events = auditSnapshot;
+        }
+
+        throw error;
+      }
+    },
+  };
+}

--- a/tests/support/audit-repository.ts
+++ b/tests/support/audit-repository.ts
@@ -6,12 +6,17 @@ import type {
 
 export class InMemoryAuditRepository implements AuditRepository {
   events: AuditEventRecord[] = [];
+  failRecording = false;
 
   constructor(events: AuditEventRecord[] = []) {
     this.events = [...events];
   }
 
   async record(event: NewAuditEventRecord) {
+    if (this.failRecording) {
+      throw new Error("Audit event was not recorded.");
+    }
+
     const createdEvent = {
       id: `event-${this.events.length + 1}`,
       createdAt: event.createdAt ?? event.occurredAt,

--- a/tests/support/hand-receipt-repository.ts
+++ b/tests/support/hand-receipt-repository.ts
@@ -1,4 +1,3 @@
-import type { AuditEventRecord, NewAuditEventRecord } from "@/modules/audit";
 import type {
   HandReceiptRecord,
   HandReceiptRepository,
@@ -8,14 +7,12 @@ import type {
 
 export class InMemoryHandReceiptRepository implements HandReceiptRepository {
   handReceipts: HandReceiptRecord[] = [];
-  auditEvents: AuditEventRecord[] = [];
-  failAuditRecording = false;
 
   constructor(handReceipts: HandReceiptRecord[] = []) {
     this.handReceipts = [...handReceipts];
   }
 
-  private async create(handReceipt: NewHandReceiptRecord) {
+  async create(handReceipt: NewHandReceiptRecord) {
     const createdHandReceipt = {
       id: `hand-receipt-${this.handReceipts.length + 1}`,
       createdAt: handReceipt.createdAt ?? new Date(),
@@ -24,25 +21,6 @@ export class InMemoryHandReceiptRepository implements HandReceiptRepository {
     };
 
     this.handReceipts.push(createdHandReceipt);
-    return createdHandReceipt;
-  }
-
-  async createWithAuditEvent(
-    handReceipt: NewHandReceiptRecord,
-    auditEvent: NewAuditEventRecord,
-  ) {
-    if (this.failAuditRecording) {
-      throw new Error("Audit event was not recorded.");
-    }
-
-    const createdHandReceipt = await this.create(handReceipt);
-    const createdAuditEvent = {
-      id: `event-${this.auditEvents.length + 1}`,
-      createdAt: auditEvent.createdAt ?? auditEvent.occurredAt,
-      ...auditEvent,
-    };
-
-    this.auditEvents.push(createdAuditEvent);
     return createdHandReceipt;
   }
 
@@ -71,16 +49,11 @@ export class InMemoryHandReceiptRepository implements HandReceiptRepository {
     );
   }
 
-  async updateWithAuditEvent(
+  async update(
     accountId: string,
     handReceiptId: string,
     updates: UpdateHandReceiptRecord,
-    auditEvent: NewAuditEventRecord,
   ) {
-    if (this.failAuditRecording) {
-      throw new Error("Audit event was not recorded.");
-    }
-
     const index = this.handReceipts.findIndex(
       (handReceipt) =>
         handReceipt.accountId === accountId && handReceipt.id === handReceiptId,
@@ -103,11 +76,6 @@ export class InMemoryHandReceiptRepository implements HandReceiptRepository {
     };
 
     this.handReceipts[index] = updatedHandReceipt;
-    this.auditEvents.push({
-      id: `event-${this.auditEvents.length + 1}`,
-      createdAt: auditEvent.createdAt ?? auditEvent.occurredAt,
-      ...auditEvent,
-    });
 
     return updatedHandReceipt;
   }

--- a/tests/unit/hand-receipts/archive-restore-hand-receipt.test.ts
+++ b/tests/unit/hand-receipts/archive-restore-hand-receipt.test.ts
@@ -89,6 +89,8 @@ describe("archiveHandReceipt", () => {
   });
 
   it("blocks archiving for read-only accounts", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+
     await expect(
       archiveHandReceipt({
         account: createAccount({
@@ -98,9 +100,10 @@ describe("archiveHandReceipt", () => {
         actorId: "owner-1",
         handReceiptId: "active-receipt",
         handReceiptRepository: createRepository(),
-        auditRepository: new InMemoryAuditRepository(),
+        auditRepository,
       }),
     ).rejects.toThrow("This account is read-only.");
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("does not archive an already archived hand receipt", async () => {
@@ -155,6 +158,7 @@ describe("restoreHandReceipt", () => {
   });
 
   it("blocks restore when Base is already at the active limit", async () => {
+    const auditRepository = new InMemoryAuditRepository();
     const repository = new InMemoryHandReceiptRepository([
       ...createRepository().handReceipts,
       {
@@ -193,9 +197,10 @@ describe("restoreHandReceipt", () => {
         actorId: "owner-1",
         handReceiptId: "archived-receipt",
         handReceiptRepository: repository,
-        auditRepository: new InMemoryAuditRepository(),
+        auditRepository,
       }),
     ).rejects.toThrow("Active hand receipt limit reached.");
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("does not restore an already active hand receipt", async () => {

--- a/tests/unit/hand-receipts/archive-restore-hand-receipt.test.ts
+++ b/tests/unit/hand-receipts/archive-restore-hand-receipt.test.ts
@@ -5,6 +5,7 @@ import {
   archiveHandReceipt,
   restoreHandReceipt,
 } from "@/modules/hand-receipts";
+import { InMemoryAuditRepository } from "../../support/audit-repository";
 import { InMemoryHandReceiptRepository } from "../../support/hand-receipt-repository";
 
 function createAccount(overrides: Partial<AccountRecord> = {}): AccountRecord {
@@ -57,12 +58,14 @@ describe("archiveHandReceipt", () => {
   it("archives an active hand receipt and records audit history", async () => {
     const account = createAccount();
     const repository = createRepository();
+    const auditRepository = new InMemoryAuditRepository();
 
     const archived = await archiveHandReceipt({
       account,
       actorId: account.userId,
       handReceiptId: "active-receipt",
       handReceiptRepository: repository,
+      auditRepository,
       now: new Date("2026-04-30T13:00:00.000Z"),
     });
 
@@ -71,7 +74,7 @@ describe("archiveHandReceipt", () => {
       status: "archived",
       updatedAt: new Date("2026-04-30T13:00:00.000Z"),
     });
-    expect(repository.auditEvents).toMatchObject([
+    expect(auditRepository.events).toMatchObject([
       {
         accountId: account.id,
         actorId: account.userId,
@@ -95,12 +98,14 @@ describe("archiveHandReceipt", () => {
         actorId: "owner-1",
         handReceiptId: "active-receipt",
         handReceiptRepository: createRepository(),
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).rejects.toThrow("This account is read-only.");
   });
 
   it("does not archive an already archived hand receipt", async () => {
     const repository = createRepository();
+    const auditRepository = new InMemoryAuditRepository();
 
     await expect(
       archiveHandReceipt({
@@ -108,9 +113,10 @@ describe("archiveHandReceipt", () => {
         actorId: "owner-1",
         handReceiptId: "archived-receipt",
         handReceiptRepository: repository,
+        auditRepository,
       }),
     ).rejects.toThrow("Hand receipt is already archived.");
-    expect(repository.auditEvents).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
   });
 });
 
@@ -118,12 +124,14 @@ describe("restoreHandReceipt", () => {
   it("restores an archived hand receipt and records audit history", async () => {
     const account = createAccount();
     const repository = createRepository();
+    const auditRepository = new InMemoryAuditRepository();
 
     const restored = await restoreHandReceipt({
       account,
       actorId: account.userId,
       handReceiptId: "archived-receipt",
       handReceiptRepository: repository,
+      auditRepository,
       now: new Date("2026-04-30T13:30:00.000Z"),
     });
 
@@ -132,7 +140,7 @@ describe("restoreHandReceipt", () => {
       status: "active",
       updatedAt: new Date("2026-04-30T13:30:00.000Z"),
     });
-    expect(repository.auditEvents).toMatchObject([
+    expect(auditRepository.events).toMatchObject([
       {
         accountId: account.id,
         actorId: account.userId,
@@ -185,13 +193,14 @@ describe("restoreHandReceipt", () => {
         actorId: "owner-1",
         handReceiptId: "archived-receipt",
         handReceiptRepository: repository,
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).rejects.toThrow("Active hand receipt limit reached.");
-    expect(repository.auditEvents).toEqual([]);
   });
 
   it("does not restore an already active hand receipt", async () => {
     const repository = createRepository();
+    const auditRepository = new InMemoryAuditRepository();
 
     await expect(
       restoreHandReceipt({
@@ -199,8 +208,9 @@ describe("restoreHandReceipt", () => {
         actorId: "owner-1",
         handReceiptId: "active-receipt",
         handReceiptRepository: repository,
+        auditRepository,
       }),
     ).rejects.toThrow("Hand receipt is already active.");
-    expect(repository.auditEvents).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
   });
 });

--- a/tests/unit/hand-receipts/create-hand-receipt.test.ts
+++ b/tests/unit/hand-receipts/create-hand-receipt.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
 import { createHandReceipt } from "@/modules/hand-receipts";
+import { InMemoryAuditRepository } from "../../support/audit-repository";
 import { InMemoryHandReceiptRepository } from "../../support/hand-receipt-repository";
 
 function createAccount(overrides: Partial<AccountRecord> = {}): AccountRecord {
@@ -21,6 +22,7 @@ describe("createHandReceipt", () => {
   it("creates an active hand receipt and records an audit event", async () => {
     const account = createAccount();
     const handReceiptRepository = new InMemoryHandReceiptRepository();
+    const auditRepository = new InMemoryAuditRepository();
 
     const handReceipt = await createHandReceipt({
       account,
@@ -30,6 +32,7 @@ describe("createHandReceipt", () => {
         notes: "Sensitive items stay in the wall locker.",
       },
       handReceiptRepository,
+      auditRepository,
       now: new Date("2026-04-30T12:00:00.000Z"),
       createHandReceiptId: () => "created-hand-receipt-1",
     });
@@ -40,7 +43,7 @@ describe("createHandReceipt", () => {
       notes: "Sensitive items stay in the wall locker.",
       status: "active",
     });
-    expect(handReceiptRepository.auditEvents).toMatchObject([
+    expect(auditRepository.events).toMatchObject([
       {
         accountId: account.id,
         actorId: account.userId,
@@ -54,9 +57,10 @@ describe("createHandReceipt", () => {
     ]);
   });
 
-  it("does not create a hand receipt when the audit event cannot be recorded", async () => {
+  it("propagates audit recording failures to the caller", async () => {
     const handReceiptRepository = new InMemoryHandReceiptRepository();
-    handReceiptRepository.failAuditRecording = true;
+    const auditRepository = new InMemoryAuditRepository();
+    auditRepository.failRecording = true;
 
     await expect(
       createHandReceipt({
@@ -66,11 +70,11 @@ describe("createHandReceipt", () => {
           name: "Unaudited receipt",
         },
         handReceiptRepository,
+        auditRepository,
       }),
     ).rejects.toThrow("Audit event was not recorded.");
 
-    expect(handReceiptRepository.handReceipts).toEqual([]);
-    expect(handReceiptRepository.auditEvents).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("requires a non-empty name", async () => {
@@ -82,6 +86,7 @@ describe("createHandReceipt", () => {
           name: "   ",
         },
         handReceiptRepository: new InMemoryHandReceiptRepository(),
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).rejects.toThrow("Hand receipt name is required.");
   });
@@ -98,6 +103,7 @@ describe("createHandReceipt", () => {
           name: "Read-only receipt",
         },
         handReceiptRepository: new InMemoryHandReceiptRepository(),
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).rejects.toThrow("This account is read-only.");
   });
@@ -157,6 +163,7 @@ describe("createHandReceipt", () => {
           name: "Charlie",
         },
         handReceiptRepository,
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).resolves.toMatchObject({
       name: "Charlie",
@@ -170,6 +177,7 @@ describe("createHandReceipt", () => {
           name: "Delta",
         },
         handReceiptRepository,
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).rejects.toThrow("Active hand receipt limit reached.");
   });
@@ -203,6 +211,7 @@ describe("createHandReceipt", () => {
         handReceiptRepository: new InMemoryHandReceiptRepository(
           seededReceipts,
         ),
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).resolves.toMatchObject({
       name: "Trial receipt",
@@ -220,6 +229,7 @@ describe("createHandReceipt", () => {
         handReceiptRepository: new InMemoryHandReceiptRepository(
           seededReceipts,
         ),
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).resolves.toMatchObject({
       name: "Pro receipt",

--- a/tests/unit/hand-receipts/update-hand-receipt.test.ts
+++ b/tests/unit/hand-receipts/update-hand-receipt.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
 import { updateHandReceipt } from "@/modules/hand-receipts";
+import { InMemoryAuditRepository } from "../../support/audit-repository";
 import { InMemoryHandReceiptRepository } from "../../support/hand-receipt-repository";
 
 function createAccount(overrides: Partial<AccountRecord> = {}): AccountRecord {
@@ -40,6 +41,7 @@ describe("updateHandReceipt", () => {
   it("updates editable fields and records the changed fields in audit history", async () => {
     const account = createAccount();
     const repository = createRepository();
+    const auditRepository = new InMemoryAuditRepository();
 
     const updated = await updateHandReceipt({
       account,
@@ -55,6 +57,7 @@ describe("updateHandReceipt", () => {
         effectiveDate: "2026-04-30",
       },
       handReceiptRepository: repository,
+      auditRepository,
       now: new Date("2026-04-30T13:00:00.000Z"),
     });
 
@@ -68,7 +71,7 @@ describe("updateHandReceipt", () => {
       uic: "W123AA",
       effectiveDate: "2026-04-30",
     });
-    expect(repository.auditEvents).toMatchObject([
+    expect(auditRepository.events).toMatchObject([
       {
         accountId: account.id,
         actorId: account.userId,
@@ -93,6 +96,7 @@ describe("updateHandReceipt", () => {
   it("returns the existing hand receipt without audit history when nothing changed", async () => {
     const account = createAccount();
     const repository = createRepository();
+    const auditRepository = new InMemoryAuditRepository();
 
     const unchanged = await updateHandReceipt({
       account,
@@ -103,6 +107,7 @@ describe("updateHandReceipt", () => {
         notes: "Before update.",
       },
       handReceiptRepository: repository,
+      auditRepository,
       now: new Date("2026-04-30T13:00:00.000Z"),
     });
 
@@ -111,7 +116,7 @@ describe("updateHandReceipt", () => {
       name: "Original receipt",
       updatedAt: new Date("2026-04-30T12:00:00.000Z"),
     });
-    expect(repository.auditEvents).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("requires a non-empty name", async () => {
@@ -124,6 +129,7 @@ describe("updateHandReceipt", () => {
           name: "   ",
         },
         handReceiptRepository: createRepository(),
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).rejects.toThrow("Hand receipt name is required.");
   });
@@ -141,12 +147,14 @@ describe("updateHandReceipt", () => {
           name: "Blocked update",
         },
         handReceiptRepository: createRepository(),
+        auditRepository: new InMemoryAuditRepository(),
       }),
     ).rejects.toThrow("This account is read-only.");
   });
 
   it("returns null without recording audit history when the record is not owned by the account", async () => {
     const repository = createRepository();
+    const auditRepository = new InMemoryAuditRepository();
 
     await expect(
       updateHandReceipt({
@@ -157,8 +165,9 @@ describe("updateHandReceipt", () => {
           name: "Other account update",
         },
         handReceiptRepository: repository,
+        auditRepository,
       }),
     ).resolves.toBeNull();
-    expect(repository.auditEvents).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
   });
 });

--- a/tests/unit/hand-receipts/update-hand-receipt.test.ts
+++ b/tests/unit/hand-receipts/update-hand-receipt.test.ts
@@ -120,6 +120,8 @@ describe("updateHandReceipt", () => {
   });
 
   it("requires a non-empty name", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+
     await expect(
       updateHandReceipt({
         account: createAccount(),
@@ -129,12 +131,15 @@ describe("updateHandReceipt", () => {
           name: "   ",
         },
         handReceiptRepository: createRepository(),
-        auditRepository: new InMemoryAuditRepository(),
+        auditRepository,
       }),
     ).rejects.toThrow("Hand receipt name is required.");
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("blocks paused or read-only accounts", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+
     await expect(
       updateHandReceipt({
         account: createAccount({
@@ -147,9 +152,10 @@ describe("updateHandReceipt", () => {
           name: "Blocked update",
         },
         handReceiptRepository: createRepository(),
-        auditRepository: new InMemoryAuditRepository(),
+        auditRepository,
       }),
     ).rejects.toThrow("This account is read-only.");
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("returns null without recording audit history when the record is not owned by the account", async () => {


### PR DESCRIPTION
## Summary

- Move hand receipt audit persistence back behind the audit module instead of the hand receipt repository.
- Add an app-owned authenticated unit-of-work boundary so hand receipt writes and audit events still commit atomically.
- Update tests, RLS coverage, docs, and verification helpers for the new boundary.
- Keep the earlier verification hardening for Sandcastle lint ignores and auth/app-shell e2e stability.

## Validation

- `pnpm verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Release Notes

## Overview
Refactored audit event persistence to enforce atomic commits of domain state and audit history through an application-owned unit-of-work boundary. Hand receipt create/update/archive/restore operations now compose separately with audit repositories instead of embedding audit logic in domain repositories.

## Architecture Changes
- **New Unit-of-Work Boundary**: Introduced `AppUnitOfWork` providing transaction-scoped `AuditRepository` and `HandReceiptRepository` instances that commit atomically within a single authenticated database session.
- **Repository Decoupling**: Removed audit-coupled methods (`createWithAuditEvent`, `updateWithAuditEvent`) from `HandReceiptRepository`; audit event recording is now a separate concern executed after successful domain operations.
- **Documentation**: Updated architecture guide and audit module README to specify that workflows requiring atomic domain state + audit history commits must route through the app-owned unit-of-work boundary.

## Core Changes
- **Audit Repository**: Added `createTransactionalDrizzleAuditRepository()` to accept externally-managed database transactions, enabling repository construction within unit-of-work scopes.
- **Hand Receipt Repository**: Added `createTransactionalDrizzleHandReceiptRepository()` for transaction-scoped repository creation; removed all direct audit event writing.
- **Application Layer**: Refactored `createHandReceipt`, `updateHandReceipt`, `archiveHandReceipt`, and `restoreHandReceipt` to accept `auditRepository` parameter and execute audit recording as a separate explicit step after successful domain updates.

## TRPC Integration
- **Context**: Added `unitOfWork: AppUnitOfWork` to TRPC context, provisioned with unavailable or Drizzle-backed instances depending on authentication state.
- **Protected Procedures**: Forwarded `unitOfWork` to resolver context alongside existing repositories.
- **Hand Receipts Router**: Updated create/update/archive/restore mutations to execute operations within `ctx.unitOfWork.run()`, receiving transaction-scoped repositories from the unit-of-work rather than using pre-bound context repositories.

## Testing & Verification
- **Test Helpers**: Added `createInMemoryAppUnitOfWork()` for in-memory unit-of-work testing with automatic transaction rollback on operation failure.
- **Audit Repository**: Extended `InMemoryAuditRepository` with `failRecording` flag to simulate audit failure scenarios.
- **Test Coverage**: Updated all integration and unit tests to wire the new `unitOfWork` dependency and verify audit events via dedicated `auditRepository` instead of hand-receipt repository audit state.
- **RLS Tests**: Simplified hand-receipt repository RLS tests by removing audit event payload construction; now call plain `create`/`update` methods.

## Configuration
- **ESLint**: Extended global ignore list to exclude `.sandcastle/` directory paths from linting.
- **Foundation Check**: Updated mock `foundation` surface to reflect plain repository methods and new `unitOfWork` dependency.
- **E2E Tests**: Fixed auth flow redirects and updated onboarding dialog handling for conditional visibility.

## Breaking Changes
- `HandReceiptRepository` no longer exposes `createWithAuditEvent()` or `updateWithAuditEvent()` methods; use plain `create()`/`update()` with separate `auditRepository` and `recordAuditEvent()` calls.
- Hand receipt application functions now require `auditRepository` parameter in their input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->