### PR TITLE
Document requirement pause state decision

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -73,7 +73,7 @@
 | **Overdue** | A requirement state where the next due date is before today. | Late task |
 | **Due Soon** | A requirement state where the next due date is today through 14 days from today. | Upcoming |
 | **Upcoming** | A requirement state where the next due date is 15 through 30 days from today. | Due soon |
-| **Suppressed Requirement** | A requirement hidden from active dashboard work because its item or hand receipt is archived or the account is paused. | Deleted requirement |
+| **Suppressed Requirement** | A requirement hidden from active dashboard work because it is paused with `pausedAt`, its item or hand receipt is archived, or the account is paused. | Deleted requirement |
 | **Cyclic Inventory** | A commander or property book office inventory process that Field Ledger does not manage in MVP. | Requirement |
 
 ## History and Lifecycle
@@ -86,7 +86,7 @@
 | **Archive** | A reversible lifecycle action that removes a record from normal workflows while preserving history. | Delete |
 | **Restore** | A lifecycle action that returns an archived record to active workflows. | Recreate |
 | **Close** | A lifecycle action that ends a 2062 assignment or item link while preserving history and documents. | Delete, destroy, deactivate |
-| **Pause** | A lifecycle action that suppresses requirement behavior without deleting the requirement. | Archive, complete |
+| **Pause** | A lifecycle action that sets requirement `pausedAt` to suppress active requirement behavior without deleting the requirement. | Archive, complete |
 
 ## Future Boundaries
 

--- a/docs/adr/0006-requirement-pause-state.md
+++ b/docs/adr/0006-requirement-pause-state.md
@@ -1,0 +1,48 @@
+# ADR 0006: Requirement Pause State
+
+## Status
+
+Accepted
+
+## Context
+
+Requirements can be paused and resumed without being archived or deleted. Pause
+is a temporary suppression of active requirement behavior: paused requirements
+stay visible on item detail, are excluded from dashboard work, and cannot be
+completed until resumed.
+
+The first requirements implementation represents pause with a nullable
+`pausedAt` timestamp. Review feedback raised the question of whether pause
+should instead be represented as a `status` enum value, such as `paused`.
+
+## Decision
+
+Keep requirement pause state timestamp-driven. A requirement is paused when
+`pausedAt` is not null and unpaused when `pausedAt` is null.
+
+The requirement `status` field remains reserved for broader record lifecycle
+states, not the pause/resume toggle. Requirement pause/resume actions emit audit
+events, and `pausedAt` records the current pause start time on the requirement
+row for filtering and display.
+
+## Consequences
+
+- Pause can be queried directly without introducing another lifecycle enum value.
+- The product keeps the timestamp of the current pause available without reading
+  audit history.
+- Pause remains distinct from archive. Archive removes a record from normal
+  workflows for history preservation; pause temporarily suppresses active
+  requirement behavior.
+- Concurrency-sensitive pause/resume writes should condition updates on the
+  expected `pausedAt` state: pause only when `pausedAt` is null, and resume only
+  when `pausedAt` is not null.
+- If requirements later gain more mutually exclusive lifecycle states, a future
+  ADR should revisit whether `status` should absorb pause state.
+
+## Rejected Alternatives
+
+- Model pause as `status = 'paused'`. This would align with some lifecycle enum
+  patterns, but it adds schema and migration churn without a current need for a
+  broader requirement status machine.
+- Remove requirement-level pause. MVP requirements explicitly need a reversible
+  way to suppress active requirement work without deleting history.

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -272,6 +272,10 @@ Rules:
 - Individual requirements can be paused and resumed. A paused requirement stays
   visible on item detail but is excluded from active requirement work and cannot
   be completed until resumed.
+- Requirement pause state is timestamp-driven: `pausedAt` is set while the
+  requirement is paused and cleared when it is resumed. Requirement `status`
+  remains reserved for broader record lifecycle state, not the pause/resume
+  toggle.
 - Resuming a requirement returns it to active behavior unless its item or hand
   receipt is archived.
 - Requirement next due adjustment, pause, and resume emit

--- a/plans/05-requirements-dashboard.md
+++ b/plans/05-requirements-dashboard.md
@@ -16,6 +16,8 @@ This plan implements item-level recurring requirements, completion history, and 
 - **Operational dates**: date-only.
 - **Dashboard windows**: overdue, due soon through 14 days, upcoming 15-30 days.
 - **Priority**: no manual priority in MVP.
+- **Pause state**: requirement pause is represented by `pausedAt`, not by a
+  `status = "paused"` enum value. Pause sets `pausedAt`; resume clears it.
 
 ---
 
@@ -73,6 +75,7 @@ Allow manual next due date adjustment and requirement pause/resume behavior.
 - [x] Next completion recalculates from completion date.
 - [x] Requirement can be paused/resumed.
 - [x] Adjustments and pause/resume emit audit events.
+- [x] Pause state uses `pausedAt` as the current suppression marker.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add ADR 0006 documenting `pausedAt` as the requirement pause state marker.
- Clarify requirement pause language in the domain model, ubiquitous language, and requirements plan.
- Keep #54 aligned to the timestamp-driven lifecycle contract.

## Validation

- `pnpm format:check`

Closes #55