### PR TITLE
[codex] Make requirement pause/resume concurrency-safe

### DIFF
--- a/docs/adr/0006-requirement-pause-state.md
+++ b/docs/adr/0006-requirement-pause-state.md
@@ -35,7 +35,7 @@ row for filtering and display.
   requirement behavior.
 - Concurrency-sensitive pause/resume writes should condition updates on the
   expected `pausedAt` state: pause only when `pausedAt` is null, and resume only
-  when `pausedAt` is not null.
+  when the stored `pausedAt` still matches the timestamp read by the service.
 - If requirements later gain more mutually exclusive lifecycle states, a future
   ADR should revisit whether `status` should absorb pause state.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,13 @@ application services. Item-detail and dashboard routes compose requirement UI
 and typed tRPC procedures; they do not calculate due windows or write audit
 events directly.
 
+Requirement pause/resume uses a conditional repository write against
+`paused_at`: pause only succeeds while the persisted value is null, and resume
+only succeeds while the persisted value still matches the timestamp read by the
+service. Future lifecycle transitions with similar read-then-write races should
+use the same conditional-write shape so stale operations fail before
+audit/activity history is recorded.
+
 ## App Shell
 
 Authenticated product routes live under the literal `/app` URL path. The

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -253,6 +253,14 @@ Rules:
 - Requirement edits emit `requirement.updated` with changed-field metadata.
 - Paused/read-only accounts can view requirements but cannot create or edit
   requirements.
+- Pausing a requirement sets `paused_at`; resuming clears it. Pause writes are
+  conditional on `paused_at` still being null, and resume writes are
+  conditional on the stored `paused_at` still matching the timestamp read by
+  the service. Stale concurrent operations fail with a state-changed conflict
+  instead of overwriting the current lifecycle state.
+- Requirement pause/resume audit events are recorded only after a successful
+  lifecycle transition. Clients that receive a conflict should refetch the
+  requirement before retrying or updating the visible state.
 - Active requirements are listed on item detail by next due date.
 - Due dates calculate from last completed date.
 - Editing an interval recalculates next due from the latest completion date, or

--- a/src/modules/requirements/application/pause-requirement.ts
+++ b/src/modules/requirements/application/pause-requirement.ts
@@ -51,10 +51,13 @@ export async function pauseRequirement({
       pausedAt: now,
       updatedAt: now,
     },
+    {
+      expectedPausedAt: null,
+    },
   );
 
   if (!updated) {
-    throw new Error("Requirement was not found.");
+    throw new Error("Requirement state has changed.");
   }
 
   await recordAuditEvent({

--- a/src/modules/requirements/application/requirement-repository.ts
+++ b/src/modules/requirements/application/requirement-repository.ts
@@ -20,6 +20,10 @@ export type RequirementLifecycleUpdateInput = {
   updatedAt: Date;
 };
 
+export type RequirementLifecycleUpdateOptions = {
+  expectedPausedAt?: Date | null;
+};
+
 export interface RequirementRepository {
   create(requirement: NewRequirementRecord): Promise<RequirementRecord>;
   findById(
@@ -50,6 +54,7 @@ export interface RequirementRepository {
     accountId: string,
     requirementId: string,
     input: RequirementLifecycleUpdateInput,
+    options?: RequirementLifecycleUpdateOptions,
   ): Promise<RequirementRecord | null>;
 }
 

--- a/src/modules/requirements/application/resume-requirement.ts
+++ b/src/modules/requirements/application/resume-requirement.ts
@@ -72,10 +72,13 @@ export async function resumeRequirement({
       pausedAt: null,
       updatedAt: now,
     },
+    {
+      expectedPausedAt: existing.pausedAt,
+    },
   );
 
   if (!updated) {
-    throw new Error("Requirement was not found.");
+    throw new Error("Requirement state has changed.");
   }
 
   await recordAuditEvent({

--- a/src/modules/requirements/infrastructure/drizzle-requirement-repository.ts
+++ b/src/modules/requirements/infrastructure/drizzle-requirement-repository.ts
@@ -182,7 +182,14 @@ function createRequirementRepository(
 
       return updated ? toRequirementRecord(updated) : null;
     },
-    async updateLifecycle(accountId, requirementId, input) {
+    async updateLifecycle(accountId, requirementId, input, options) {
+      const pausedAtCondition =
+        options && "expectedPausedAt" in options
+          ? options.expectedPausedAt === null
+            ? sql`${requirements.pausedAt} is null`
+            : eq(requirements.pausedAt, options.expectedPausedAt)
+          : undefined;
+
       const [updated] = await run((transaction) =>
         transaction
           .update(requirements)
@@ -197,6 +204,7 @@ function createRequirementRepository(
             and(
               eq(requirements.accountId, accountId),
               eq(requirements.id, requirementId),
+              pausedAtCondition,
             ),
           )
           .returning(),

--- a/src/server/trpc/routers/requirements.ts
+++ b/src/server/trpc/routers/requirements.ts
@@ -110,6 +110,7 @@ function toTRPCError(
     case "Requirement is already paused.":
     case "Requirement is not paused.":
     case "Requirement is paused.":
+    case "Requirement state has changed.":
     case "Cannot resume requirement on archived item.":
     case "Cannot resume requirement on archived hand receipt.":
       throw new TRPCError({ code: "CONFLICT", message });

--- a/tests/integration/trpc/requirements-router.test.ts
+++ b/tests/integration/trpc/requirements-router.test.ts
@@ -766,4 +766,46 @@ describe("requirementsRouter", () => {
 
     expect(auditRepository.events).toEqual([]);
   });
+
+  it("maps stale resume writes to a conflict response", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+    const requirementRepository = new MutatingRequirementRepository(
+      [
+        {
+          id: "1f9de16d-fec7-462f-95b4-9a53a93fc636",
+          accountId: "account-1",
+          itemId: itemOneId,
+          name: "Monthly function check",
+          notes: null,
+          intervalType: "monthly",
+          intervalValue: null,
+          nextDueDate: "2026-05-15",
+          status: "active",
+          pausedAt: new Date("2026-05-01T12:00:00.000Z"),
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ],
+      (repository) => {
+        repository.requirements[0] = {
+          ...repository.requirements[0]!,
+          pausedAt: new Date("2026-05-01T12:30:00.000Z"),
+        };
+      },
+    );
+
+    await expect(
+      createCaller({
+        auditRepository,
+        requirementRepository,
+      }).requirements.resume({
+        requirementId: "1f9de16d-fec7-462f-95b4-9a53a93fc636",
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Requirement state has changed.",
+    });
+
+    expect(auditRepository.events).toEqual([]);
+  });
 });

--- a/tests/integration/trpc/requirements-router.test.ts
+++ b/tests/integration/trpc/requirements-router.test.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server";
 import { describe, expect, it } from "vitest";
 
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import type { RequirementRecord } from "@/modules/requirements";
 import { appRouter } from "@/server/trpc/router";
 import { InMemoryAccountRepository } from "../../support/account-repository";
 import { InMemoryAuditRepository } from "../../support/audit-repository";
@@ -123,6 +124,29 @@ function createCaller({
       requirementRepository,
     }),
   });
+}
+
+class MutatingRequirementRepository extends InMemoryRequirementRepository {
+  constructor(
+    requirements: RequirementRecord[],
+    private readonly mutateAfterRead: (
+      repository: InMemoryRequirementRepository,
+    ) => void,
+  ) {
+    super(requirements);
+  }
+
+  override async findById(accountId: string, requirementId: string) {
+    const requirement = await super.findById(accountId, requirementId);
+
+    if (requirement) {
+      const snapshot = { ...requirement };
+      this.mutateAfterRead(this);
+      return snapshot;
+    }
+
+    return null;
+  }
 }
 
 describe("requirementsRouter", () => {
@@ -699,5 +723,47 @@ describe("requirementsRouter", () => {
       code: "CONFLICT",
       message: "Requirement is not paused.",
     });
+  });
+
+  it("maps stale pause writes to a conflict response", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+    const requirementRepository = new MutatingRequirementRepository(
+      [
+        {
+          id: "1f9de16d-fec7-462f-95b4-9a53a93fc636",
+          accountId: "account-1",
+          itemId: itemOneId,
+          name: "Monthly function check",
+          notes: null,
+          intervalType: "monthly",
+          intervalValue: null,
+          nextDueDate: "2026-05-15",
+          status: "active",
+          pausedAt: null,
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ],
+      (repository) => {
+        repository.requirements[0] = {
+          ...repository.requirements[0]!,
+          pausedAt: new Date("2026-05-01T12:30:00.000Z"),
+        };
+      },
+    );
+
+    await expect(
+      createCaller({
+        auditRepository,
+        requirementRepository,
+      }).requirements.pause({
+        requirementId: "1f9de16d-fec7-462f-95b4-9a53a93fc636",
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Requirement state has changed.",
+    });
+
+    expect(auditRepository.events).toEqual([]);
   });
 });

--- a/tests/support/requirement-repository.ts
+++ b/tests/support/requirement-repository.ts
@@ -155,6 +155,9 @@ export class InMemoryRequirementRepository implements RequirementRepository {
       pausedAt?: Date | null;
       updatedAt: Date;
     },
+    options?: {
+      expectedPausedAt?: Date | null;
+    },
   ) {
     const index = this.requirements.findIndex(
       (requirement) =>
@@ -168,6 +171,14 @@ export class InMemoryRequirementRepository implements RequirementRepository {
     const existing = this.requirements[index];
 
     if (!existing) {
+      return null;
+    }
+
+    if (
+      options &&
+      "expectedPausedAt" in options &&
+      !samePausedAt(existing.pausedAt, options.expectedPausedAt)
+    ) {
       return null;
     }
 
@@ -185,4 +196,12 @@ export class InMemoryRequirementRepository implements RequirementRepository {
 
 export function createEmptyRequirementRepository() {
   return new InMemoryRequirementRepository();
+}
+
+function samePausedAt(left: Date | null, right: Date | null | undefined) {
+  if (left === null || right === null || right === undefined) {
+    return left === right;
+  }
+
+  return left.getTime() === right.getTime();
 }

--- a/tests/unit/requirements/requirement-lifecycle.test.ts
+++ b/tests/unit/requirements/requirement-lifecycle.test.ts
@@ -215,12 +215,13 @@ describe("requirement lifecycle controls", () => {
 
   it("fails a stale pause when the requirement is paused between read and write", async () => {
     const auditRepository = new InMemoryAuditRepository();
+    const concurrentPausedAt = new Date("2026-05-10T19:59:00.000Z");
     const requirementRepository = new MutatingRequirementRepository(
       [createRequirement()],
       (repository) => {
         repository.requirements[0] = {
           ...repository.requirements[0]!,
-          pausedAt: new Date("2026-05-10T19:59:00.000Z"),
+          pausedAt: concurrentPausedAt,
         };
       },
     );
@@ -237,6 +238,9 @@ describe("requirement lifecycle controls", () => {
     ).rejects.toThrow("Requirement state has changed.");
 
     expect(auditRepository.events).toEqual([]);
+    expect(requirementRepository.requirements[0]!.pausedAt).toEqual(
+      concurrentPausedAt,
+    );
   });
 
   it("fails a stale resume when the requirement is resumed between read and write", async () => {
@@ -269,10 +273,12 @@ describe("requirement lifecycle controls", () => {
     ).rejects.toThrow("Requirement state has changed.");
 
     expect(auditRepository.events).toEqual([]);
+    expect(requirementRepository.requirements[0]!.pausedAt).toBeNull();
   });
 
   it("fails a stale resume when the requirement is resumed and paused again between read and write", async () => {
     const auditRepository = new InMemoryAuditRepository();
+    const concurrentPausedAt = new Date("2026-05-10T19:30:00.000Z");
     const requirementRepository = new MutatingRequirementRepository(
       [
         createRequirement({
@@ -282,7 +288,7 @@ describe("requirement lifecycle controls", () => {
       (repository) => {
         repository.requirements[0] = {
           ...repository.requirements[0]!,
-          pausedAt: new Date("2026-05-10T19:30:00.000Z"),
+          pausedAt: concurrentPausedAt,
         };
       },
     );
@@ -301,6 +307,9 @@ describe("requirement lifecycle controls", () => {
     ).rejects.toThrow("Requirement state has changed.");
 
     expect(auditRepository.events).toEqual([]);
+    expect(requirementRepository.requirements[0]!.pausedAt).toEqual(
+      concurrentPausedAt,
+    );
   });
 
   it("blocks lifecycle changes for read-only accounts and invalid paused transitions", async () => {

--- a/tests/unit/requirements/requirement-lifecycle.test.ts
+++ b/tests/unit/requirements/requirement-lifecycle.test.ts
@@ -88,6 +88,29 @@ function createHandReceiptRepository(status: "active" | "archived" = "active") {
   ]);
 }
 
+class MutatingRequirementRepository extends InMemoryRequirementRepository {
+  constructor(
+    requirements: RequirementRecord[],
+    private readonly mutateAfterRead: (
+      repository: InMemoryRequirementRepository,
+    ) => void,
+  ) {
+    super(requirements);
+  }
+
+  override async findById(accountId: string, requirementId: string) {
+    const requirement = await super.findById(accountId, requirementId);
+
+    if (requirement) {
+      const snapshot = { ...requirement };
+      this.mutateAfterRead(this);
+      return snapshot;
+    }
+
+    return null;
+  }
+}
+
 describe("requirement lifecycle controls", () => {
   it("manually adjusts next due without changing the interval and records activity", async () => {
     const auditRepository = new InMemoryAuditRepository();
@@ -188,6 +211,96 @@ describe("requirement lifecycle controls", () => {
       "requirement.paused",
       "requirement.resumed",
     ]);
+  });
+
+  it("fails a stale pause when the requirement is paused between read and write", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+    const requirementRepository = new MutatingRequirementRepository(
+      [createRequirement()],
+      (repository) => {
+        repository.requirements[0] = {
+          ...repository.requirements[0]!,
+          pausedAt: new Date("2026-05-10T19:59:00.000Z"),
+        };
+      },
+    );
+
+    await expect(
+      pauseRequirement({
+        account: createAccount(),
+        actorId: "owner-1",
+        input: { requirementId: "requirement-1" },
+        auditRepository,
+        requirementRepository,
+        now: new Date("2026-05-10T20:00:00.000Z"),
+      }),
+    ).rejects.toThrow("Requirement state has changed.");
+
+    expect(auditRepository.events).toEqual([]);
+  });
+
+  it("fails a stale resume when the requirement is resumed between read and write", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+    const requirementRepository = new MutatingRequirementRepository(
+      [
+        createRequirement({
+          pausedAt: new Date("2026-05-10T19:00:00.000Z"),
+        }),
+      ],
+      (repository) => {
+        repository.requirements[0] = {
+          ...repository.requirements[0]!,
+          pausedAt: null,
+        };
+      },
+    );
+
+    await expect(
+      resumeRequirement({
+        account: createAccount(),
+        actorId: "owner-1",
+        input: { requirementId: "requirement-1" },
+        auditRepository,
+        handReceiptRepository: createHandReceiptRepository(),
+        itemRepository: createItemRepository(),
+        requirementRepository,
+        now: new Date("2026-05-10T20:00:00.000Z"),
+      }),
+    ).rejects.toThrow("Requirement state has changed.");
+
+    expect(auditRepository.events).toEqual([]);
+  });
+
+  it("fails a stale resume when the requirement is resumed and paused again between read and write", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+    const requirementRepository = new MutatingRequirementRepository(
+      [
+        createRequirement({
+          pausedAt: new Date("2026-05-10T19:00:00.000Z"),
+        }),
+      ],
+      (repository) => {
+        repository.requirements[0] = {
+          ...repository.requirements[0]!,
+          pausedAt: new Date("2026-05-10T19:30:00.000Z"),
+        };
+      },
+    );
+
+    await expect(
+      resumeRequirement({
+        account: createAccount(),
+        actorId: "owner-1",
+        input: { requirementId: "requirement-1" },
+        auditRepository,
+        handReceiptRepository: createHandReceiptRepository(),
+        itemRepository: createItemRepository(),
+        requirementRepository,
+        now: new Date("2026-05-10T20:00:00.000Z"),
+      }),
+    ).rejects.toThrow("Requirement state has changed.");
+
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("blocks lifecycle changes for read-only accounts and invalid paused transitions", async () => {


### PR DESCRIPTION
## Summary
- make requirement pause/resume lifecycle writes conditional on the exact persisted `pausedAt` state
- map stale lifecycle writes to a tRPC `CONFLICT` without emitting pause/resume audit events
- document the timestamp-driven concurrency contract and add stale-transition coverage

## Validation
- `pnpm verify`

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Concurrency-Safe Requirement Pause/Resume

### Overview
Made requirement lifecycle pause/resume transitions concurrency-safe by implementing optimistic concurrency control. Stale operations now fail gracefully with a `CONFLICT` error instead of silently overwriting state.

### Key Improvements
- **Pause Operations**: Now conditional on `pausedAt` being `null`. Pause succeeds only when the requirement is currently unpaused.
- **Resume Operations**: Now conditional on `pausedAt` matching the timestamp read by the service. Resume succeeds only when the requirement is currently paused with the expected timestamp.
- **Conflict Detection**: Stale or concurrent lifecycle attempts now return a tRPC `CONFLICT` error with the message "Requirement state has changed."
- **Audit Trail**: Pause/resume audit events are recorded only after successful transitions, preventing spurious events for failed operations.

### Implementation Details
- Added `RequirementLifecycleUpdateOptions` type with optional `expectedPausedAt` field for concurrency control
- Updated `updateLifecycle` method across repository implementations (interface, Drizzle, and test utilities) to support conditional writes based on `expectedPausedAt`
- Enhanced tRPC error mapping to recognize "Requirement state has changed" and route it to `CONFLICT` status

### Testing
- New unit tests in `requirement-lifecycle.test.ts` verify that stale pause/resume attempts are rejected and no audit events are recorded
- New integration test in `requirements-router.test.ts` validates end-to-end behavior with concurrent state mutations
- Includes `MutatingRequirementRepository` test helper for simulating concurrent modifications

### Documentation
- Added concurrency contract specification to `docs/architecture.md` detailing the conditional-write pattern
- Updated `docs/domain-model.md` with client guidance: conflicted operations should refetch the requirement before retrying

### Requirements
- Run `pnpm verify` to validate all changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->