### PR TITLE
[codex] Add document upload foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,5 +11,7 @@ BETTER_AUTH_URL=http://localhost:3000
 # replaced with an app runtime role before additional account-owned tables land.
 DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:54332/postgres
 
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331
+SUPABASE_SERVICE_ROLE_KEY=replace-with-local-service-role-key-from-supabase-status
 SUPABASE_STUDIO_URL=http://127.0.0.1:54333
 SUPABASE_INBUCKET_URL=http://127.0.0.1:54334

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,8 +87,9 @@ Document upload behavior is owned by `src/modules/documents/`. The module
 validates accepted PDF/image types and the application upload-size limit,
 requests private upload/read URLs through the file-storage provider boundary,
 persists account-owned hand-receipt-scoped metadata only after the browser file
-upload succeeds, and emits `document.uploaded` activity without storing file
-contents or sensitive document snapshots in audit metadata.
+upload succeeds and the server verifies the private storage object exists, and
+emits `document.uploaded` activity without storing file contents or sensitive
+document snapshots in audit metadata.
 
 ## App Shell
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,13 @@ service. Future lifecycle transitions with similar read-then-write races should
 use the same conditional-write shape so stale operations fail before
 audit/activity history is recorded.
 
+Document upload behavior is owned by `src/modules/documents/`. The module
+validates accepted PDF/image types and the application upload-size limit,
+requests private upload/read URLs through the file-storage provider boundary,
+persists account-owned hand-receipt-scoped metadata only after the browser file
+upload succeeds, and emits `document.uploaded` activity without storing file
+contents or sensitive document snapshots in audit metadata.
+
 ## App Shell
 
 Authenticated product routes live under the literal `/app` URL path. The

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -201,11 +201,20 @@ MVP document metadata:
 
 - filename
 - MIME type
-- size
+- size in bytes
 - storage path
 - uploaded timestamp
+- hand receipt
 
-Documents are preserved by default. Closing a 2062 or archiving an item/hand receipt does not delete files.
+The storage path is app-generated as `{account_id}/{document_id}` so filenames
+remain display metadata and cannot collide inside the private documents bucket.
+Creating a document is a two-step workflow: the app first creates a private
+signed upload URL, then persists metadata and emits `document.uploaded` only
+after the browser file upload succeeds. The audit event uses lightweight
+metadata only and must not store document contents.
+
+Documents are preserved by default. Closing a 2062 or archiving an item/hand
+receipt does not delete files.
 
 ## 2062 Assignments
 

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -210,8 +210,9 @@ The storage path is app-generated as `{account_id}/{document_id}` so filenames
 remain display metadata and cannot collide inside the private documents bucket.
 Creating a document is a two-step workflow: the app first creates a private
 signed upload URL, then persists metadata and emits `document.uploaded` only
-after the browser file upload succeeds. The audit event uses lightweight
-metadata only and must not store document contents.
+after the browser file upload succeeds and the server verifies the storage
+object exists at the expected path. The audit event uses lightweight metadata
+only and must not store document contents.
 
 Documents are preserved by default. Closing a 2062 or archiving an item/hand
 receipt does not delete files.

--- a/docs/prd/field-ledger-phase-5-documents-2062-prd.md
+++ b/docs/prd/field-ledger-phase-5-documents-2062-prd.md
@@ -1,0 +1,349 @@
+# PRD: Field Ledger Phase 5 - Documents and 2062 Assignments
+
+## Problem Statement
+
+Field Ledger now has the foundation for authenticated use, account access,
+audit/activity, hand receipts, property items, global search, contacts,
+locations, manual signed-to state, item requirements, and dashboard due-work
+visibility. The next part is the formal accountability layer users need when
+property is signed to another person with a DA Form 2062.
+
+Without this phase, the app can record that an item is manually signed to a
+contact, but it cannot preserve the document that proves formal coverage. Users
+would still need to manage scanned 2062s outside the app, remember which
+document applies to which items, and manually reconcile returned property.
+That weakens the core Field Ledger promise: quickly answering what property is
+held, where it is, who it is signed to, and which 2062s are active.
+
+This phase also needs to protect the product boundary. Field Ledger helps an
+individual owner organize private accountability records. It is not an
+official Army system of record, not a property book system, not a document
+management system for unit files, and not a place for classified information,
+PHI, or sensitive operational details. Uploaded 2062s are private supporting
+records for the account owner's workflow, and users remain responsible for
+official records and regulations.
+
+The implementation must keep formal 2062 behavior distinct from manual
+signed-to state. Manual signed-to state is useful but informal. Active 2062s
+must mean formal 2062 assignments only. Documents must be preserved by default,
+assignment history must survive close/remove actions, and item movement/archive
+rules must not accidentally break the meaning of an active 2062.
+
+## Solution
+
+Phase 5 will add private document upload, document metadata, a file storage
+boundary, formal 2062 assignment creation, Active 2062s review, close/remove
+workflows, and enforcement of active 2062 constraints across item workflows.
+
+Users will be able to upload accepted PDF/image documents for 2062 workflows.
+Document records will be account-owned, stored privately through the app-owned
+file storage boundary, and preserved by default. Closing a 2062, removing an
+item link, archiving an item, or archiving a hand receipt must not delete the
+uploaded file. Uploads will emit audit/activity events and will be blocked for
+paused/read-only accounts.
+
+Users will be able to create a one-item 2062 assignment from item detail. The
+item will be preselected, contact selection will be required, and a document
+upload will be required. If the item already has manual signed-to state, the
+flow will default the contact to that person and convert the item to formal
+2062 coverage when the assignment is created.
+
+Users will also be able to create a multi-item 2062 assignment from a hand
+receipt. The assignment will belong to one hand receipt, one contact, one
+primary document, and one or more linked items from that same hand receipt. The
+flow will prevent selecting items from other hand receipts. Each linked item
+will show signed-to state from active 2062 coverage after creation.
+
+Users will be able to review formal Active 2062s in a dedicated list. The list
+will exclude manual signed-to records and show enough context to answer who
+has property, how many items are covered, which hand receipt the assignment
+belongs to, and how to open the assignment context. Mobile access should be
+discoverable from the More/dashboard context without becoming a primary bottom
+navigation item. Tablet and desktop access should fit the sidebar or secondary
+navigation model.
+
+Users will be able to close a whole 2062 assignment or remove one returned
+item from a multi-item 2062. Closing a 2062 clears current signed-to state for
+all active linked items. Removing one item link clears current signed-to state
+for only that item and leaves the assignment active if other item links remain.
+Return/close dates default to today, past dates are allowed, future dates must
+be handled deliberately, and all history and documents are preserved.
+
+Finally, item workflows will enforce active 2062 meaning. An item with active
+2062 coverage cannot move to another hand receipt until its active 2062 item
+link is closed. Archiving an item with active 2062 coverage is allowed only as
+a deliberate accountability action that warns the user and closes the item
+link. If archiving closes the last active item link on an assignment, the user
+should be prompted to close the assignment. All meaningful state changes emit
+audit/activity events.
+
+## User Stories
+
+1. As an individual Army property holder, I want uploaded 2062 scans stored with my property records, so that I do not need a separate file pile to understand current accountability.
+2. As a user, I want 2062 files stored privately, so that scans are not publicly accessible.
+3. As a user, I want document metadata saved with my account, so that the app can link files to accountability workflows.
+4. As a user, I want accepted document types to include PDF and common images, so that I can upload scanned or photographed 2062s.
+5. As a user, I want upload failures to be clear, so that I know whether the document was saved.
+6. As a user, I want uploaded document names and basic metadata visible where useful, so that I can recognize the right file later.
+7. As a user, I want document uploads to emit activity, so that document history is preserved.
+8. As a paused/read-only user, I want to view existing documents, so that I do not lose access to accountability records.
+9. As a paused/read-only user, I want document upload blocked consistently, so that read-only account behavior is understandable.
+10. As a user, I want closing a 2062 not to delete its document, so that evidence remains available after return.
+11. As a user, I want archiving an item not to delete linked documents, so that history stays intact.
+12. As a user, I want archiving a hand receipt not to delete linked documents, so that old accountability records remain reviewable.
+13. As a user, I want a focused upload 2062 flow from item detail, so that one-off assignments are quick.
+14. As a user, I want the item upload flow to preselect the current item, so that I do not accidentally assign the wrong property.
+15. As a user, I want the item upload flow to require a contact, so that every formal assignment has a person.
+16. As a user, I want the item upload flow to let me create a contact inline, so that I can keep moving when the person is not already saved.
+17. As a user, I want the item upload flow to require a document, so that formal coverage has attached evidence.
+18. As a user, I want an item with manual signed-to state to default the 2062 contact to the same person, so that conversion is fast and accurate.
+19. As a user, I want uploading a 2062 for a manually signed-to item to convert it to formal 2062 coverage, so that the item no longer shows as informal.
+20. As a user, I want manual signed-to state cleared or replaced when formal coverage is created, so that current signed-to state is not duplicated.
+21. As a user, I want creating a one-item 2062 to emit activity, so that assignment history is preserved.
+22. As a user, I want a focused upload 2062 flow from hand receipt detail, so that multi-item 2062s can be created from the bucket they belong to.
+23. As a user, I want a 2062 assignment to belong to one hand receipt, so that the document's scope stays understandable.
+24. As a user, I want the hand receipt upload flow to require a contact, so that every formal assignment has a person.
+25. As a user, I want the hand receipt upload flow to require a document, so that formal coverage has attached evidence.
+26. As a user, I want to select one or more items from the current hand receipt, so that one 2062 can cover multiple items.
+27. As a user, I want the flow to block creating an empty 2062, so that every assignment covers actual property.
+28. As a user, I want items from other hand receipts excluded from selection, so that I cannot mix buckets inside one 2062.
+29. As a user, I want search/filter behavior inside the multi-item selector, so that large hand receipts remain workable on mobile.
+30. As a user, I want selected items summarized before creation, so that I can catch mistakes before saving the assignment.
+31. As a user, I want creating a multi-item 2062 to emit assignment and item-link activity, so that history explains what changed.
+32. As a user, I want each item to have at most one active 2062 link, so that current accountability is unambiguous.
+33. As a user, I want an item to preserve many historical closed 2062 links, so that prior assignments remain visible.
+34. As a user, I want the app to block adding an item to a new active 2062 when it already has active 2062 coverage, so that I do not create conflicting assignments.
+35. As a user, I want active 2062 coverage to update linked items' signed-to state, so that item surfaces show the current assignee.
+36. As a user, I want manual signed-to items and formal 2062 items visually distinguished, so that I know which ones have document coverage.
+37. As a user, I want Active 2062s to include only formal 2062 assignments, so that the term stays accurate.
+38. As a user, I want manual signed-to records excluded from Active 2062s, so that informal assignments do not appear as documents.
+39. As a user, I want each Active 2062 row to show contact, item count, hand receipt, date/status, and an open action, so that I can quickly understand the assignment.
+40. As a mobile user, I want Active 2062s discoverable without adding another bottom-nav item, so that primary navigation stays focused.
+41. As a tablet or desktop user, I want Active 2062s available from the sidebar or secondary navigation, so that formal accountability is easy to review.
+42. As a user, I want an empty Active 2062s state, so that I know whether there are no formal documents currently out.
+43. As a user, I want to open an active 2062 context from the list, so that I can review covered items and close or remove links.
+44. As a user, I want to close a whole 2062 assignment, so that returned property no longer appears signed out.
+45. As a user, I want close date to default to today, so that current returns are fast to record.
+46. As a user, I want to enter a past close date, so that I can record returns after the fact.
+47. As a user, I want future close dates blocked or clearly warned, so that assignment history does not pretend property already returned.
+48. As a user, I want closing a 2062 to clear current signed-to state for all active linked items, so that returned items stop appearing assigned out.
+49. As a user, I want closing a 2062 to preserve the document and item history, so that accountability evidence remains reviewable.
+50. As a user, I want closing a 2062 to emit assignment and item activity, so that history explains the return.
+51. As a user, I want to remove one item from a multi-item 2062, so that one returned item can be handled without closing the whole assignment.
+52. As a user, I want removing one item link to clear signed-to state only for that item, so that other covered items stay assigned out.
+53. As a user, I want a multi-item assignment to stay active when other item links remain, so that partial returns do not close the whole document.
+54. As a user, I want removing the last active item link to lead toward closing the assignment, so that empty active assignments do not linger.
+55. As a user, I want item detail to show current 2062 coverage, so that I can understand formal assignment state from the property record.
+56. As a user, I want item detail to show historical 2062 links, so that I can review prior assignment history.
+57. As a user, I want hand receipt detail to show active 2062 context where useful, so that the bucket's formal coverage is understandable.
+58. As a user, I want an item with active 2062 coverage blocked from moving to another hand receipt, so that the document's hand receipt scope stays true.
+59. As a user, I want the move block to explain that the active 2062 link must be closed first, so that I know how to proceed.
+60. As a user, I want archiving an item with active 2062 coverage to warn me, so that I understand the accountability impact.
+61. As a user, I want archiving an item with active 2062 coverage to close that item link, so that archived property does not remain actively assigned out.
+62. As a user, I want archiving one item from a multi-item 2062 to leave other item links active, so that unrelated property stays covered.
+63. As a user, I want archiving the last active item on a 2062 to prompt me to close the assignment, so that empty active coverage is not confusing.
+64. As a user, I want all 2062 state changes to emit readable activity labels, so that I can understand what changed without technical event names.
+65. As a developer, I want document behavior owned by a documents module, so that file metadata and storage rules do not drift into route components.
+66. As a developer, I want file storage behind an app-owned provider boundary, so that Supabase Storage details do not leak into domain or UI code.
+67. As a developer, I want 2062 behavior owned by an assignments-2062 module, so that assignment rules stay testable and reusable.
+68. As a developer, I want assignment creation to run through application services, so that document, contact, item-link, capability, and audit behavior stay consistent.
+69. As a developer, I want close/remove behavior to run through application services, so that item signed-to state and audit events stay consistent.
+70. As a developer, I want item move/archive workflows to call assignment-domain checks, so that active 2062 constraints are enforced outside the UI.
+71. As a developer, I want document and assignment records account-owned and protected by RLS, so that one account cannot read or mutate another account's data.
+72. As a developer, I want vertical slices to land schema, services, typed API, UI, tests, and docs together, so that documents and 2062s do not become disconnected screens.
+73. As a future OCR user, I want documents attached through a clean document boundary, so that later extraction can build on existing records without rewriting assignment workflows.
+74. As a future import/export user, I want 2062 data exposed through typed query boundaries, so that export support can include document and assignment context later.
+
+## Implementation Decisions
+
+- Build this phase on the existing authenticated app shell, account boundary,
+  capability layer, audit foundation, hand receipt module, item module,
+  contacts module, tRPC setup, Drizzle schema, local Supabase foundation,
+  requirement/dashboard work, and private ownership model.
+- Introduce or complete a documents module as a domain-first module with
+  document metadata behavior, persistence, file storage port usage, module UI
+  where useful, and tests.
+- Introduce a file storage provider boundary for private uploads. Supabase
+  Storage is the expected adapter, but domain and UI code should call app-owned
+  services/ports.
+- Model documents as account-owned records.
+- Store document metadata including filename, MIME type, size, storage path,
+  and uploaded timestamp.
+- Accept PDF and common image uploads for MVP 2062 workflows.
+- Keep documents private by default.
+- Preserve uploaded documents by default.
+- Do not delete documents as part of 2062 close, item-link removal, item
+  archive, or hand receipt archive behavior.
+- Block document upload for paused/read-only accounts while allowing read
+  access to existing document metadata and files.
+- Emit audit/activity events for document upload.
+- Introduce or complete an assignments-2062 module as a domain-first module
+  with assignment rules, item-link lifecycle behavior, persistence,
+  application services, module UI where useful, and tests.
+- Model a 2062 assignment as account-owned and belonging to exactly one hand
+  receipt, one contact, one primary document, and one or more linked items.
+- Require contact, document, hand receipt, and at least one item to create a
+  2062 assignment.
+- Require all linked items to belong to the assignment's hand receipt.
+- Allow one item to have at most one active 2062 link.
+- Preserve many historical closed 2062 links per item.
+- Treat manual signed-to state and formal 2062 coverage as distinct states.
+- Convert manual signed-to state to formal 2062 coverage when a 2062 is
+  uploaded for that item.
+- Default the contact in single-item upload when the item already has manual
+  signed-to state.
+- Clear or replace manual signed-to state when formal 2062 coverage is created.
+- Build single-item upload 2062 behavior from item detail.
+- Build multi-item upload 2062 behavior from hand receipt detail.
+- Keep item selection for multi-item 2062s scoped to the current hand receipt.
+- Update linked item signed-to surfaces from active 2062 coverage.
+- Build Active 2062s as a simple MVP list for formal 2062 assignments only.
+- Exclude manual signed-to records from Active 2062s.
+- Show contact, item count, hand receipt context, status/date, and an open
+  action in Active 2062 rows or cards.
+- Make Active 2062s discoverable on mobile without adding it to primary bottom
+  navigation.
+- Make Active 2062s accessible from tablet/desktop sidebar or secondary
+  navigation.
+- Support closing all active item links for a 2062 assignment.
+- Support closing a single item link from a multi-item 2062.
+- Clearing a whole 2062 clears current signed-to state for all active linked
+  items.
+- Removing one item link clears current signed-to state for only that item.
+- Keep a multi-item assignment active when at least one active item link
+  remains.
+- Prompt or force assignment close when the last active item link would be
+  removed, so empty active assignments do not linger.
+- Default close/remove return date to today.
+- Allow past close/remove dates.
+- Decide during issue slicing whether future close/remove dates are blocked
+  outright or allowed only behind an explicit warning; in either case, the UI
+  and domain service must handle the rule consistently.
+- Emit audit/activity events for assignment creation, item-link creation,
+  whole-assignment close, single-item removal, manual-to-formal conversion, and
+  assignment-related item state changes.
+- Block moving an item with an active 2062 link to another hand receipt until
+  the active link is closed.
+- Allow archiving an item with active 2062 coverage only as a deliberate action
+  that warns the user and closes that item link.
+- If archiving closes the final active item link on a 2062 assignment, prompt
+  the user to close the assignment.
+- Keep routes thin: routes compose module UI and call typed procedures; document
+  storage rules and 2062 assignment rules live in module application services.
+- Protect document, 2062 assignment, and 2062 item-link tables with RLS.
+- Use the application-set account/session context for RLS, consistent with the
+  existing account-owned table direction.
+- Keep audit metadata useful but not excessive. Do not store classified, PHI,
+  sensitive operational details, or large document snapshots in audit metadata.
+- Leave OCR, automatic 2062 extraction, QR codes, item photos, reports,
+  import/export, offline read cache, email reminders, and push reminders for
+  future phases.
+- Update domain, architecture, testing, and product docs if implementation
+  changes terminology, route responsibility, audit expectations, document
+  lifecycle behavior, or 2062 assignment lifecycle behavior.
+
+## Testing Decisions
+
+- Use TDD where behavior is clear, especially accepted upload types,
+  capability checks, 2062 assignment validation, active-link uniqueness,
+  manual-to-formal conversion, close/remove behavior, item move/archive
+  constraints, and audit emission.
+- Good tests should prove externally visible behavior and domain rules, not
+  private implementation details.
+- Unit tests should cover document upload validation, document preservation
+  decisions, assignment creation validation, same-hand-receipt item selection,
+  empty assignment blocking, active-link uniqueness, manual-to-formal
+  conversion, close/remove date validation, whole-assignment close, single-item
+  removal, and signed-to state updates.
+- Unit tests should cover item move/archive decisions when active 2062 coverage
+  exists.
+- Unit tests should cover Active 2062 filtering so manual signed-to records
+  never appear in the formal list.
+- Integration tests should cover document metadata creation through the module
+  service or typed API boundary.
+- Integration tests should cover private file storage through the app-owned
+  storage port with provider details isolated behind the boundary.
+- Integration tests should cover single-item 2062 creation from item detail
+  behavior, including preselected item and manual-to-formal conversion.
+- Integration tests should cover multi-item 2062 creation from hand receipt
+  behavior, including same-hand-receipt enforcement.
+- Integration tests should cover closing a whole 2062 and clearing signed-to
+  state for all linked items.
+- Integration tests should cover removing one item from a multi-item 2062 while
+  preserving other active item links.
+- Integration tests should cover paused/read-only accounts being able to read
+  existing documents and assignments but unable to upload documents or mutate
+  assignments.
+- Integration tests should prove 2062 workflows emit audit/activity events.
+- Integration tests should prove item movement is blocked while active 2062
+  coverage exists.
+- Integration tests should prove item archive with active 2062 coverage performs
+  the deliberate close-link behavior and emits activity.
+- RLS tests are required for document, 2062 assignment, and 2062 item-link
+  tables because they are account-owned.
+- RLS tests should prove one account cannot read or write another account's
+  documents, assignment records, or item links.
+- RLS tests should prove assignment item links cannot cross account ownership or
+  hand receipt ownership boundaries.
+- Browser tests should stay focused on critical flows: single-item upload 2062,
+  multi-item upload 2062, Active 2062s list, whole-assignment close,
+  single-item removal, read-only blocking, and basic mobile and desktop
+  rendering.
+- Browser tests should include the mobile route discovery path for Active 2062s
+  and the tablet/desktop navigation path.
+- Browser tests should avoid trying to prove every domain edge case when unit
+  and integration tests cover those rules more clearly.
+- Full verification for sliced work should include formatting, linting,
+  typechecking, unit tests, integration tests, RLS tests, focused browser tests,
+  build, and local Supabase checks required by the slice.
+
+## Out of Scope
+
+- Official Army system-of-record behavior.
+- Property book office workflows.
+- Commander cyclic inventory workflows.
+- Organization/team collaboration.
+- Public document sharing.
+- General-purpose document management outside accountability workflows.
+- Hard deletion of uploaded documents as a normal workflow.
+- OCR or automatic extraction from 2062 scans.
+- Automatic generation of filled 2062 forms.
+- Digital signatures.
+- Document versioning.
+- Multiple primary documents per 2062 assignment.
+- One 2062 assignment spanning multiple hand receipts.
+- Active manual signed-to records appearing in Active 2062s.
+- Moving actively covered items to another hand receipt without closing the
+  active 2062 item link.
+- Offline document upload or offline 2062 mutation.
+- CSV/XLSX import/export implementation.
+- Reports.
+- QR codes.
+- Item photos.
+- Email reminders.
+- Push reminders.
+- Real Stripe checkout, webhooks, invoices, customer portal, or subscription
+  automation.
+- Storage of classified information, PHI, or sensitive operational details.
+
+## Further Notes
+
+This PRD is intended to be sliced into vertical implementation issues before
+work begins. The slices should keep documents and 2062 assignments tied to real
+item detail, hand receipt detail, and Active 2062 workflows instead of building
+a detached file browser or a generic assignment subsystem.
+
+The main guardrail is that formal 2062 assignment behavior belongs in the
+assignments-2062 module, and private file behavior belongs behind the documents
+module and file storage boundary. Routes and UI should compose those behaviors;
+they should not decide assignment validity, active-link uniqueness, file
+privacy, or signed-to state transitions.
+
+The second guardrail is product language. Active 2062s means formal 2062
+assignments only. Manual signed-to state remains visible in signed-out item
+surfaces but must stay clearly labeled as informal/no-document coverage.
+
+The third guardrail is preservation. Closing, removing, archiving, and future
+historical workflows should preserve accountability evidence by default.
+Destroying documents or assignment history should not be part of normal MVP
+behavior.

--- a/drizzle/0021_green_maestro.sql
+++ b/drizzle/0021_green_maestro.sql
@@ -10,6 +10,7 @@ CREATE TABLE "documents" (
 	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
+ALTER TABLE "documents" ADD CONSTRAINT "documents_storage_path_matches_account_and_id" CHECK ("storage_path" = "account_id"::text || '/' || "id"::text);--> statement-breakpoint
 ALTER TABLE "documents" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
 ALTER TABLE "documents" ADD CONSTRAINT "documents_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "documents_account_id_created_at_idx" ON "documents" USING btree ("account_id","created_at" DESC NULLS LAST);--> statement-breakpoint

--- a/drizzle/0021_green_maestro.sql
+++ b/drizzle/0021_green_maestro.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "documents" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"account_id" uuid NOT NULL,
+	"filename" text NOT NULL,
+	"mime_type" text NOT NULL,
+	"size_bytes" integer NOT NULL,
+	"storage_path" text NOT NULL,
+	"uploaded_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "documents" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "documents" ADD CONSTRAINT "documents_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "documents_account_id_created_at_idx" ON "documents" USING btree ("account_id","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE UNIQUE INDEX "documents_account_id_storage_path_unique_idx" ON "documents" USING btree ("account_id","storage_path");--> statement-breakpoint
+GRANT SELECT, INSERT ON TABLE "documents" TO authenticated;--> statement-breakpoint
+CREATE POLICY "documents_owner_select" ON "documents" FOR SELECT TO authenticated USING ("account_id" = (SELECT "id" FROM "accounts" WHERE "auth_user_id" = "app"."current_auth_subject"()));--> statement-breakpoint
+CREATE POLICY "documents_owner_insert" ON "documents" FOR INSERT TO authenticated WITH CHECK ("account_id" = (SELECT "id" FROM "accounts" WHERE "auth_user_id" = "app"."current_auth_subject"()));

--- a/drizzle/0022_slippery_polaris.sql
+++ b/drizzle/0022_slippery_polaris.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "documents" ADD COLUMN "hand_receipt_id" uuid;--> statement-breakpoint
+DELETE FROM "documents" WHERE "hand_receipt_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "documents" ALTER COLUMN "hand_receipt_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "documents" ADD CONSTRAINT "documents_hand_receipt_id_hand_receipts_id_fk" FOREIGN KEY ("hand_receipt_id") REFERENCES "public"."hand_receipts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "documents_account_id_hand_receipt_id_idx" ON "documents" USING btree ("account_id","hand_receipt_id");

--- a/drizzle/0022_slippery_polaris.sql
+++ b/drizzle/0022_slippery_polaris.sql
@@ -1,5 +1,12 @@
 ALTER TABLE "documents" ADD COLUMN "hand_receipt_id" uuid;--> statement-breakpoint
-DELETE FROM "documents" WHERE "hand_receipt_id" IS NULL;--> statement-breakpoint
+ALTER TABLE "hand_receipts" ADD CONSTRAINT "hand_receipts_id_account_id_key" UNIQUE("id","account_id");--> statement-breakpoint
+DO $$
+BEGIN
+	IF EXISTS (SELECT 1 FROM "documents" WHERE "hand_receipt_id" IS NULL) THEN
+		RAISE EXCEPTION 'Backfill required: documents.hand_receipt_id contains NULL rows';
+	END IF;
+END
+$$;--> statement-breakpoint
 ALTER TABLE "documents" ALTER COLUMN "hand_receipt_id" SET NOT NULL;--> statement-breakpoint
-ALTER TABLE "documents" ADD CONSTRAINT "documents_hand_receipt_id_hand_receipts_id_fk" FOREIGN KEY ("hand_receipt_id") REFERENCES "public"."hand_receipts"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "documents" ADD CONSTRAINT "documents_hand_receipt_account_fk" FOREIGN KEY ("hand_receipt_id","account_id") REFERENCES "public"."hand_receipts"("id","account_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 CREATE INDEX "documents_account_id_hand_receipt_id_idx" ON "documents" USING btree ("account_id","hand_receipt_id");

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -771,7 +771,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "documents_storage_path_matches_account_and_id": {
+          "name": "documents_storage_path_matches_account_and_id",
+          "value": "\"documents\".\"storage_path\" = \"documents\".\"account_id\"::text || '/' || \"documents\".\"id\"::text"
+        }
+      },
       "isRLSEnabled": true
     },
     "public.hand_receipts": {

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,1677 @@
+{
+  "id": "311630c8-32a2-4c05-a63d-85b8f2b09365",
+  "prevId": "b89cd006-a028-4432-8113-4543a598239d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_state": {
+          "name": "access_state",
+          "type": "access_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trialing'"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "subscription_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_starts_at": {
+          "name": "trial_starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_item_sequence": {
+          "name": "next_item_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_auth_user_id_unique": {
+          "name": "accounts_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "auth_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "accounts_trial_window_check": {
+          "name": "accounts_trial_window_check",
+          "value": "\"accounts\".\"trial_ends_at\" >= \"accounts\".\"trial_starts_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_account_id_occurred_at_idx": {
+          "name": "audit_events_account_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_account_id_accounts_id_fk": {
+          "name": "audit_events_account_id_accounts_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_account_id_display_name_idx": {
+          "name": "contacts_account_id_display_name_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_account_id_accounts_id_fk": {
+          "name": "contacts_account_id_accounts_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_account_id_created_at_idx": {
+          "name": "documents_account_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_account_id_storage_path_unique_idx": {
+          "name": "documents_account_id_storage_path_unique_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_account_id_accounts_id_fk": {
+          "name": "documents_account_id_accounts_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.hand_receipts": {
+      "name": "hand_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_receipt_number": {
+          "name": "hand_receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "holder_name": {
+          "name": "holder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_name": {
+          "name": "unit_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uic": {
+          "name": "uic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "hand_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hand_receipts_account_id_status_created_at_idx": {
+          "name": "hand_receipts_account_id_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hand_receipts_account_id_accounts_id_fk": {
+          "name": "hand_receipts_account_id_accounts_id_fk",
+          "tableFrom": "hand_receipts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hand_receipt_id": {
+          "name": "hand_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nomenclature": {
+          "name": "nomenclature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ecn": {
+          "name": "ecn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_id": {
+          "name": "generated_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "signed_to_contact_id": {
+          "name": "signed_to_contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "items_account_id_status_created_at_idx": {
+          "name": "items_account_id_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_hand_receipt_id_status_created_at_idx": {
+          "name": "items_hand_receipt_id_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "hand_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_account_id_ecn_idx": {
+          "name": "items_account_id_ecn_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ecn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_account_id_serial_number_idx": {
+          "name": "items_account_id_serial_number_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_account_id_generated_id_unique_idx": {
+          "name": "items_account_id_generated_id_unique_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_account_id_location_id_idx": {
+          "name": "items_account_id_location_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "items_account_id_accounts_id_fk": {
+          "name": "items_account_id_accounts_id_fk",
+          "tableFrom": "items",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_hand_receipt_id_hand_receipts_id_fk": {
+          "name": "items_hand_receipt_id_hand_receipts_id_fk",
+          "tableFrom": "items",
+          "tableTo": "hand_receipts",
+          "columnsFrom": [
+            "hand_receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_signed_to_contact_id_contacts_id_fk": {
+          "name": "items_signed_to_contact_id_contacts_id_fk",
+          "tableFrom": "items",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "signed_to_contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "items_location_id_locations_id_fk": {
+          "name": "items_location_id_locations_id_fk",
+          "tableFrom": "items",
+          "tableTo": "locations",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "locations_account_id_lower_name_unique_idx": {
+          "name": "locations_account_id_lower_name_unique_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_account_id_accounts_id_fk": {
+          "name": "locations_account_id_accounts_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.requirement_completions": {
+      "name": "requirement_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_on": {
+          "name": "completed_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requirement_completions_requirement_completed_idx": {
+          "name": "requirement_completions_requirement_completed_idx",
+          "columns": [
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_on",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "requirement_completions_account_id_created_at_idx": {
+          "name": "requirement_completions_account_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "requirement_completions_account_id_accounts_id_fk": {
+          "name": "requirement_completions_account_id_accounts_id_fk",
+          "tableFrom": "requirement_completions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requirement_completions_requirement_account_fk": {
+          "name": "requirement_completions_requirement_account_fk",
+          "tableFrom": "requirement_completions",
+          "tableTo": "requirements",
+          "columnsFrom": [
+            "requirement_id",
+            "account_id"
+          ],
+          "columnsTo": [
+            "id",
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.requirements": {
+      "name": "requirements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_type": {
+          "name": "interval_type",
+          "type": "requirement_interval_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_value": {
+          "name": "interval_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "requirement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requirements_account_id_item_id_status_idx": {
+          "name": "requirements_account_id_item_id_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "requirements_account_id_next_due_idx": {
+          "name": "requirements_account_id_next_due_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "requirements_account_id_accounts_id_fk": {
+          "name": "requirements_account_id_accounts_id_fk",
+          "tableFrom": "requirements",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requirements_item_id_items_id_fk": {
+          "name": "requirements_item_id_items_id_fk",
+          "tableFrom": "requirements",
+          "tableTo": "items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "requirements_id_account_id_key": {
+          "name": "requirements_id_account_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "requirements_interval_value_chk": {
+          "name": "requirements_interval_value_chk",
+          "value": "(\n        (\"requirements\".\"interval_type\" in ('custom_days', 'custom_months') and \"requirements\".\"interval_value\" is not null and \"requirements\".\"interval_value\" > 0)\n        or\n        (\"requirements\".\"interval_type\" in ('weekly', 'monthly', 'quarterly', 'semiannual', 'annual') and \"requirements\".\"interval_value\" is null)\n      )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "app_internal.scaffold_migration_checks": {
+      "name": "scaffold_migration_checks",
+      "schema": "app_internal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_state": {
+      "name": "access_state",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "paused_read_only"
+      ]
+    },
+    "public.hand_receipt_status": {
+      "name": "hand_receipt_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "archived"
+      ]
+    },
+    "public.requirement_interval_type": {
+      "name": "requirement_interval_type",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "quarterly",
+        "semiannual",
+        "annual",
+        "custom_days",
+        "custom_months"
+      ]
+    },
+    "public.requirement_status": {
+      "name": "requirement_status",
+      "schema": "public",
+      "values": [
+        "active"
+      ]
+    },
+    "public.subscription_tier": {
+      "name": "subscription_tier",
+      "schema": "public",
+      "values": [
+        "base",
+        "pro"
+      ]
+    }
+  },
+  "schemas": {
+    "app_internal": "app_internal"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -83,7 +83,9 @@
         "accounts_auth_user_id_unique": {
           "name": "accounts_auth_user_id_unique",
           "nullsNotDistinct": false,
-          "columns": ["auth_user_id"]
+          "columns": [
+            "auth_user_id"
+          ]
         }
       },
       "policies": {},
@@ -185,8 +187,12 @@
           "name": "audit_events_account_id_accounts_id_fk",
           "tableFrom": "audit_events",
           "tableTo": "accounts",
-          "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -305,8 +311,12 @@
           "name": "account_user_id_user_id_fk",
           "tableFrom": "account",
           "tableTo": "user",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -395,8 +405,12 @@
           "name": "session_user_id_user_id_fk",
           "tableFrom": "session",
           "tableTo": "user",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -406,7 +420,9 @@
         "session_token_unique": {
           "name": "session_token_unique",
           "nullsNotDistinct": false,
-          "columns": ["token"]
+          "columns": [
+            "token"
+          ]
         }
       },
       "policies": {},
@@ -471,7 +487,9 @@
         "user_email_unique": {
           "name": "user_email_unique",
           "nullsNotDistinct": false,
-          "columns": ["email"]
+          "columns": [
+            "email"
+          ]
         }
       },
       "policies": {},
@@ -612,8 +630,12 @@
           "name": "contacts_account_id_accounts_id_fk",
           "tableFrom": "contacts",
           "tableTo": "accounts",
-          "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -763,17 +785,27 @@
           "name": "documents_account_id_accounts_id_fk",
           "tableFrom": "documents",
           "tableTo": "accounts",
-          "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
-        "documents_hand_receipt_id_hand_receipts_id_fk": {
-          "name": "documents_hand_receipt_id_hand_receipts_id_fk",
+        "documents_hand_receipt_account_fk": {
+          "name": "documents_hand_receipt_account_fk",
           "tableFrom": "documents",
           "tableTo": "hand_receipts",
-          "columnsFrom": ["hand_receipt_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "hand_receipt_id",
+            "account_id"
+          ],
+          "columnsTo": [
+            "id",
+            "account_id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -781,7 +813,12 @@
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
-      "checkConstraints": {},
+      "checkConstraints": {
+        "documents_storage_path_matches_account_and_id": {
+          "name": "documents_storage_path_matches_account_and_id",
+          "value": "\"documents\".\"storage_path\" = \"documents\".\"account_id\"::text || '/' || \"documents\".\"id\"::text"
+        }
+      },
       "isRLSEnabled": true
     },
     "public.hand_receipts": {
@@ -900,14 +937,27 @@
           "name": "hand_receipts_account_id_accounts_id_fk",
           "tableFrom": "hand_receipts",
           "tableTo": "accounts",
-          "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
       },
       "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
+      "uniqueConstraints": {
+        "hand_receipts_id_account_id_key": {
+          "name": "hand_receipts_id_account_id_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "account_id"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": true
@@ -1145,8 +1195,12 @@
           "name": "items_account_id_accounts_id_fk",
           "tableFrom": "items",
           "tableTo": "accounts",
-          "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1154,8 +1208,12 @@
           "name": "items_hand_receipt_id_hand_receipts_id_fk",
           "tableFrom": "items",
           "tableTo": "hand_receipts",
-          "columnsFrom": ["hand_receipt_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "hand_receipt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1163,8 +1221,12 @@
           "name": "items_signed_to_contact_id_contacts_id_fk",
           "tableFrom": "items",
           "tableTo": "contacts",
-          "columnsFrom": ["signed_to_contact_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "signed_to_contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         },
@@ -1172,8 +1234,12 @@
           "name": "items_location_id_locations_id_fk",
           "tableFrom": "items",
           "tableTo": "locations",
-          "columnsFrom": ["location_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "set null",
           "onUpdate": "no action"
         }
@@ -1250,8 +1316,12 @@
           "name": "locations_account_id_accounts_id_fk",
           "tableFrom": "locations",
           "tableTo": "accounts",
-          "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1354,8 +1424,12 @@
           "name": "requirement_completions_account_id_accounts_id_fk",
           "tableFrom": "requirement_completions",
           "tableTo": "accounts",
-          "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1363,8 +1437,14 @@
           "name": "requirement_completions_requirement_account_fk",
           "tableFrom": "requirement_completions",
           "tableTo": "requirements",
-          "columnsFrom": ["requirement_id", "account_id"],
-          "columnsTo": ["id", "account_id"],
+          "columnsFrom": [
+            "requirement_id",
+            "account_id"
+          ],
+          "columnsTo": [
+            "id",
+            "account_id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1513,8 +1593,12 @@
           "name": "requirements_account_id_accounts_id_fk",
           "tableFrom": "requirements",
           "tableTo": "accounts",
-          "columnsFrom": ["account_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -1522,8 +1606,12 @@
           "name": "requirements_item_id_items_id_fk",
           "tableFrom": "requirements",
           "tableTo": "items",
-          "columnsFrom": ["item_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -1533,7 +1621,10 @@
         "requirements_id_account_id_key": {
           "name": "requirements_id_account_id_key",
           "nullsNotDistinct": false,
-          "columns": ["id", "account_id"]
+          "columns": [
+            "id",
+            "account_id"
+          ]
         }
       },
       "policies": {},
@@ -1576,17 +1667,27 @@
     "public.access_state": {
       "name": "access_state",
       "schema": "public",
-      "values": ["trialing", "active", "paused_read_only"]
+      "values": [
+        "trialing",
+        "active",
+        "paused_read_only"
+      ]
     },
     "public.hand_receipt_status": {
       "name": "hand_receipt_status",
       "schema": "public",
-      "values": ["active", "archived"]
+      "values": [
+        "active",
+        "archived"
+      ]
     },
     "public.item_status": {
       "name": "item_status",
       "schema": "public",
-      "values": ["active", "archived"]
+      "values": [
+        "active",
+        "archived"
+      ]
     },
     "public.requirement_interval_type": {
       "name": "requirement_interval_type",
@@ -1604,12 +1705,17 @@
     "public.requirement_status": {
       "name": "requirement_status",
       "schema": "public",
-      "values": ["active"]
+      "values": [
+        "active"
+      ]
     },
     "public.subscription_tier": {
       "name": "subscription_tier",
       "schema": "public",
-      "values": ["base", "pro"]
+      "values": [
+        "base",
+        "pro"
+      ]
     }
   },
   "schemas": {

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1627 @@
+{
+  "id": "1713f371-1f47-4178-9c8a-8f17de6c2a5c",
+  "prevId": "311630c8-32a2-4c05-a63d-85b8f2b09365",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_state": {
+          "name": "access_state",
+          "type": "access_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trialing'"
+        },
+        "subscription_tier": {
+          "name": "subscription_tier",
+          "type": "subscription_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_starts_at": {
+          "name": "trial_starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trial_ends_at": {
+          "name": "trial_ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_item_sequence": {
+          "name": "next_item_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_auth_user_id_unique": {
+          "name": "accounts_auth_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["auth_user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "accounts_trial_window_check": {
+          "name": "accounts_trial_window_check",
+          "value": "\"accounts\".\"trial_ends_at\" >= \"accounts\".\"trial_starts_at\""
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_events_account_id_occurred_at_idx": {
+          "name": "audit_events_account_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_account_id_accounts_id_fk": {
+          "name": "audit_events_account_id_accounts_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_account_id_display_name_idx": {
+          "name": "contacts_account_id_display_name_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "display_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_account_id_accounts_id_fk": {
+          "name": "contacts_account_id_accounts_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hand_receipt_id": {
+          "name": "hand_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_at": {
+          "name": "uploaded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "documents_account_id_created_at_idx": {
+          "name": "documents_account_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_account_id_hand_receipt_id_idx": {
+          "name": "documents_account_id_hand_receipt_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hand_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "documents_account_id_storage_path_unique_idx": {
+          "name": "documents_account_id_storage_path_unique_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "storage_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "documents_account_id_accounts_id_fk": {
+          "name": "documents_account_id_accounts_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_hand_receipt_id_hand_receipts_id_fk": {
+          "name": "documents_hand_receipt_id_hand_receipts_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "hand_receipts",
+          "columnsFrom": ["hand_receipt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.hand_receipts": {
+      "name": "hand_receipts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hand_receipt_number": {
+          "name": "hand_receipt_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "holder_name": {
+          "name": "holder_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unit_name": {
+          "name": "unit_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uic": {
+          "name": "uic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "hand_receipt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hand_receipts_account_id_status_created_at_idx": {
+          "name": "hand_receipts_account_id_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hand_receipts_account_id_accounts_id_fk": {
+          "name": "hand_receipts_account_id_accounts_id_fk",
+          "tableFrom": "hand_receipts",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.items": {
+      "name": "items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hand_receipt_id": {
+          "name": "hand_receipt_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nomenclature": {
+          "name": "nomenclature",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ecn": {
+          "name": "ecn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serial_number": {
+          "name": "serial_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_id": {
+          "name": "generated_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "signed_to_contact_id": {
+          "name": "signed_to_contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "items_account_id_status_created_at_idx": {
+          "name": "items_account_id_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_hand_receipt_id_status_created_at_idx": {
+          "name": "items_hand_receipt_id_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "hand_receipt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_account_id_ecn_idx": {
+          "name": "items_account_id_ecn_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ecn",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_account_id_serial_number_idx": {
+          "name": "items_account_id_serial_number_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "serial_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_account_id_generated_id_unique_idx": {
+          "name": "items_account_id_generated_id_unique_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "items_account_id_location_id_idx": {
+          "name": "items_account_id_location_id_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "location_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "items_account_id_accounts_id_fk": {
+          "name": "items_account_id_accounts_id_fk",
+          "tableFrom": "items",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_hand_receipt_id_hand_receipts_id_fk": {
+          "name": "items_hand_receipt_id_hand_receipts_id_fk",
+          "tableFrom": "items",
+          "tableTo": "hand_receipts",
+          "columnsFrom": ["hand_receipt_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "items_signed_to_contact_id_contacts_id_fk": {
+          "name": "items_signed_to_contact_id_contacts_id_fk",
+          "tableFrom": "items",
+          "tableTo": "contacts",
+          "columnsFrom": ["signed_to_contact_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "items_location_id_locations_id_fk": {
+          "name": "items_location_id_locations_id_fk",
+          "tableFrom": "items",
+          "tableTo": "locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.locations": {
+      "name": "locations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "locations_account_id_lower_name_unique_idx": {
+          "name": "locations_account_id_lower_name_unique_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "locations_account_id_accounts_id_fk": {
+          "name": "locations_account_id_accounts_id_fk",
+          "tableFrom": "locations",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.requirement_completions": {
+      "name": "requirement_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_id": {
+          "name": "requirement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_on": {
+          "name": "completed_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requirement_completions_requirement_completed_idx": {
+          "name": "requirement_completions_requirement_completed_idx",
+          "columns": [
+            {
+              "expression": "requirement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_on",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "requirement_completions_account_id_created_at_idx": {
+          "name": "requirement_completions_account_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "requirement_completions_account_id_accounts_id_fk": {
+          "name": "requirement_completions_account_id_accounts_id_fk",
+          "tableFrom": "requirement_completions",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requirement_completions_requirement_account_fk": {
+          "name": "requirement_completions_requirement_account_fk",
+          "tableFrom": "requirement_completions",
+          "tableTo": "requirements",
+          "columnsFrom": ["requirement_id", "account_id"],
+          "columnsTo": ["id", "account_id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": true
+    },
+    "public.requirements": {
+      "name": "requirements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interval_type": {
+          "name": "interval_type",
+          "type": "requirement_interval_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval_value": {
+          "name": "interval_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_due_date": {
+          "name": "next_due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "requirement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "requirements_account_id_item_id_status_idx": {
+          "name": "requirements_account_id_item_id_status_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "requirements_account_id_next_due_idx": {
+          "name": "requirements_account_id_next_due_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "requirements_account_id_accounts_id_fk": {
+          "name": "requirements_account_id_accounts_id_fk",
+          "tableFrom": "requirements",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "requirements_item_id_items_id_fk": {
+          "name": "requirements_item_id_items_id_fk",
+          "tableFrom": "requirements",
+          "tableTo": "items",
+          "columnsFrom": ["item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "requirements_id_account_id_key": {
+          "name": "requirements_id_account_id_key",
+          "nullsNotDistinct": false,
+          "columns": ["id", "account_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "requirements_interval_value_chk": {
+          "name": "requirements_interval_value_chk",
+          "value": "(\n        (\"requirements\".\"interval_type\" in ('custom_days', 'custom_months') and \"requirements\".\"interval_value\" is not null and \"requirements\".\"interval_value\" > 0)\n        or\n        (\"requirements\".\"interval_type\" in ('weekly', 'monthly', 'quarterly', 'semiannual', 'annual') and \"requirements\".\"interval_value\" is null)\n      )"
+        }
+      },
+      "isRLSEnabled": true
+    },
+    "app_internal.scaffold_migration_checks": {
+      "name": "scaffold_migration_checks",
+      "schema": "app_internal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.access_state": {
+      "name": "access_state",
+      "schema": "public",
+      "values": ["trialing", "active", "paused_read_only"]
+    },
+    "public.hand_receipt_status": {
+      "name": "hand_receipt_status",
+      "schema": "public",
+      "values": ["active", "archived"]
+    },
+    "public.item_status": {
+      "name": "item_status",
+      "schema": "public",
+      "values": ["active", "archived"]
+    },
+    "public.requirement_interval_type": {
+      "name": "requirement_interval_type",
+      "schema": "public",
+      "values": [
+        "weekly",
+        "monthly",
+        "quarterly",
+        "semiannual",
+        "annual",
+        "custom_days",
+        "custom_months"
+      ]
+    },
+    "public.requirement_status": {
+      "name": "requirement_status",
+      "schema": "public",
+      "values": ["active"]
+    },
+    "public.subscription_tier": {
+      "name": "subscription_tier",
+      "schema": "public",
+      "values": ["base", "pro"]
+    }
+  },
+  "schemas": {
+    "app_internal": "app_internal"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,20 @@
       "when": 1777693332050,
       "tag": "0020_pale_timeslip",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1777750636093,
+      "tag": "0021_green_maestro",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1777752735314,
+      "tag": "0022_slippery_polaris",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@better-auth/drizzle-adapter": "^1.6.9",
+    "@supabase/supabase-js": "^2.105.1",
     "@tanstack/react-query": "^5.100.6",
     "@trpc/client": "^11.17.0",
     "@trpc/react-query": "^11.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@better-auth/drizzle-adapter':
         specifier: ^1.6.9
         version: 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.16)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(kysely@0.28.16)(postgres@3.4.9))
+      '@supabase/supabase-js':
+        specifier: ^2.105.1
+        version: 2.105.1
       '@tanstack/react-query':
         specifier: ^5.100.6
         version: 5.100.6(react@19.2.4)
@@ -2261,6 +2264,33 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.105.1':
+    resolution: {integrity: sha512-zc4s8Xg4truwE1Q4Q8M8oUVDARMd05pKh73NyQsMbYU1HDdDN2iiKzena/yu+yJze3WrD4c092FdckPiK1rLQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.105.1':
+    resolution: {integrity: sha512-dTk1e7oE51VGc1lS2S0J0NLo0Wp4JYChj74ArJKbIWgoWuFwO0wcJYjeyOV3AAEpKst8/LQWUZOUKO1tRXBrpA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.1':
+    resolution: {integrity: sha512-hWGJkDAfWUNY8k0C080u3sGNFd2ncl9erhKgP7hnGkgJWEfT5Pd/SXal4QmWXBECVlZrannMAc9sBaaRyWpiUA==}
+
+  '@supabase/postgrest-js@2.105.1':
+    resolution: {integrity: sha512-6SbtsoWC55xfsm7gbfLqvF+yIwTQEbjt+jFGf4klDpwSnUy17Hv5x0Dq52oqwTQlw6Ta0h1D5gTP0/pApqNojA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.105.1':
+    resolution: {integrity: sha512-3X3cUEl5cJ4lRQHr1hXHx0b98OaL97RRO2vrRZ98FD91JV/MquZHhrGJSv/+IkOnjF6E2e0RUOxE8P3Zi035ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.105.1':
+    resolution: {integrity: sha512-owfdCNH5ikXXDusjzsgU6LavEBqGUoueOnL/9XIucld70/WJ/rbqp89K//c9QPICDNuegsmpoeasydDAiucLKQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.105.1':
+    resolution: {integrity: sha512-4gn6HmsAkCCVU7p8JmgKGhHJ5Btod4ZzSp8qKZf4JHaTxbhaIK86/usHzeLxWv7EJJDhBmILDmJOSOf9iF4CLA==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2426,6 +2456,9 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.59.1':
     resolution: {integrity: sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==}
@@ -3707,6 +3740,10 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -7123,6 +7160,46 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.105.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.105.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.1': {}
+
+  '@supabase/postgrest-js@2.105.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.105.1':
+    dependencies:
+      '@supabase/phoenix': 0.4.1
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.105.1':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.105.1':
+    dependencies:
+      '@supabase/auth-js': 2.105.1
+      '@supabase/functions-js': 2.105.1
+      '@supabase/postgrest-js': 2.105.1
+      '@supabase/realtime-js': 2.105.1
+      '@supabase/storage-js': 2.105.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -7263,6 +7340,10 @@ snapshots:
   '@types/statuses@2.0.6': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.39
 
   '@typescript-eslint/eslint-plugin@8.59.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -8657,6 +8738,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.7.2:
     dependencies:

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -221,6 +221,7 @@ export const handReceipts = pgTable(
       .defaultNow(),
   },
   (table) => [
+    unique("hand_receipts_id_account_id_key").on(table.id, table.accountId),
     index("hand_receipts_account_id_status_created_at_idx").on(
       table.accountId,
       table.status,
@@ -341,9 +342,7 @@ export const documents = pgTable(
     accountId: uuid("account_id")
       .notNull()
       .references(() => accounts.id),
-    handReceiptId: uuid("hand_receipt_id")
-      .notNull()
-      .references(() => handReceipts.id),
+    handReceiptId: uuid("hand_receipt_id").notNull(),
     filename: text("filename").notNull(),
     mimeType: text("mime_type").notNull(),
     sizeBytes: integer("size_bytes").notNull(),
@@ -359,6 +358,11 @@ export const documents = pgTable(
       .defaultNow(),
   },
   (table) => [
+    foreignKey({
+      columns: [table.handReceiptId, table.accountId],
+      foreignColumns: [handReceipts.id, handReceipts.accountId],
+      name: "documents_hand_receipt_account_fk",
+    }),
     index("documents_account_id_created_at_idx").on(
       table.accountId,
       table.createdAt.desc(),
@@ -370,6 +374,10 @@ export const documents = pgTable(
     uniqueIndex("documents_account_id_storage_path_unique_idx").on(
       table.accountId,
       table.storagePath,
+    ),
+    check(
+      "documents_storage_path_matches_account_and_id",
+      sql`${table.storagePath} = ${table.accountId}::text || '/' || ${table.id}::text`,
     ),
   ],
 ).enableRLS();

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -334,6 +334,46 @@ export const items = pgTable(
   ],
 ).enableRLS();
 
+export const documents = pgTable(
+  "documents",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    accountId: uuid("account_id")
+      .notNull()
+      .references(() => accounts.id),
+    handReceiptId: uuid("hand_receipt_id")
+      .notNull()
+      .references(() => handReceipts.id),
+    filename: text("filename").notNull(),
+    mimeType: text("mime_type").notNull(),
+    sizeBytes: integer("size_bytes").notNull(),
+    storagePath: text("storage_path").notNull(),
+    uploadedAt: timestamp("uploaded_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("documents_account_id_created_at_idx").on(
+      table.accountId,
+      table.createdAt.desc(),
+    ),
+    index("documents_account_id_hand_receipt_id_idx").on(
+      table.accountId,
+      table.handReceiptId,
+    ),
+    uniqueIndex("documents_account_id_storage_path_unique_idx").on(
+      table.accountId,
+      table.storagePath,
+    ),
+  ],
+).enableRLS();
+
 export const requirements = pgTable(
   "requirements",
   {

--- a/src/modules/audit/application/format-audit-action-label.ts
+++ b/src/modules/audit/application/format-audit-action-label.ts
@@ -3,6 +3,7 @@ import type { AuditAction, KnownAuditAction } from "./types";
 const auditActionLabels: Record<KnownAuditAction, string> = {
   "account.onboarding_completed": "Onboarding completed",
   "contact.created": "Contact created",
+  "document.uploaded": "Document uploaded",
   "hand_receipt.archived": "Hand receipt archived",
   "hand_receipt.created": "Hand receipt created",
   "hand_receipt.restored": "Hand receipt restored",

--- a/src/modules/audit/application/types.ts
+++ b/src/modules/audit/application/types.ts
@@ -2,6 +2,7 @@ export type KnownAuditAction =
   | "system.initialized"
   | "account.onboarding_completed"
   | "contact.created"
+  | "document.uploaded"
   | "hand_receipt.created"
   | "hand_receipt.updated"
   | "hand_receipt.archived"

--- a/src/modules/billing/application/capabilities.ts
+++ b/src/modules/billing/application/capabilities.ts
@@ -35,6 +35,10 @@ export function canCreateRequirement(capabilities: AccountCapabilities) {
   return !capabilities.isReadOnly;
 }
 
+export function canUploadDocument(capabilities: AccountCapabilities) {
+  return !capabilities.isReadOnly;
+}
+
 export function canEditRequirement(capabilities: AccountCapabilities) {
   return !capabilities.isReadOnly;
 }

--- a/src/modules/billing/index.ts
+++ b/src/modules/billing/index.ts
@@ -5,6 +5,7 @@ export {
   canEditRequirement,
   canMoveItem,
   canRestoreHandReceipt,
+  canUploadDocument,
   getActiveHandReceiptLimit,
   isAccountReadOnly,
 } from "@/modules/billing/application/capabilities";

--- a/src/modules/documents/application/document-repository.ts
+++ b/src/modules/documents/application/document-repository.ts
@@ -1,0 +1,32 @@
+import type { DocumentRecord, NewDocumentRecord } from "./types";
+
+export type ListDocumentsOptions = {
+  handReceiptId?: string;
+  limit?: number;
+};
+
+export type DocumentRepository = {
+  create(record: NewDocumentRecord): Promise<DocumentRecord>;
+  findById(
+    accountId: string,
+    documentId: string,
+  ): Promise<DocumentRecord | null>;
+  listByAccountId(
+    accountId: string,
+    options?: ListDocumentsOptions,
+  ): Promise<DocumentRecord[]>;
+};
+
+export function createUnavailableDocumentRepository(): DocumentRepository {
+  return {
+    async create() {
+      throw new Error("An authenticated document repository is required.");
+    },
+    async findById() {
+      throw new Error("An authenticated document repository is required.");
+    },
+    async listByAccountId() {
+      throw new Error("An authenticated document repository is required.");
+    },
+  };
+}

--- a/src/modules/documents/application/get-document.ts
+++ b/src/modules/documents/application/get-document.ts
@@ -1,0 +1,33 @@
+import type { StoragePort } from "@/modules/provider-boundaries/storage";
+import type { DocumentRepository } from "./document-repository";
+
+export async function getDocument({
+  accountId,
+  documentId,
+  repository,
+  storagePort,
+  includeDownloadUrl = false,
+}: {
+  accountId: string;
+  documentId: string;
+  repository: DocumentRepository;
+  storagePort?: StoragePort;
+  includeDownloadUrl?: boolean;
+}) {
+  const document = await repository.findById(accountId, documentId);
+
+  if (!document) {
+    return null;
+  }
+
+  if (!includeDownloadUrl || !storagePort) {
+    return { document, downloadUrl: null };
+  }
+
+  return {
+    document,
+    downloadUrl: await storagePort.createSignedDownloadUrl(
+      document.storagePath,
+    ),
+  };
+}

--- a/src/modules/documents/application/list-documents.ts
+++ b/src/modules/documents/application/list-documents.ts
@@ -1,0 +1,16 @@
+import type { DocumentRepository } from "./document-repository";
+
+export function listDocuments({
+  accountId,
+  handReceiptId,
+  repository,
+}: {
+  accountId: string;
+  handReceiptId?: string;
+  repository: DocumentRepository;
+}) {
+  return repository.listByAccountId(
+    accountId,
+    handReceiptId ? { handReceiptId } : undefined,
+  );
+}

--- a/src/modules/documents/application/types.ts
+++ b/src/modules/documents/application/types.ts
@@ -1,0 +1,59 @@
+export const ACCEPTED_DOCUMENT_MIME_TYPES = [
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+] as const;
+
+export const MAX_DOCUMENT_UPLOAD_SIZE_BYTES = 20 * 1024 * 1024;
+
+export type AcceptedDocumentMimeType =
+  (typeof ACCEPTED_DOCUMENT_MIME_TYPES)[number];
+
+export type DocumentRecord = {
+  id: string;
+  accountId: string;
+  handReceiptId: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  storagePath: string;
+  uploadedAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type NewDocumentRecord = Omit<
+  DocumentRecord,
+  "id" | "createdAt" | "updatedAt"
+> & {
+  id?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+export type UploadDocumentInput = {
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
+  handReceiptId: string;
+};
+
+export type CompleteDocumentUploadInput = UploadDocumentInput & {
+  documentId: string;
+};
+
+export class UnsupportedDocumentMimeTypeError extends Error {
+  constructor(mimeType: string) {
+    super(`Unsupported document type: ${mimeType}.`);
+    this.name = "UnsupportedDocumentMimeTypeError";
+  }
+}
+
+export class DocumentUploadReadOnlyError extends Error {
+  constructor() {
+    super("This account is read-only.");
+    this.name = "DocumentUploadReadOnlyError";
+  }
+}

--- a/src/modules/documents/application/upload-document.ts
+++ b/src/modules/documents/application/upload-document.ts
@@ -33,6 +33,7 @@ type CompleteDocumentUploadArgs = {
   documentRepository: DocumentRepository;
   handReceiptRepository: HandReceiptRepository;
   auditRepository: AuditRepository;
+  storagePort: StoragePort;
   now?: Date;
 };
 
@@ -135,6 +136,7 @@ export async function completeDocumentUpload({
   documentRepository,
   handReceiptRepository,
   auditRepository,
+  storagePort,
   now = new Date(),
 }: CompleteDocumentUploadArgs) {
   await validateDocumentUpload({
@@ -146,6 +148,12 @@ export async function completeDocumentUpload({
 
   const filename = cleanFilename(input.filename);
   const storagePath = `${account.id}/${input.documentId}`;
+  const uploadedObjectExists = await storagePort.objectExists(storagePath);
+
+  if (!uploadedObjectExists) {
+    throw new Error("Uploaded document file was not found.");
+  }
+
   const document = await documentRepository.create({
     id: input.documentId,
     accountId: account.id,

--- a/src/modules/documents/application/upload-document.ts
+++ b/src/modules/documents/application/upload-document.ts
@@ -1,0 +1,180 @@
+import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import { recordAuditEvent, type AuditRepository } from "@/modules/audit";
+import {
+  canUploadDocument,
+  deriveAccountCapabilities,
+} from "@/modules/billing";
+import type { HandReceiptRepository } from "@/modules/hand-receipts";
+import type { StoragePort } from "@/modules/provider-boundaries/storage";
+import type { DocumentRepository } from "./document-repository";
+import {
+  ACCEPTED_DOCUMENT_MIME_TYPES,
+  type AcceptedDocumentMimeType,
+  type CompleteDocumentUploadInput,
+  DocumentUploadReadOnlyError,
+  MAX_DOCUMENT_UPLOAD_SIZE_BYTES,
+  UnsupportedDocumentMimeTypeError,
+  type UploadDocumentInput,
+} from "./types";
+
+type InitiateDocumentUploadArgs = {
+  account: AccountRecord;
+  input: UploadDocumentInput;
+  handReceiptRepository: HandReceiptRepository;
+  storagePort: StoragePort;
+  now?: Date;
+  createDocumentId?: () => string;
+};
+
+type CompleteDocumentUploadArgs = {
+  account: AccountRecord;
+  actorId: string;
+  input: CompleteDocumentUploadInput;
+  documentRepository: DocumentRepository;
+  handReceiptRepository: HandReceiptRepository;
+  auditRepository: AuditRepository;
+  now?: Date;
+};
+
+function cleanFilename(filename: string) {
+  const trimmed = filename.trim();
+
+  if (!trimmed) {
+    throw new Error("Document filename is required.");
+  }
+
+  return trimmed;
+}
+
+async function validateDocumentUpload({
+  account,
+  input,
+  handReceiptRepository,
+  now,
+}: {
+  account: AccountRecord;
+  input: UploadDocumentInput;
+  handReceiptRepository: HandReceiptRepository;
+  now: Date;
+}) {
+  const capabilities = deriveAccountCapabilities(account, now);
+
+  if (!canUploadDocument(capabilities)) {
+    throw new DocumentUploadReadOnlyError();
+  }
+
+  if (
+    !ACCEPTED_DOCUMENT_MIME_TYPES.includes(
+      input.mimeType as AcceptedDocumentMimeType,
+    )
+  ) {
+    throw new UnsupportedDocumentMimeTypeError(input.mimeType);
+  }
+
+  if (!Number.isInteger(input.sizeBytes) || input.sizeBytes <= 0) {
+    throw new Error("Document file size must be greater than zero.");
+  }
+
+  if (input.sizeBytes > MAX_DOCUMENT_UPLOAD_SIZE_BYTES) {
+    throw new Error("Document file size must be 20 MiB or smaller.");
+  }
+
+  const handReceipt = await handReceiptRepository.findById(
+    account.id,
+    input.handReceiptId,
+  );
+
+  if (!handReceipt) {
+    throw new Error("Hand receipt was not found.");
+  }
+
+  if (handReceipt.status !== "active") {
+    throw new Error("Hand receipt must be active to upload documents.");
+  }
+}
+
+export async function initiateDocumentUpload({
+  account,
+  input,
+  handReceiptRepository,
+  storagePort,
+  now = new Date(),
+  createDocumentId = () => globalThis.crypto.randomUUID(),
+}: InitiateDocumentUploadArgs) {
+  await validateDocumentUpload({
+    account,
+    input,
+    handReceiptRepository,
+    now,
+  });
+
+  const documentId = createDocumentId();
+  const filename = cleanFilename(input.filename);
+  const storagePath = `${account.id}/${documentId}`;
+  const upload = await storagePort.createSignedUploadUrl(storagePath);
+
+  return {
+    pendingDocument: {
+      id: documentId,
+      handReceiptId: input.handReceiptId,
+      filename,
+      mimeType: input.mimeType,
+      sizeBytes: input.sizeBytes,
+      storagePath: upload.path,
+    },
+    signedUploadUrl: upload.signedUrl,
+    uploadToken: upload.token,
+    storagePath: upload.path,
+  };
+}
+
+export async function completeDocumentUpload({
+  account,
+  actorId,
+  input,
+  documentRepository,
+  handReceiptRepository,
+  auditRepository,
+  now = new Date(),
+}: CompleteDocumentUploadArgs) {
+  await validateDocumentUpload({
+    account,
+    input,
+    handReceiptRepository,
+    now,
+  });
+
+  const filename = cleanFilename(input.filename);
+  const storagePath = `${account.id}/${input.documentId}`;
+  const document = await documentRepository.create({
+    id: input.documentId,
+    accountId: account.id,
+    handReceiptId: input.handReceiptId,
+    filename,
+    mimeType: input.mimeType,
+    sizeBytes: input.sizeBytes,
+    storagePath,
+    uploadedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await recordAuditEvent({
+    accountId: account.id,
+    actorId,
+    action: "document.uploaded",
+    target: {
+      type: "document",
+      id: document.id,
+    },
+    metadata: {
+      filename,
+      mimeType: input.mimeType,
+      sizeBytes: input.sizeBytes,
+    },
+    occurredAt: now,
+    repository: auditRepository,
+  });
+
+  return { document };
+}

--- a/src/modules/documents/index.ts
+++ b/src/modules/documents/index.ts
@@ -1,0 +1,5 @@
+export * from "./application/document-repository";
+export * from "./application/get-document";
+export * from "./application/list-documents";
+export * from "./application/types";
+export * from "./application/upload-document";

--- a/src/modules/documents/infrastructure/drizzle-document-repository.ts
+++ b/src/modules/documents/infrastructure/drizzle-document-repository.ts
@@ -1,0 +1,102 @@
+import { and, desc, eq } from "drizzle-orm";
+
+import { documents } from "@/db/schema";
+import type { DocumentRepository, DocumentRecord } from "@/modules/documents";
+import type {
+  AuthenticatedDatabaseSession,
+  AuthenticatedDatabaseTransaction,
+} from "@/modules/provider-boundaries/database/authenticated-session";
+import { runWithAuthenticatedDatabaseSession } from "@/modules/provider-boundaries/database/authenticated-session";
+import type { createDrizzleClient } from "@/modules/provider-boundaries/database/drizzle";
+
+type DrizzleClient = ReturnType<typeof createDrizzleClient>;
+type DocumentRow = typeof documents.$inferSelect;
+type DocumentOperation = <T>(
+  operation: (transaction: AuthenticatedDatabaseTransaction) => Promise<T>,
+) => Promise<T>;
+
+function toDocumentRecord(row: DocumentRow): DocumentRecord {
+  return {
+    id: row.id,
+    accountId: row.accountId,
+    handReceiptId: row.handReceiptId,
+    filename: row.filename,
+    mimeType: row.mimeType,
+    sizeBytes: row.sizeBytes,
+    storagePath: row.storagePath,
+    uploadedAt: row.uploadedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function createDocumentRepository(run: DocumentOperation): DocumentRepository {
+  return {
+    async create(document) {
+      const [createdDocument] = await run(async (transaction) => {
+        const [created] = await transaction
+          .insert(documents)
+          .values(document)
+          .returning();
+
+        if (!created) {
+          throw new Error("Document was not created.");
+        }
+
+        return [created];
+      });
+
+      return toDocumentRecord(createdDocument);
+    },
+    async findById(accountId, documentId) {
+      const [row] = await run((transaction) =>
+        transaction
+          .select()
+          .from(documents)
+          .where(
+            and(
+              eq(documents.accountId, accountId),
+              eq(documents.id, documentId),
+            ),
+          )
+          .limit(1),
+      );
+
+      return row ? toDocumentRecord(row) : null;
+    },
+    async listByAccountId(accountId, options = {}) {
+      const rows = await run((transaction) =>
+        transaction
+          .select()
+          .from(documents)
+          .where(
+            options.handReceiptId
+              ? and(
+                  eq(documents.accountId, accountId),
+                  eq(documents.handReceiptId, options.handReceiptId),
+                )
+              : eq(documents.accountId, accountId),
+          )
+          .orderBy(desc(documents.uploadedAt))
+          .limit(options.limit ?? 50),
+      );
+
+      return rows.map(toDocumentRecord);
+    },
+  };
+}
+
+export function createDrizzleDocumentRepository(
+  db: DrizzleClient,
+  session: AuthenticatedDatabaseSession,
+): DocumentRepository {
+  return createDocumentRepository((operation) =>
+    runWithAuthenticatedDatabaseSession(db, session, operation),
+  );
+}
+
+export function createTransactionalDrizzleDocumentRepository(
+  transaction: AuthenticatedDatabaseTransaction,
+): DocumentRepository {
+  return createDocumentRepository((operation) => operation(transaction));
+}

--- a/src/modules/documents/ui/document-list.tsx
+++ b/src/modules/documents/ui/document-list.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { Download } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/trpc/react";
+
+function formatBytes(sizeBytes: number) {
+  if (sizeBytes < 1024) {
+    return `${sizeBytes} B`;
+  }
+
+  if (sizeBytes < 1024 * 1024) {
+    return `${(sizeBytes / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(value: Date | string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
+export function DocumentList({ handReceiptId }: { handReceiptId: string }) {
+  const utilities = trpc.useUtils();
+  const documentsQuery = trpc.documents.list.useQuery({ handReceiptId });
+
+  async function openDownload(documentId: string) {
+    const result = await utilities.client.documents.getById.query({
+      id: documentId,
+    });
+
+    if (result.downloadUrl) {
+      window.open(result.downloadUrl, "_blank", "noopener,noreferrer");
+    }
+  }
+
+  if (documentsQuery.isLoading) {
+    return (
+      <div className="rounded-lg border bg-secondary p-4 text-sm text-muted-foreground">
+        Loading documents...
+      </div>
+    );
+  }
+
+  if (documentsQuery.error) {
+    return (
+      <div
+        className="space-y-2 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        <p className="font-medium">Documents could not be loaded.</p>
+        <Button
+          onClick={() => void documentsQuery.refetch()}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  const documents = documentsQuery.data ?? [];
+
+  if (documents.length === 0) {
+    return (
+      <div className="rounded-lg border bg-background p-4 text-sm text-muted-foreground">
+        Uploaded 2062 scans and images will appear here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {documents.map((document) => (
+        <div
+          className="flex items-center justify-between gap-3 rounded-lg border bg-background p-3"
+          key={document.id}
+        >
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">{document.filename}</p>
+            <p className="text-xs text-muted-foreground">
+              {formatBytes(document.sizeBytes)} · Uploaded{" "}
+              {formatDate(document.uploadedAt)}
+            </p>
+          </div>
+          <Button
+            aria-label={`Download ${document.filename}`}
+            onClick={() => void openDownload(document.id)}
+            size="icon-sm"
+            type="button"
+            variant="outline"
+          >
+            <Download aria-hidden="true" className="size-4" />
+          </Button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/modules/documents/ui/document-list.tsx
+++ b/src/modules/documents/ui/document-list.tsx
@@ -30,12 +30,29 @@ export function DocumentList({ handReceiptId }: { handReceiptId: string }) {
   const documentsQuery = trpc.documents.list.useQuery({ handReceiptId });
 
   async function openDownload(documentId: string) {
-    const result = await utilities.client.documents.getById.query({
-      id: documentId,
-    });
+    const downloadWindow = window.open("about:blank", "_blank");
 
-    if (result.downloadUrl) {
-      window.open(result.downloadUrl, "_blank", "noopener,noreferrer");
+    if (downloadWindow) {
+      downloadWindow.opener = null;
+    }
+
+    try {
+      const result = await utilities.client.documents.getById.query({
+        id: documentId,
+      });
+
+      if (result.downloadUrl) {
+        if (downloadWindow) {
+          downloadWindow.location.href = result.downloadUrl;
+        } else {
+          window.location.assign(result.downloadUrl);
+        }
+      } else {
+        downloadWindow?.close();
+      }
+    } catch (error) {
+      downloadWindow?.close();
+      throw error;
     }
   }
 

--- a/src/modules/documents/ui/document-upload.tsx
+++ b/src/modules/documents/ui/document-upload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useId, useRef, useState } from "react";
 import { FileUp, Loader2, RotateCcw } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -10,11 +10,23 @@ import {
 } from "@/modules/documents";
 import { trpc } from "@/trpc/react";
 
+type PendingDocumentUpload = {
+  id: string;
+  handReceiptId: string;
+  filename: string;
+  mimeType: AcceptedDocumentMimeType;
+  sizeBytes: number;
+};
+
 type UploadState =
   | { status: "idle" }
   | { status: "uploading"; filename: string }
   | { status: "success"; filename: string }
-  | { status: "error"; message: string };
+  | {
+      status: "error";
+      message: string;
+      pendingDocument?: PendingDocumentUpload;
+    };
 
 export function DocumentUpload({
   handReceiptId,
@@ -25,11 +37,43 @@ export function DocumentUpload({
   disabled: boolean;
   onUploadComplete?: () => void;
 }) {
+  const inputId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
   const [state, setState] = useState<UploadState>({ status: "idle" });
   const initiateUpload = trpc.documents.initiateUpload.useMutation();
   const completeUpload = trpc.documents.completeUpload.useMutation();
   const acceptedTypes = ACCEPTED_DOCUMENT_MIME_TYPES.join(",");
+
+  async function completePendingUpload(
+    pendingDocument: PendingDocumentUpload,
+    successFilename = pendingDocument.filename,
+  ) {
+    try {
+      setState({ status: "uploading", filename: pendingDocument.filename });
+      await completeUpload.mutateAsync({
+        documentId: pendingDocument.id,
+        filename: pendingDocument.filename,
+        handReceiptId: pendingDocument.handReceiptId,
+        mimeType: pendingDocument.mimeType,
+        sizeBytes: pendingDocument.sizeBytes,
+      });
+
+      setState({ status: "success", filename: successFilename });
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
+      onUploadComplete?.();
+    } catch (error) {
+      setState({
+        status: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "The upload could not be completed.",
+        pendingDocument,
+      });
+    }
+  }
 
   async function uploadFile(file: File) {
     if (
@@ -66,16 +110,16 @@ export function DocumentUpload({
         throw new Error("The file could not be stored. Try again.");
       }
 
-      await completeUpload.mutateAsync({
-        documentId: upload.pendingDocument.id,
-        filename: upload.pendingDocument.filename,
-        handReceiptId: upload.pendingDocument.handReceiptId,
-        mimeType: upload.pendingDocument.mimeType as AcceptedDocumentMimeType,
-        sizeBytes: upload.pendingDocument.sizeBytes,
-      });
-
-      setState({ status: "success", filename: file.name });
-      onUploadComplete?.();
+      await completePendingUpload(
+        {
+          id: upload.pendingDocument.id,
+          filename: upload.pendingDocument.filename,
+          handReceiptId: upload.pendingDocument.handReceiptId,
+          mimeType: upload.pendingDocument.mimeType as AcceptedDocumentMimeType,
+          sizeBytes: upload.pendingDocument.sizeBytes,
+        },
+        file.name,
+      );
     } catch (error) {
       setState({
         status: "error",
@@ -84,10 +128,6 @@ export function DocumentUpload({
             ? error.message
             : "The upload could not be started.",
       });
-    } finally {
-      if (inputRef.current) {
-        inputRef.current.value = "";
-      }
     }
   }
 
@@ -107,7 +147,11 @@ export function DocumentUpload({
       </div>
 
       <div className="space-y-3">
+        <label className="sr-only" htmlFor={inputId}>
+          Upload 2062 document
+        </label>
         <input
+          id={inputId}
           ref={inputRef}
           accept={acceptedTypes}
           className="block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"
@@ -145,13 +189,23 @@ export function DocumentUpload({
           >
             <p className="font-medium">{state.message}</p>
             <Button
-              onClick={() => setState({ status: "idle" })}
+              onClick={() => {
+                if (state.pendingDocument) {
+                  void completePendingUpload(state.pendingDocument);
+                  return;
+                }
+
+                if (inputRef.current) {
+                  inputRef.current.value = "";
+                }
+                setState({ status: "idle" });
+              }}
               size="sm"
               type="button"
               variant="outline"
             >
               <RotateCcw aria-hidden="true" className="size-4" />
-              Retry
+              {state.pendingDocument ? "Retry save" : "Retry"}
             </Button>
           </div>
         ) : null}

--- a/src/modules/documents/ui/document-upload.tsx
+++ b/src/modules/documents/ui/document-upload.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { FileUp, Loader2, RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  ACCEPTED_DOCUMENT_MIME_TYPES,
+  type AcceptedDocumentMimeType,
+} from "@/modules/documents";
+import { trpc } from "@/trpc/react";
+
+type UploadState =
+  | { status: "idle" }
+  | { status: "uploading"; filename: string }
+  | { status: "success"; filename: string }
+  | { status: "error"; message: string };
+
+export function DocumentUpload({
+  handReceiptId,
+  disabled,
+  onUploadComplete,
+}: {
+  handReceiptId: string;
+  disabled: boolean;
+  onUploadComplete?: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [state, setState] = useState<UploadState>({ status: "idle" });
+  const initiateUpload = trpc.documents.initiateUpload.useMutation();
+  const completeUpload = trpc.documents.completeUpload.useMutation();
+  const acceptedTypes = ACCEPTED_DOCUMENT_MIME_TYPES.join(",");
+
+  async function uploadFile(file: File) {
+    if (
+      !ACCEPTED_DOCUMENT_MIME_TYPES.includes(
+        file.type as AcceptedDocumentMimeType,
+      )
+    ) {
+      setState({
+        status: "error",
+        message: "Upload a PDF, JPG, PNG, WebP, or HEIC document.",
+      });
+      return;
+    }
+
+    setState({ status: "uploading", filename: file.name });
+
+    try {
+      const upload = await initiateUpload.mutateAsync({
+        filename: file.name,
+        handReceiptId,
+        mimeType: file.type as AcceptedDocumentMimeType,
+        sizeBytes: file.size,
+      });
+
+      const response = await fetch(upload.signedUploadUrl, {
+        method: "PUT",
+        headers: {
+          "content-type": file.type,
+        },
+        body: file,
+      });
+
+      if (!response.ok) {
+        throw new Error("The file could not be stored. Try again.");
+      }
+
+      await completeUpload.mutateAsync({
+        documentId: upload.pendingDocument.id,
+        filename: upload.pendingDocument.filename,
+        handReceiptId: upload.pendingDocument.handReceiptId,
+        mimeType: upload.pendingDocument.mimeType as AcceptedDocumentMimeType,
+        sizeBytes: upload.pendingDocument.sizeBytes,
+      });
+
+      setState({ status: "success", filename: file.name });
+      onUploadComplete?.();
+    } catch (error) {
+      setState({
+        status: "error",
+        message:
+          error instanceof Error
+            ? error.message
+            : "The upload could not be started.",
+      });
+    } finally {
+      if (inputRef.current) {
+        inputRef.current.value = "";
+      }
+    }
+  }
+
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+          <FileUp aria-hidden="true" className="size-4" />
+        </span>
+        <div className="min-w-0 space-y-1">
+          <h2 className="text-sm font-semibold tracking-normal">Upload 2062</h2>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Add a private PDF or image scan now. Assignment selection lands in a
+            later 2062 slice.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <input
+          ref={inputRef}
+          accept={acceptedTypes}
+          className="block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-2 file:text-sm file:font-medium file:text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          disabled={disabled || state.status === "uploading"}
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+
+            if (file) {
+              void uploadFile(file);
+            }
+          }}
+          type="file"
+        />
+        {disabled ? (
+          <p className="text-sm text-muted-foreground">
+            Read-only accounts can review existing documents but cannot upload
+            new files.
+          </p>
+        ) : null}
+        {state.status === "uploading" ? (
+          <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+            Uploading {state.filename}
+          </p>
+        ) : null}
+        {state.status === "success" ? (
+          <p className="rounded-md border border-green-700/20 bg-green-700/10 px-3 py-2 text-sm font-medium text-green-800 dark:text-green-300">
+            {state.filename} is saved as private document evidence.
+          </p>
+        ) : null}
+        {state.status === "error" ? (
+          <div
+            className="space-y-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            role="alert"
+          >
+            <p className="font-medium">{state.message}</p>
+            <Button
+              onClick={() => setState({ status: "idle" })}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <RotateCcw aria-hidden="true" className="size-4" />
+              Retry
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      <p className="sr-only">Upload context: hand receipt {handReceiptId}</p>
+    </section>
+  );
+}

--- a/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
+++ b/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
@@ -7,7 +7,6 @@ import {
   ArrowLeft,
   CalendarDays,
   ClipboardList,
-  FileUp,
   History,
   Pencil,
   RotateCcw,
@@ -23,6 +22,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ActivityList } from "@/modules/audit/ui/activity-list";
+import { DocumentList } from "@/modules/documents/ui/document-list";
+import { DocumentUpload } from "@/modules/documents/ui/document-upload";
 import type { HandReceiptRecord } from "@/modules/hand-receipts";
 import type { ItemRecord } from "@/modules/items";
 import { CreateItemForm } from "@/modules/items/ui/create-item-form";
@@ -64,30 +65,6 @@ function MetadataRow({
         {value || "Not set"}
       </dd>
     </div>
-  );
-}
-
-function FutureSection({
-  icon: Icon,
-  label,
-  text,
-}: {
-  icon: typeof FileUp;
-  label: string;
-  text: string;
-}) {
-  return (
-    <section className="rounded-lg border bg-card p-4">
-      <div className="flex items-start gap-3">
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
-          <Icon aria-hidden="true" className="size-4" />
-        </span>
-        <div className="min-w-0 space-y-1">
-          <h2 className="text-sm font-semibold tracking-normal">{label}</h2>
-          <p className="text-sm leading-6 text-muted-foreground">{text}</p>
-        </div>
-      </div>
-    </section>
   );
 }
 
@@ -223,6 +200,7 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
       utilities.items.listByHandReceipt.invalidate({ handReceiptId }),
       utilities.items.search.invalidate(),
       utilities.billing.capabilities.invalidate(),
+      utilities.documents.list.invalidate(),
     ]);
   }
 
@@ -522,11 +500,19 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
               />
             )}
           </section>
-          <FutureSection
-            icon={FileUp}
-            label="Upload 2062"
-            text="The future upload flow starts from this receipt and keeps the selected bucket in context."
-          />
+          <div className="space-y-3">
+            <DocumentUpload
+              disabled={isReadOnly || handReceipt.status !== "active"}
+              handReceiptId={handReceiptId}
+              onUploadComplete={() => {
+                void Promise.all([
+                  utilities.documents.list.invalidate({ handReceiptId }),
+                  utilities.audit.listRecentActivity.invalidate(),
+                ]);
+              }}
+            />
+            <DocumentList handReceiptId={handReceiptId} />
+          </div>
         </div>
 
         <section className="space-y-3">

--- a/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
+++ b/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
@@ -508,6 +508,10 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
                 void Promise.all([
                   utilities.documents.list.invalidate({ handReceiptId }),
                   utilities.audit.listRecentActivity.invalidate(),
+                  utilities.audit.listTargetActivity.invalidate({
+                    targetType: "hand_receipt",
+                    targetId: handReceiptId,
+                  }),
                 ]);
               }}
             />

--- a/src/modules/provider-boundaries/database/app-unit-of-work.ts
+++ b/src/modules/provider-boundaries/database/app-unit-of-work.ts
@@ -2,6 +2,8 @@ import type { AuditRepository } from "@/modules/audit";
 import { createTransactionalDrizzleAuditRepository } from "@/modules/audit/infrastructure/drizzle-audit-repository";
 import type { ContactRepository } from "@/modules/contacts";
 import { createTransactionalDrizzleContactRepository } from "@/modules/contacts/infrastructure/drizzle-contact-repository";
+import type { DocumentRepository } from "@/modules/documents";
+import { createTransactionalDrizzleDocumentRepository } from "@/modules/documents/infrastructure/drizzle-document-repository";
 import type { AccountRepository } from "@/modules/accounts/application/ensure-account";
 import { createTransactionalDrizzleAccountRepository } from "@/modules/accounts/infrastructure/drizzle-account-repository";
 import type { HandReceiptRepository } from "@/modules/hand-receipts";
@@ -24,6 +26,7 @@ export type AppUnitOfWorkRepositories = {
   accountRepository: AccountRepository;
   auditRepository: AuditRepository;
   contactRepository: ContactRepository;
+  documentRepository: DocumentRepository;
   handReceiptRepository: HandReceiptRepository;
   itemRepository: ItemRepository;
   locationRepository: LocationRepository;
@@ -59,6 +62,8 @@ export function createDrizzleAppUnitOfWork(
             createTransactionalDrizzleAuditRepository(transaction),
           contactRepository:
             createTransactionalDrizzleContactRepository(transaction),
+          documentRepository:
+            createTransactionalDrizzleDocumentRepository(transaction),
           handReceiptRepository:
             createTransactionalDrizzleHandReceiptRepository(transaction),
           itemRepository: createTransactionalDrizzleItemRepository(transaction),

--- a/src/modules/provider-boundaries/storage/index.ts
+++ b/src/modules/provider-boundaries/storage/index.ts
@@ -1,0 +1,33 @@
+export type SignedUploadUrl = {
+  signedUrl: string;
+  token: string;
+  path: string;
+};
+
+export type CreateSignedUploadUrlOptions = {
+  expiresIn?: number;
+};
+
+export type StoragePort = {
+  createSignedUploadUrl(
+    path: string,
+    options?: CreateSignedUploadUrlOptions,
+  ): Promise<SignedUploadUrl>;
+  createSignedDownloadUrl(path: string, expiresIn?: number): Promise<string>;
+};
+
+export function createUnavailableStoragePort(): StoragePort {
+  return {
+    async createSignedUploadUrl() {
+      throw new Error("A file storage provider is required.");
+    },
+    async createSignedDownloadUrl() {
+      throw new Error("A file storage provider is required.");
+    },
+  };
+}
+
+export {
+  createStoragePortFromEnvironment,
+  createSupabaseStorageAdapter,
+} from "./supabase-storage-adapter";

--- a/src/modules/provider-boundaries/storage/index.ts
+++ b/src/modules/provider-boundaries/storage/index.ts
@@ -14,6 +14,7 @@ export type StoragePort = {
     options?: CreateSignedUploadUrlOptions,
   ): Promise<SignedUploadUrl>;
   createSignedDownloadUrl(path: string, expiresIn?: number): Promise<string>;
+  objectExists(path: string): Promise<boolean>;
 };
 
 export function createUnavailableStoragePort(): StoragePort {
@@ -22,6 +23,9 @@ export function createUnavailableStoragePort(): StoragePort {
       throw new Error("A file storage provider is required.");
     },
     async createSignedDownloadUrl() {
+      throw new Error("A file storage provider is required.");
+    },
+    async objectExists() {
       throw new Error("A file storage provider is required.");
     },
   };

--- a/src/modules/provider-boundaries/storage/supabase-storage-adapter.ts
+++ b/src/modules/provider-boundaries/storage/supabase-storage-adapter.ts
@@ -25,7 +25,13 @@ export function createSupabaseStorageAdapter(): StoragePort {
   });
 
   return {
-    async createSignedUploadUrl(path) {
+    async createSignedUploadUrl(path, options) {
+      if (options?.expiresIn !== undefined) {
+        throw new Error(
+          "Supabase signed upload URLs do not support configurable expiration.",
+        );
+      }
+
       const { data, error } = await client.storage
         .from(DOCUMENTS_BUCKET)
         .createSignedUploadUrl(path, {
@@ -53,6 +59,28 @@ export function createSupabaseStorageAdapter(): StoragePort {
 
       return data.signedUrl;
     },
+    async objectExists(path) {
+      const separatorIndex = path.lastIndexOf("/");
+
+      if (separatorIndex < 0) {
+        return false;
+      }
+
+      const folder = path.slice(0, separatorIndex);
+      const filename = path.slice(separatorIndex + 1);
+      const { data, error } = await client.storage
+        .from(DOCUMENTS_BUCKET)
+        .list(folder, {
+          limit: 100,
+          search: filename,
+        });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return data.some((object) => object.name === filename);
+    },
   };
 }
 
@@ -66,6 +94,9 @@ export function createStoragePortFromEnvironment(): StoragePort {
         throw new Error("A file storage provider is required.");
       },
       async createSignedDownloadUrl() {
+        throw new Error("A file storage provider is required.");
+      },
+      async objectExists() {
         throw new Error("A file storage provider is required.");
       },
     };

--- a/src/modules/provider-boundaries/storage/supabase-storage-adapter.ts
+++ b/src/modules/provider-boundaries/storage/supabase-storage-adapter.ts
@@ -1,0 +1,75 @@
+import { createClient } from "@supabase/supabase-js";
+
+import type { StoragePort } from ".";
+
+const DOCUMENTS_BUCKET = "documents";
+
+function readRequiredEnv(name: string) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`${name} is required for Supabase Storage.`);
+  }
+
+  return value;
+}
+
+export function createSupabaseStorageAdapter(): StoragePort {
+  const supabaseUrl = readRequiredEnv("NEXT_PUBLIC_SUPABASE_URL");
+  const serviceRoleKey = readRequiredEnv("SUPABASE_SERVICE_ROLE_KEY");
+  const client = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+
+  return {
+    async createSignedUploadUrl(path) {
+      const { data, error } = await client.storage
+        .from(DOCUMENTS_BUCKET)
+        .createSignedUploadUrl(path, {
+          upsert: false,
+        });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return {
+        signedUrl: data.signedUrl,
+        token: data.token,
+        path: data.path,
+      };
+    },
+    async createSignedDownloadUrl(path, expiresIn = 60 * 10) {
+      const { data, error } = await client.storage
+        .from(DOCUMENTS_BUCKET)
+        .createSignedUrl(path, expiresIn);
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return data.signedUrl;
+    },
+  };
+}
+
+export function createStoragePortFromEnvironment(): StoragePort {
+  if (
+    !process.env.NEXT_PUBLIC_SUPABASE_URL ||
+    !process.env.SUPABASE_SERVICE_ROLE_KEY
+  ) {
+    return {
+      async createSignedUploadUrl() {
+        throw new Error("A file storage provider is required.");
+      },
+      async createSignedDownloadUrl() {
+        throw new Error("A file storage provider is required.");
+      },
+    };
+  }
+
+  return createSupabaseStorageAdapter();
+}

--- a/src/server/trpc/context.ts
+++ b/src/server/trpc/context.ts
@@ -14,6 +14,11 @@ import {
 } from "@/modules/contacts";
 import { createDrizzleContactRepository } from "@/modules/contacts/infrastructure/drizzle-contact-repository";
 import {
+  createUnavailableDocumentRepository,
+  type DocumentRepository,
+} from "@/modules/documents";
+import { createDrizzleDocumentRepository } from "@/modules/documents/infrastructure/drizzle-document-repository";
+import {
   createUnavailableHandReceiptRepository,
   type HandReceiptRepository,
 } from "@/modules/hand-receipts";
@@ -44,6 +49,11 @@ import {
   type AppUnitOfWork,
 } from "@/modules/provider-boundaries/database/app-unit-of-work";
 import { getDrizzleClient } from "@/modules/provider-boundaries/database/drizzle";
+import {
+  createStoragePortFromEnvironment,
+  createUnavailableStoragePort,
+  type StoragePort,
+} from "@/modules/provider-boundaries/storage";
 
 export async function createTRPCContext(): Promise<{
   session: AppSession | null;
@@ -51,12 +61,14 @@ export async function createTRPCContext(): Promise<{
   accountRepository: ReturnType<typeof createDrizzleAccountRepository>;
   auditRepository: AuditRepository;
   contactRepository: ContactRepository;
+  documentRepository?: DocumentRepository;
   handReceiptRepository: HandReceiptRepository;
   itemRepository: ItemRepository;
   locationRepository: LocationRepository;
   requirementCompletionRepository?: RequirementCompletionRepository;
   requirementRepository: RequirementRepository;
   unitOfWork: AppUnitOfWork;
+  storagePort?: StoragePort;
 }> {
   const db = getDrizzleClient();
   const accountRepository = createDrizzleAccountRepository(db);
@@ -69,6 +81,7 @@ export async function createTRPCContext(): Promise<{
       accountRepository,
       auditRepository: createUnavailableAuditRepository(),
       contactRepository: createUnavailableContactRepository(),
+      documentRepository: createUnavailableDocumentRepository(),
       handReceiptRepository: createUnavailableHandReceiptRepository(),
       itemRepository: createUnavailableItemRepository(),
       locationRepository: createUnavailableLocationRepository(),
@@ -76,6 +89,7 @@ export async function createTRPCContext(): Promise<{
         createUnavailableRequirementCompletionRepository(),
       requirementRepository: createUnavailableRequirementRepository(),
       unitOfWork: createUnavailableAppUnitOfWork(),
+      storagePort: createUnavailableStoragePort(),
     };
   }
 
@@ -92,6 +106,9 @@ export async function createTRPCContext(): Promise<{
       authSubject: session.userId,
     }),
     contactRepository: createDrizzleContactRepository(db, {
+      authSubject: session.userId,
+    }),
+    documentRepository: createDrizzleDocumentRepository(db, {
       authSubject: session.userId,
     }),
     handReceiptRepository: createDrizzleHandReceiptRepository(db, {
@@ -113,6 +130,7 @@ export async function createTRPCContext(): Promise<{
     unitOfWork: createDrizzleAppUnitOfWork(db, {
       authSubject: session.userId,
     }),
+    storagePort: createStoragePortFromEnvironment(),
   };
 }
 

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -6,6 +6,8 @@ import {
   createUnavailableRequirementCompletionRepository,
   createUnavailableRequirementRepository,
 } from "@/modules/requirements";
+import { createUnavailableDocumentRepository } from "@/modules/documents";
+import { createUnavailableStoragePort } from "@/modules/provider-boundaries/storage";
 import type { TRPCContext } from "@/server/trpc/context";
 
 const t = initTRPC.context<TRPCContext>().create({
@@ -29,6 +31,8 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
       accountRepository: ctx.accountRepository,
       auditRepository: ctx.auditRepository,
       contactRepository: ctx.contactRepository,
+      documentRepository:
+        ctx.documentRepository ?? createUnavailableDocumentRepository(),
       handReceiptRepository: ctx.handReceiptRepository,
       itemRepository: ctx.itemRepository,
       locationRepository: ctx.locationRepository,
@@ -38,6 +42,7 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
       requirementRepository:
         ctx.requirementRepository ?? createUnavailableRequirementRepository(),
       unitOfWork: ctx.unitOfWork,
+      storagePort: ctx.storagePort ?? createUnavailableStoragePort(),
     },
   });
 });

--- a/src/server/trpc/router.ts
+++ b/src/server/trpc/router.ts
@@ -3,6 +3,7 @@ import { accountsRouter } from "@/server/trpc/routers/accounts";
 import { auditRouter } from "@/server/trpc/routers/audit";
 import { billingRouter } from "@/server/trpc/routers/billing";
 import { contactsRouter } from "@/server/trpc/routers/contacts";
+import { documentsRouter } from "@/server/trpc/routers/documents";
 import { foundationRouter } from "@/server/trpc/routers/foundation";
 import { handReceiptsRouter } from "@/server/trpc/routers/hand-receipts";
 import { itemsRouter } from "@/server/trpc/routers/items";
@@ -14,6 +15,7 @@ export const appRouter = createTRPCRouter({
   audit: auditRouter,
   billing: billingRouter,
   contacts: contactsRouter,
+  documents: documentsRouter,
   foundation: foundationRouter,
   handReceipts: handReceiptsRouter,
   items: itemsRouter,

--- a/src/server/trpc/routers/documents.ts
+++ b/src/server/trpc/routers/documents.ts
@@ -55,7 +55,8 @@ function toTRPCError(error: unknown): never {
     message === "Document filename is required." ||
     message === "Document file size must be greater than zero." ||
     message === "Document file size must be 20 MiB or smaller." ||
-    message === "Hand receipt must be active to upload documents."
+    message === "Hand receipt must be active to upload documents." ||
+    message === "Uploaded document file was not found."
   ) {
     throw new TRPCError({ code: "BAD_REQUEST", message });
   }
@@ -111,6 +112,7 @@ export const documentsRouter = createTRPCRouter({
           documentRepository: repositories.documentRepository,
           handReceiptRepository: repositories.handReceiptRepository,
           auditRepository: repositories.auditRepository,
+          storagePort: ctx.storagePort,
         }),
       ),
     ),

--- a/src/server/trpc/routers/documents.ts
+++ b/src/server/trpc/routers/documents.ts
@@ -1,0 +1,144 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import {
+  ACCEPTED_DOCUMENT_MIME_TYPES,
+  completeDocumentUpload,
+  DocumentUploadReadOnlyError,
+  getDocument,
+  initiateDocumentUpload,
+  listDocuments,
+  UnsupportedDocumentMimeTypeError,
+} from "@/modules/documents";
+import type {
+  AppUnitOfWork,
+  AppUnitOfWorkRepositories,
+} from "@/modules/provider-boundaries/database/app-unit-of-work";
+import type { StoragePort } from "@/modules/provider-boundaries/storage";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/init";
+
+const uploadInput = z.object({
+  filename: z.string().trim().min(1).max(255),
+  handReceiptId: z.uuid(),
+  mimeType: z.enum(ACCEPTED_DOCUMENT_MIME_TYPES),
+  sizeBytes: z
+    .number()
+    .int()
+    .positive()
+    .max(20 * 1024 * 1024),
+});
+
+const completeUploadInput = uploadInput.extend({
+  documentId: z.uuid(),
+});
+
+const documentIdInput = z.object({
+  id: z.uuid(),
+});
+
+const listDocumentsInput = z
+  .object({
+    handReceiptId: z.uuid().optional(),
+  })
+  .optional();
+
+function toTRPCError(error: unknown): never {
+  const message =
+    error instanceof Error ? error.message : "Unable to update documents.";
+
+  if (error instanceof DocumentUploadReadOnlyError) {
+    throw new TRPCError({ code: "FORBIDDEN", message });
+  }
+
+  if (
+    error instanceof UnsupportedDocumentMimeTypeError ||
+    message === "Document filename is required." ||
+    message === "Document file size must be greater than zero." ||
+    message === "Document file size must be 20 MiB or smaller." ||
+    message === "Hand receipt must be active to upload documents."
+  ) {
+    throw new TRPCError({ code: "BAD_REQUEST", message });
+  }
+
+  if (message === "Hand receipt was not found.") {
+    throw new TRPCError({ code: "NOT_FOUND", message });
+  }
+
+  throw new TRPCError({
+    code: "INTERNAL_SERVER_ERROR",
+    message,
+  });
+}
+
+async function runInUnitOfWork<T>(
+  ctx: { unitOfWork: AppUnitOfWork; storagePort: StoragePort },
+  operation: (repositories: AppUnitOfWorkRepositories) => Promise<T>,
+): Promise<T> {
+  try {
+    return await ctx.unitOfWork.run(operation);
+  } catch (error) {
+    if (error instanceof TRPCError) {
+      throw error;
+    }
+
+    toTRPCError(error);
+  }
+}
+
+export const documentsRouter = createTRPCRouter({
+  initiateUpload: protectedProcedure
+    .input(uploadInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await initiateDocumentUpload({
+          account: ctx.account,
+          input,
+          handReceiptRepository: ctx.handReceiptRepository,
+          storagePort: ctx.storagePort,
+        });
+      } catch (error) {
+        toTRPCError(error);
+      }
+    }),
+  completeUpload: protectedProcedure
+    .input(completeUploadInput)
+    .mutation(({ ctx, input }) =>
+      runInUnitOfWork(ctx, (repositories) =>
+        completeDocumentUpload({
+          account: ctx.account,
+          actorId: ctx.session.userId,
+          input,
+          documentRepository: repositories.documentRepository,
+          handReceiptRepository: repositories.handReceiptRepository,
+          auditRepository: repositories.auditRepository,
+        }),
+      ),
+    ),
+  list: protectedProcedure.input(listDocumentsInput).query(({ ctx, input }) =>
+    listDocuments({
+      accountId: ctx.account.id,
+      repository: ctx.documentRepository,
+      ...(input?.handReceiptId ? { handReceiptId: input.handReceiptId } : {}),
+    }),
+  ),
+  getById: protectedProcedure
+    .input(documentIdInput)
+    .query(async ({ ctx, input }) => {
+      const result = await getDocument({
+        accountId: ctx.account.id,
+        documentId: input.id,
+        repository: ctx.documentRepository,
+        storagePort: ctx.storagePort,
+        includeDownloadUrl: true,
+      });
+
+      if (!result) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Document was not found.",
+        });
+      }
+
+      return result;
+    }),
+});

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -119,6 +119,11 @@ file_size_limit = "50MiB"
 # allowed_mime_types = ["image/png", "image/jpeg"]
 # objects_path = "./images"
 
+[storage.buckets.documents]
+public = false
+file_size_limit = "20MiB"
+allowed_mime_types = ["application/pdf", "image/jpeg", "image/png", "image/webp", "image/heic"]
+
 # Allow connections via S3 compatible clients
 [storage.s3_protocol]
 enabled = true

--- a/tests/integration/trpc/documents-router.test.ts
+++ b/tests/integration/trpc/documents-router.test.ts
@@ -1,0 +1,198 @@
+import { TRPCError } from "@trpc/server";
+import { describe, expect, it } from "vitest";
+
+import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import type { AcceptedDocumentMimeType } from "@/modules/documents";
+import { appRouter } from "@/server/trpc/router";
+import { createEmptyAccountRepository } from "../../support/account-repository";
+import { InMemoryAuditRepository } from "../../support/audit-repository";
+import { createInMemoryAppUnitOfWork } from "../../support/app-unit-of-work";
+import { createEmptyContactRepository } from "../../support/contact-repository";
+import { InMemoryDocumentRepository } from "../../support/document-repository";
+import { InMemoryHandReceiptRepository } from "../../support/hand-receipt-repository";
+import { createEmptyItemRepository } from "../../support/item-repository";
+import { createEmptyLocationRepository } from "../../support/location-repository";
+import { createEmptyRequirementRepository } from "../../support/requirement-repository";
+import { MockStoragePort } from "../../support/storage-port";
+
+function createAccount(overrides: Partial<AccountRecord> = {}): AccountRecord {
+  return {
+    id: "account-1",
+    userId: "owner-1",
+    accessState: "active",
+    subscriptionTier: "base",
+    trialStartsAt: new Date("2026-04-01T12:00:00.000Z"),
+    trialEndsAt: new Date("2100-01-01T00:00:00.000Z"),
+    onboardingCompletedAt: null,
+    ...overrides,
+  };
+}
+
+function createHandReceipt(overrides = {}) {
+  return {
+    id: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+    accountId: "account-1",
+    name: "Primary receipt",
+    notes: null,
+    handReceiptNumber: null,
+    holderName: null,
+    unitName: null,
+    uic: null,
+    effectiveDate: null,
+    status: "active" as const,
+    createdAt: new Date("2026-05-02T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-02T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createCaller({
+  account = createAccount(),
+  documentRepository = new InMemoryDocumentRepository(),
+  handReceiptRepository = new InMemoryHandReceiptRepository([
+    createHandReceipt({ accountId: account.id }),
+  ]),
+  auditRepository = new InMemoryAuditRepository(),
+  storagePort = new MockStoragePort(),
+}: {
+  account?: AccountRecord;
+  documentRepository?: InMemoryDocumentRepository;
+  handReceiptRepository?: InMemoryHandReceiptRepository;
+  auditRepository?: InMemoryAuditRepository;
+  storagePort?: MockStoragePort;
+} = {}) {
+  const contactRepository = createEmptyContactRepository();
+  const itemRepository = createEmptyItemRepository();
+  const locationRepository = createEmptyLocationRepository();
+  const requirementRepository = createEmptyRequirementRepository();
+
+  return appRouter.createCaller({
+    session: {
+      userId: account.userId,
+      email: "owner@example.com",
+    },
+    account,
+    accountRepository: createEmptyAccountRepository(),
+    auditRepository,
+    contactRepository,
+    documentRepository,
+    handReceiptRepository,
+    itemRepository,
+    locationRepository,
+    requirementRepository,
+    storagePort,
+    unitOfWork: createInMemoryAppUnitOfWork({
+      auditRepository,
+      contactRepository,
+      documentRepository,
+      handReceiptRepository,
+      itemRepository,
+      locationRepository,
+      requirementRepository,
+    }),
+  });
+}
+
+describe("documentsRouter", () => {
+  it("initiates an upload without persisting metadata until completion", async () => {
+    const documentRepository = new InMemoryDocumentRepository();
+    const caller = createCaller({ documentRepository });
+
+    const result = await caller.documents.initiateUpload({
+      filename: "signed-2062.pdf",
+      handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+      mimeType: "application/pdf",
+      sizeBytes: 1024,
+    });
+
+    expect(result.pendingDocument).toMatchObject({
+      filename: "signed-2062.pdf",
+      handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+      storagePath: `account-1/${result.pendingDocument.id}`,
+    });
+    await expect(
+      caller.documents.list({
+        handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+      }),
+    ).resolves.toEqual([]);
+
+    const completed = await caller.documents.completeUpload({
+      documentId: result.pendingDocument.id,
+      filename: result.pendingDocument.filename,
+      handReceiptId: result.pendingDocument.handReceiptId,
+      mimeType: result.pendingDocument.mimeType as AcceptedDocumentMimeType,
+      sizeBytes: result.pendingDocument.sizeBytes,
+    });
+
+    expect(completed.document).toMatchObject({
+      accountId: "account-1",
+      handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+      filename: "signed-2062.pdf",
+      storagePath: `account-1/${result.pendingDocument.id}`,
+    });
+    await expect(caller.documents.list()).resolves.toMatchObject([
+      { id: result.pendingDocument.id },
+    ]);
+    await expect(
+      caller.documents.list({
+        handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+      }),
+    ).resolves.toMatchObject([{ id: result.pendingDocument.id }]);
+  });
+
+  it("returns FORBIDDEN for read-only accounts", async () => {
+    await expect(
+      createCaller({
+        account: createAccount({ accessState: "paused_read_only" }),
+      }).documents.initiateUpload({
+        filename: "signed-2062.pdf",
+        handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+        mimeType: "application/pdf",
+        sizeBytes: 1024,
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("rejects invalid MIME types before the procedure runs", async () => {
+    await expect(
+      createCaller().documents.initiateUpload({
+        filename: "notes.txt",
+        handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+        mimeType: "text/plain" as "application/pdf",
+        sizeBytes: 1024,
+      }),
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  it("gets a document with a signed download URL", async () => {
+    const documentRepository = new InMemoryDocumentRepository([
+      {
+        id: "4d39229c-f714-4e3f-9ea1-77c9bfdca76c",
+        accountId: "account-1",
+        handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+        filename: "signed-2062.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 1024,
+        storagePath: "account-1/4d39229c-f714-4e3f-9ea1-77c9bfdca76c",
+        uploadedAt: new Date("2026-05-02T12:00:00.000Z"),
+        createdAt: new Date("2026-05-02T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-02T12:00:00.000Z"),
+      },
+    ]);
+    const caller = createCaller({ documentRepository });
+
+    await expect(
+      caller.documents.getById({
+        id: "4d39229c-f714-4e3f-9ea1-77c9bfdca76c",
+      }),
+    ).resolves.toMatchObject({
+      document: {
+        filename: "signed-2062.pdf",
+      },
+      downloadUrl:
+        "https://storage.test/download/account-1/4d39229c-f714-4e3f-9ea1-77c9bfdca76c",
+    });
+  });
+});

--- a/tests/integration/trpc/documents-router.test.ts
+++ b/tests/integration/trpc/documents-router.test.ts
@@ -96,7 +96,8 @@ function createCaller({
 describe("documentsRouter", () => {
   it("initiates an upload without persisting metadata until completion", async () => {
     const documentRepository = new InMemoryDocumentRepository();
-    const caller = createCaller({ documentRepository });
+    const storagePort = new MockStoragePort();
+    const caller = createCaller({ documentRepository, storagePort });
 
     const result = await caller.documents.initiateUpload({
       filename: "signed-2062.pdf",
@@ -116,6 +117,7 @@ describe("documentsRouter", () => {
       }),
     ).resolves.toEqual([]);
 
+    storagePort.existingPaths.add(result.storagePath);
     const completed = await caller.documents.completeUpload({
       documentId: result.pendingDocument.id,
       filename: result.pendingDocument.filename,

--- a/tests/rls/documents/document-repository-rls.test.ts
+++ b/tests/rls/documents/document-repository-rls.test.ts
@@ -16,6 +16,7 @@ const ownerOneHandReceiptId = "de3d2d42-5cf8-4c0d-955f-46f81ece789a";
 const ownerTwoHandReceiptId = "948d1cfd-f171-41d4-82a0-e478a94d9614";
 const ownerOneDocumentId = "8c798729-b56e-484b-97bd-3b2689daf9f4";
 const ownerTwoDocumentId = "14675277-bd0e-4e60-9bf3-c833230df018";
+const mismatchedHandReceiptDocumentId = "71865d0d-89a7-48c9-a101-1350823acf26";
 
 const sql = postgres(databaseUrl, { max: 1 });
 const db = createDrizzleClient(databaseUrl);
@@ -75,7 +76,7 @@ describe("document repository RLS boundary", () => {
   });
 
   afterAll(async () => {
-    await sql`delete from documents where id in (${ownerOneDocumentId}, ${ownerTwoDocumentId})`;
+    await sql`delete from documents where id in (${ownerOneDocumentId}, ${ownerTwoDocumentId}, ${mismatchedHandReceiptDocumentId})`;
     await sql`delete from hand_receipts where id in (${ownerOneHandReceiptId}, ${ownerTwoHandReceiptId})`;
     await sql`delete from accounts where id in (${ownerOneAccountId}, ${ownerTwoAccountId})`;
     await sql.end();
@@ -111,6 +112,25 @@ describe("document repository RLS boundary", () => {
         mimeType: "application/pdf",
         sizeBytes: 100,
         storagePath: `${ownerTwoAccountId}/blocked`,
+        uploadedAt: new Date("2026-05-02T12:00:00.000Z"),
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("cannot create a document linked to another account's hand receipt", async () => {
+    const repository = createDrizzleDocumentRepository(db, {
+      authSubject: ownerOneId,
+    });
+
+    await expect(
+      repository.create({
+        id: mismatchedHandReceiptDocumentId,
+        accountId: ownerOneAccountId,
+        handReceiptId: ownerTwoHandReceiptId,
+        filename: "mismatched-receipt.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 100,
+        storagePath: `${ownerOneAccountId}/${mismatchedHandReceiptDocumentId}`,
         uploadedAt: new Date("2026-05-02T12:00:00.000Z"),
       }),
     ).rejects.toThrow();

--- a/tests/rls/documents/document-repository-rls.test.ts
+++ b/tests/rls/documents/document-repository-rls.test.ts
@@ -1,0 +1,118 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createDrizzleDocumentRepository } from "@/modules/documents/infrastructure/drizzle-document-repository";
+import { createDrizzleClient } from "@/modules/provider-boundaries/database/drizzle";
+
+const databaseUrl =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@127.0.0.1:54332/postgres";
+
+const ownerOneId = "better-auth-document-repository-owner-one";
+const ownerTwoId = "better-auth-document-repository-owner-two";
+const ownerOneAccountId = "cb203d86-2b05-42c4-a4f1-96f34b9a38a5";
+const ownerTwoAccountId = "4afbfd78-1046-413a-825e-5d86f6e925e1";
+const ownerOneHandReceiptId = "de3d2d42-5cf8-4c0d-955f-46f81ece789a";
+const ownerTwoHandReceiptId = "948d1cfd-f171-41d4-82a0-e478a94d9614";
+const ownerOneDocumentId = "8c798729-b56e-484b-97bd-3b2689daf9f4";
+const ownerTwoDocumentId = "14675277-bd0e-4e60-9bf3-c833230df018";
+
+const sql = postgres(databaseUrl, { max: 1 });
+const db = createDrizzleClient(databaseUrl);
+
+describe("document repository RLS boundary", () => {
+  beforeAll(async () => {
+    await sql`insert into accounts ${sql([
+      {
+        id: ownerOneAccountId,
+        auth_user_id: ownerOneId,
+        access_state: "trialing",
+        trial_starts_at: new Date("2026-04-30T12:00:00.000Z"),
+        trial_ends_at: new Date("2026-05-30T12:00:00.000Z"),
+      },
+      {
+        id: ownerTwoAccountId,
+        auth_user_id: ownerTwoId,
+        access_state: "trialing",
+        trial_starts_at: new Date("2026-04-30T12:00:00.000Z"),
+        trial_ends_at: new Date("2026-05-30T12:00:00.000Z"),
+      },
+    ])} on conflict (auth_user_id) do update set access_state = excluded.access_state`;
+
+    await sql`insert into hand_receipts ${sql([
+      {
+        id: ownerOneHandReceiptId,
+        account_id: ownerOneAccountId,
+        name: "Owner one receipt",
+      },
+      {
+        id: ownerTwoHandReceiptId,
+        account_id: ownerTwoAccountId,
+        name: "Owner two receipt",
+      },
+    ])} on conflict (id) do nothing`;
+
+    await sql`insert into documents ${sql([
+      {
+        id: ownerOneDocumentId,
+        account_id: ownerOneAccountId,
+        hand_receipt_id: ownerOneHandReceiptId,
+        filename: "owner-one.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 100,
+        storage_path: `${ownerOneAccountId}/${ownerOneDocumentId}`,
+      },
+      {
+        id: ownerTwoDocumentId,
+        account_id: ownerTwoAccountId,
+        hand_receipt_id: ownerTwoHandReceiptId,
+        filename: "owner-two.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 100,
+        storage_path: `${ownerTwoAccountId}/${ownerTwoDocumentId}`,
+      },
+    ])} on conflict (id) do nothing`;
+  });
+
+  afterAll(async () => {
+    await sql`delete from documents where id in (${ownerOneDocumentId}, ${ownerTwoDocumentId})`;
+    await sql`delete from hand_receipts where id in (${ownerOneHandReceiptId}, ${ownerTwoHandReceiptId})`;
+    await sql`delete from accounts where id in (${ownerOneAccountId}, ${ownerTwoAccountId})`;
+    await sql.end();
+  });
+
+  it("lists only rows allowed by the authenticated database session", async () => {
+    const repository = createDrizzleDocumentRepository(db, {
+      authSubject: ownerOneId,
+    });
+
+    await expect(
+      repository.listByAccountId(ownerOneAccountId),
+    ).resolves.toMatchObject([
+      {
+        id: ownerOneDocumentId,
+      },
+    ]);
+    await expect(
+      repository.listByAccountId(ownerTwoAccountId),
+    ).resolves.toEqual([]);
+  });
+
+  it("cannot create documents for another account through the repository", async () => {
+    const repository = createDrizzleDocumentRepository(db, {
+      authSubject: ownerOneId,
+    });
+
+    await expect(
+      repository.create({
+        accountId: ownerTwoAccountId,
+        handReceiptId: ownerTwoHandReceiptId,
+        filename: "blocked.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 100,
+        storagePath: `${ownerTwoAccountId}/blocked`,
+        uploadedAt: new Date("2026-05-02T12:00:00.000Z"),
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/rls/documents/documents-rls.test.ts
+++ b/tests/rls/documents/documents-rls.test.ts
@@ -14,6 +14,8 @@ const ownerTwoHandReceiptId = "2579d0ac-9085-4d9c-b975-336bd550d490";
 const ownerOneDocumentId = "b3f7d90a-7b7a-4f90-9e7a-b05fe5470599";
 const ownerTwoDocumentId = "fca2646a-8ac8-48c6-a06b-8e1f8f9236ca";
 const ownerOneInsertAllowedDocumentId = "94e067e4-c154-4a66-aa61-dd2f8dcb3568";
+const mismatchedHandReceiptDocumentId = "8a4769b9-d1cb-4902-984c-529d4d3f5587";
+const mismatchedStoragePathDocumentId = "b32fbff4-d285-47d6-b2a3-b5ad8d0cfda9";
 
 const sql = postgres(databaseUrl, { max: 1 });
 
@@ -84,7 +86,7 @@ describe("documents RLS", () => {
   });
 
   afterAll(async () => {
-    await sql`delete from documents where id in (${ownerOneDocumentId}, ${ownerTwoDocumentId}, ${ownerOneInsertAllowedDocumentId})`;
+    await sql`delete from documents where id in (${ownerOneDocumentId}, ${ownerTwoDocumentId}, ${ownerOneInsertAllowedDocumentId}, ${mismatchedHandReceiptDocumentId}, ${mismatchedStoragePathDocumentId})`;
     await sql`delete from hand_receipts where id in (${ownerOneHandReceiptId}, ${ownerTwoHandReceiptId})`;
     await sql`delete from accounts where id in (${ownerOneAccountId}, ${ownerTwoAccountId})`;
     await sql.end();
@@ -155,6 +157,58 @@ describe("documents RLS", () => {
             'application/pdf',
             100,
             ${`${ownerTwoAccountId}/blocked`}
+          )`,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("prevents an owner from linking a document to another account's hand receipt", async () => {
+    await expect(
+      asAuthenticatedOwner(
+        ownerOneId,
+        async (transaction) =>
+          transaction`insert into documents (
+            id,
+            account_id,
+            hand_receipt_id,
+            filename,
+            mime_type,
+            size_bytes,
+            storage_path
+          ) values (
+            ${mismatchedHandReceiptDocumentId},
+            ${ownerOneAccountId},
+            ${ownerTwoHandReceiptId},
+            'mismatched-receipt.pdf',
+            'application/pdf',
+            100,
+            ${`${ownerOneAccountId}/${mismatchedHandReceiptDocumentId}`}
+          )`,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("prevents an owner from inserting a document with a mismatched storage path", async () => {
+    await expect(
+      asAuthenticatedOwner(
+        ownerOneId,
+        async (transaction) =>
+          transaction`insert into documents (
+            id,
+            account_id,
+            hand_receipt_id,
+            filename,
+            mime_type,
+            size_bytes,
+            storage_path
+          ) values (
+            ${mismatchedStoragePathDocumentId},
+            ${ownerOneAccountId},
+            ${ownerOneHandReceiptId},
+            'mismatched-path.pdf',
+            'application/pdf',
+            100,
+            ${`${ownerTwoAccountId}/${mismatchedStoragePathDocumentId}`}
           )`,
       ),
     ).rejects.toThrow();

--- a/tests/rls/documents/documents-rls.test.ts
+++ b/tests/rls/documents/documents-rls.test.ts
@@ -1,0 +1,162 @@
+import postgres from "postgres";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const databaseUrl =
+  process.env.DATABASE_URL ??
+  "postgresql://postgres:postgres@127.0.0.1:54332/postgres";
+
+const ownerOneId = "better-auth-documents-owner-one";
+const ownerTwoId = "better-auth-documents-owner-two";
+const ownerOneAccountId = "9d272f75-7642-46ba-91cd-a26a8ae4277f";
+const ownerTwoAccountId = "52de8870-03f0-4f47-948a-2fa3cd5dfcf0";
+const ownerOneHandReceiptId = "63926adf-33a5-482c-8dd7-a8748bfeb957";
+const ownerTwoHandReceiptId = "2579d0ac-9085-4d9c-b975-336bd550d490";
+const ownerOneDocumentId = "b3f7d90a-7b7a-4f90-9e7a-b05fe5470599";
+const ownerTwoDocumentId = "fca2646a-8ac8-48c6-a06b-8e1f8f9236ca";
+const ownerOneInsertAllowedDocumentId = "94e067e4-c154-4a66-aa61-dd2f8dcb3568";
+
+const sql = postgres(databaseUrl, { max: 1 });
+
+async function asAuthenticatedOwner<T>(
+  authSubject: string,
+  query: (transaction: postgres.TransactionSql) => Promise<T>,
+) {
+  return sql.begin(async (transaction) => {
+    await transaction`set local role authenticated`;
+    await transaction`select set_config('app.current_auth_subject', ${authSubject}, true)`;
+
+    return query(transaction);
+  });
+}
+
+describe("documents RLS", () => {
+  beforeAll(async () => {
+    await sql`insert into accounts ${sql([
+      {
+        id: ownerOneAccountId,
+        auth_user_id: ownerOneId,
+        access_state: "trialing",
+        trial_starts_at: new Date("2026-04-30T12:00:00.000Z"),
+        trial_ends_at: new Date("2026-05-30T12:00:00.000Z"),
+      },
+      {
+        id: ownerTwoAccountId,
+        auth_user_id: ownerTwoId,
+        access_state: "trialing",
+        trial_starts_at: new Date("2026-04-30T12:00:00.000Z"),
+        trial_ends_at: new Date("2026-05-30T12:00:00.000Z"),
+      },
+    ])} on conflict (auth_user_id) do update set access_state = excluded.access_state`;
+
+    await sql`insert into hand_receipts ${sql([
+      {
+        id: ownerOneHandReceiptId,
+        account_id: ownerOneAccountId,
+        name: "Owner one receipt",
+      },
+      {
+        id: ownerTwoHandReceiptId,
+        account_id: ownerTwoAccountId,
+        name: "Owner two receipt",
+      },
+    ])} on conflict (id) do nothing`;
+
+    await sql`insert into documents ${sql([
+      {
+        id: ownerOneDocumentId,
+        account_id: ownerOneAccountId,
+        hand_receipt_id: ownerOneHandReceiptId,
+        filename: "owner-one.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 100,
+        storage_path: `${ownerOneAccountId}/${ownerOneDocumentId}`,
+      },
+      {
+        id: ownerTwoDocumentId,
+        account_id: ownerTwoAccountId,
+        hand_receipt_id: ownerTwoHandReceiptId,
+        filename: "owner-two.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 100,
+        storage_path: `${ownerTwoAccountId}/${ownerTwoDocumentId}`,
+      },
+    ])} on conflict (id) do nothing`;
+  });
+
+  afterAll(async () => {
+    await sql`delete from documents where id in (${ownerOneDocumentId}, ${ownerTwoDocumentId}, ${ownerOneInsertAllowedDocumentId})`;
+    await sql`delete from hand_receipts where id in (${ownerOneHandReceiptId}, ${ownerTwoHandReceiptId})`;
+    await sql`delete from accounts where id in (${ownerOneAccountId}, ${ownerTwoAccountId})`;
+    await sql.end();
+  });
+
+  it("allows an owner to read their own documents", async () => {
+    const rows = await asAuthenticatedOwner(
+      ownerOneId,
+      async (transaction) =>
+        transaction`select id from documents where account_id = ${ownerOneAccountId}`,
+    );
+
+    expect(rows).toEqual([{ id: ownerOneDocumentId }]);
+  });
+
+  it("prevents an owner from reading another account's documents", async () => {
+    const rows = await asAuthenticatedOwner(
+      ownerOneId,
+      async (transaction) =>
+        transaction`select id from documents where account_id = ${ownerTwoAccountId}`,
+    );
+
+    expect(rows).toEqual([]);
+  });
+
+  it("allows an owner to insert documents for their own account", async () => {
+    await expect(
+      asAuthenticatedOwner(
+        ownerOneId,
+        async (transaction) =>
+          transaction`insert into documents (
+            id,
+            account_id,
+            hand_receipt_id,
+            filename,
+            mime_type,
+            size_bytes,
+            storage_path
+          ) values (
+            ${ownerOneInsertAllowedDocumentId},
+            ${ownerOneAccountId},
+            ${ownerOneHandReceiptId},
+            'allowed.pdf',
+            'application/pdf',
+            100,
+            ${`${ownerOneAccountId}/${ownerOneInsertAllowedDocumentId}`}
+          )`,
+      ),
+    ).resolves.not.toThrow();
+  });
+
+  it("prevents an owner from inserting documents for another account", async () => {
+    await expect(
+      asAuthenticatedOwner(
+        ownerOneId,
+        async (transaction) =>
+          transaction`insert into documents (
+            account_id,
+            hand_receipt_id,
+            filename,
+            mime_type,
+            size_bytes,
+            storage_path
+          ) values (
+            ${ownerTwoAccountId},
+            ${ownerTwoHandReceiptId},
+            'blocked.pdf',
+            'application/pdf',
+            100,
+            ${`${ownerTwoAccountId}/blocked`}
+          )`,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/tests/support/app-unit-of-work.ts
+++ b/tests/support/app-unit-of-work.ts
@@ -5,6 +5,7 @@ import type {
 import { InMemoryAccountRepository } from "./account-repository";
 import { InMemoryAuditRepository } from "./audit-repository";
 import { InMemoryContactRepository } from "./contact-repository";
+import { InMemoryDocumentRepository } from "./document-repository";
 import { InMemoryHandReceiptRepository } from "./hand-receipt-repository";
 import { InMemoryItemRepository } from "./item-repository";
 import { InMemoryLocationRepository } from "./location-repository";
@@ -20,6 +21,8 @@ export function createInMemoryAppUnitOfWork(
     repositories.auditRepository ?? new InMemoryAuditRepository();
   const contactRepository =
     repositories.contactRepository ?? new InMemoryContactRepository();
+  const documentRepository =
+    repositories.documentRepository ?? new InMemoryDocumentRepository();
   const accountRepository =
     repositories.accountRepository ?? new InMemoryAccountRepository();
   const itemRepository =
@@ -66,6 +69,14 @@ export function createInMemoryAppUnitOfWork(
         inMemoryContactRepository !== null
           ? [...inMemoryContactRepository.contacts]
           : null;
+      const inMemoryDocumentRepository =
+        documentRepository instanceof InMemoryDocumentRepository
+          ? documentRepository
+          : null;
+      const documentSnapshot =
+        inMemoryDocumentRepository !== null
+          ? [...inMemoryDocumentRepository.documents]
+          : null;
       const inMemoryLocationRepository =
         locationRepository instanceof InMemoryLocationRepository
           ? locationRepository
@@ -105,6 +116,7 @@ export function createInMemoryAppUnitOfWork(
           accountRepository,
           auditRepository,
           contactRepository,
+          documentRepository,
           handReceiptRepository,
           itemRepository,
           locationRepository,
@@ -126,6 +138,10 @@ export function createInMemoryAppUnitOfWork(
 
         if (inMemoryContactRepository && contactSnapshot) {
           inMemoryContactRepository.contacts = contactSnapshot;
+        }
+
+        if (inMemoryDocumentRepository && documentSnapshot) {
+          inMemoryDocumentRepository.documents = documentSnapshot;
         }
 
         if (inMemoryLocationRepository && locationSnapshot) {

--- a/tests/support/document-repository.ts
+++ b/tests/support/document-repository.ts
@@ -1,0 +1,57 @@
+import type {
+  DocumentRecord,
+  DocumentRepository,
+  NewDocumentRecord,
+} from "@/modules/documents";
+
+export class InMemoryDocumentRepository implements DocumentRepository {
+  documents: DocumentRecord[] = [];
+
+  constructor(documents: DocumentRecord[] = []) {
+    this.documents = [...documents];
+  }
+
+  async create(document: NewDocumentRecord) {
+    const createdDocument = {
+      id: document.id ?? `document-${this.documents.length + 1}`,
+      createdAt: document.createdAt ?? new Date(),
+      updatedAt: document.updatedAt ?? new Date(),
+      ...document,
+    };
+
+    this.documents.push(createdDocument);
+    return createdDocument;
+  }
+
+  async findById(accountId: string, documentId: string) {
+    return (
+      this.documents.find(
+        (document) =>
+          document.accountId === accountId && document.id === documentId,
+      ) ?? null
+    );
+  }
+
+  async listByAccountId(accountId: string, options = {}) {
+    const { handReceiptId, limit = 50 } = options as {
+      handReceiptId?: string;
+      limit?: number;
+    };
+
+    return this.documents
+      .filter((document) => document.accountId === accountId)
+      .filter(
+        (document) =>
+          handReceiptId === undefined ||
+          document.handReceiptId === handReceiptId,
+      )
+      .sort(
+        (left, right) => right.uploadedAt.getTime() - left.uploadedAt.getTime(),
+      )
+      .slice(0, limit);
+  }
+}
+
+export function createEmptyDocumentRepository() {
+  return new InMemoryDocumentRepository();
+}

--- a/tests/support/document-repository.ts
+++ b/tests/support/document-repository.ts
@@ -13,10 +13,10 @@ export class InMemoryDocumentRepository implements DocumentRepository {
 
   async create(document: NewDocumentRecord) {
     const createdDocument = {
+      ...document,
       id: document.id ?? `document-${this.documents.length + 1}`,
       createdAt: document.createdAt ?? new Date(),
       updatedAt: document.updatedAt ?? new Date(),
-      ...document,
     };
 
     this.documents.push(createdDocument);

--- a/tests/support/storage-port.ts
+++ b/tests/support/storage-port.ts
@@ -1,0 +1,42 @@
+import type {
+  CreateSignedUploadUrlOptions,
+  SignedUploadUrl,
+  StoragePort,
+} from "@/modules/provider-boundaries/storage";
+
+export class MockStoragePort implements StoragePort {
+  uploadCalls: Array<{ path: string; options?: CreateSignedUploadUrlOptions }> =
+    [];
+  downloadCalls: Array<{ path: string; expiresIn?: number }> = [];
+  failUploads = false;
+  failDownloads = false;
+
+  async createSignedUploadUrl(
+    path: string,
+    options?: CreateSignedUploadUrlOptions,
+  ): Promise<SignedUploadUrl> {
+    this.uploadCalls.push(options === undefined ? { path } : { path, options });
+
+    if (this.failUploads) {
+      throw new Error("Storage upload URL was not created.");
+    }
+
+    return {
+      signedUrl: `https://storage.test/upload/${path}`,
+      token: `token-${path}`,
+      path,
+    };
+  }
+
+  async createSignedDownloadUrl(path: string, expiresIn?: number) {
+    this.downloadCalls.push(
+      expiresIn === undefined ? { path } : { path, expiresIn },
+    );
+
+    if (this.failDownloads) {
+      throw new Error("Storage download URL was not created.");
+    }
+
+    return `https://storage.test/download/${path}`;
+  }
+}

--- a/tests/support/storage-port.ts
+++ b/tests/support/storage-port.ts
@@ -8,8 +8,18 @@ export class MockStoragePort implements StoragePort {
   uploadCalls: Array<{ path: string; options?: CreateSignedUploadUrlOptions }> =
     [];
   downloadCalls: Array<{ path: string; expiresIn?: number }> = [];
+  existsCalls: Array<{ path: string }> = [];
+  existingPaths: Set<string>;
   failUploads = false;
   failDownloads = false;
+
+  constructor({
+    existingPaths = [],
+  }: {
+    existingPaths?: string[];
+  } = {}) {
+    this.existingPaths = new Set(existingPaths);
+  }
 
   async createSignedUploadUrl(
     path: string,
@@ -38,5 +48,10 @@ export class MockStoragePort implements StoragePort {
     }
 
     return `https://storage.test/download/${path}`;
+  }
+
+  async objectExists(path: string) {
+    this.existsCalls.push({ path });
+    return this.existingPaths.has(path);
   }
 }

--- a/tests/unit/documents/upload-document.test.ts
+++ b/tests/unit/documents/upload-document.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import {
+  completeDocumentUpload,
+  initiateDocumentUpload,
+} from "@/modules/documents";
+import { InMemoryAuditRepository } from "../../support/audit-repository";
+import { InMemoryDocumentRepository } from "../../support/document-repository";
+import { InMemoryHandReceiptRepository } from "../../support/hand-receipt-repository";
+import { MockStoragePort } from "../../support/storage-port";
+
+function createAccount(overrides: Partial<AccountRecord> = {}): AccountRecord {
+  return {
+    id: "account-1",
+    userId: "owner-1",
+    accessState: "active",
+    subscriptionTier: "base",
+    trialStartsAt: new Date("2026-04-01T12:00:00.000Z"),
+    trialEndsAt: new Date("2100-01-01T00:00:00.000Z"),
+    onboardingCompletedAt: null,
+    ...overrides,
+  };
+}
+
+function createHandReceipt(overrides = {}) {
+  return {
+    id: "hand-receipt-1",
+    accountId: "account-1",
+    name: "Primary receipt",
+    notes: null,
+    handReceiptNumber: null,
+    holderName: null,
+    unitName: null,
+    uic: null,
+    effectiveDate: null,
+    status: "active" as const,
+    createdAt: new Date("2026-05-02T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-02T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("initiateDocumentUpload", () => {
+  it("creates a signed upload URL without persisting metadata or activity", async () => {
+    const account = createAccount();
+    const documentRepository = new InMemoryDocumentRepository();
+    const auditRepository = new InMemoryAuditRepository();
+    const handReceiptRepository = new InMemoryHandReceiptRepository([
+      createHandReceipt(),
+    ]);
+    const storagePort = new MockStoragePort();
+
+    const result = await initiateDocumentUpload({
+      account,
+      input: {
+        filename: "signed-2062.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 1234,
+        handReceiptId: "hand-receipt-1",
+      },
+      handReceiptRepository,
+      storagePort,
+      now: new Date("2026-05-02T12:00:00.000Z"),
+      createDocumentId: () => "document-1",
+    });
+
+    expect(result.pendingDocument).toMatchObject({
+      id: "document-1",
+      filename: "signed-2062.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 1234,
+      handReceiptId: "hand-receipt-1",
+      storagePath: "account-1/document-1",
+    });
+    expect(result.signedUploadUrl).toBe(
+      "https://storage.test/upload/account-1/document-1",
+    );
+    expect(storagePort.uploadCalls).toMatchObject([
+      { path: "account-1/document-1" },
+    ]);
+    expect(documentRepository.documents).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
+  });
+});
+
+describe("completeDocumentUpload", () => {
+  it("persists receipt-scoped metadata and records activity after upload success", async () => {
+    const account = createAccount();
+    const documentRepository = new InMemoryDocumentRepository();
+    const auditRepository = new InMemoryAuditRepository();
+    const handReceiptRepository = new InMemoryHandReceiptRepository([
+      createHandReceipt(),
+    ]);
+
+    const result = await completeDocumentUpload({
+      account,
+      actorId: account.userId,
+      input: {
+        documentId: "document-1",
+        filename: "signed-2062.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 1234,
+        handReceiptId: "hand-receipt-1",
+      },
+      documentRepository,
+      handReceiptRepository,
+      auditRepository,
+      now: new Date("2026-05-02T12:00:00.000Z"),
+    });
+
+    expect(result.document).toMatchObject({
+      id: "document-1",
+      accountId: account.id,
+      handReceiptId: "hand-receipt-1",
+      filename: "signed-2062.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 1234,
+      storagePath: "account-1/document-1",
+    });
+    expect(auditRepository.events).toMatchObject([
+      {
+        accountId: account.id,
+        actorId: account.userId,
+        action: "document.uploaded",
+        targetType: "document",
+        targetId: "document-1",
+      },
+    ]);
+  });
+
+  it("rejects unsupported MIME types", async () => {
+    await expect(
+      initiateDocumentUpload({
+        account: createAccount(),
+        input: {
+          filename: "notes.txt",
+          mimeType: "text/plain",
+          sizeBytes: 12,
+          handReceiptId: "hand-receipt-1",
+        },
+        handReceiptRepository: new InMemoryHandReceiptRepository([
+          createHandReceipt(),
+        ]),
+        storagePort: new MockStoragePort(),
+      }),
+    ).rejects.toThrow("Unsupported document type: text/plain.");
+  });
+
+  it("blocks paused read-only accounts before storage is touched", async () => {
+    const storagePort = new MockStoragePort();
+
+    await expect(
+      initiateDocumentUpload({
+        account: createAccount({ accessState: "paused_read_only" }),
+        input: {
+          filename: "signed-2062.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 12,
+          handReceiptId: "hand-receipt-1",
+        },
+        handReceiptRepository: new InMemoryHandReceiptRepository([
+          createHandReceipt(),
+        ]),
+        storagePort,
+      }),
+    ).rejects.toThrow("This account is read-only.");
+    expect(storagePort.uploadCalls).toEqual([]);
+  });
+
+  it("rejects files over the application upload limit before storage is touched", async () => {
+    const storagePort = new MockStoragePort();
+
+    await expect(
+      initiateDocumentUpload({
+        account: createAccount(),
+        input: {
+          filename: "too-large.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 20 * 1024 * 1024 + 1,
+          handReceiptId: "hand-receipt-1",
+        },
+        handReceiptRepository: new InMemoryHandReceiptRepository([
+          createHandReceipt(),
+        ]),
+        storagePort,
+      }),
+    ).rejects.toThrow("Document file size must be 20 MiB or smaller.");
+    expect(storagePort.uploadCalls).toEqual([]);
+  });
+});

--- a/tests/unit/documents/upload-document.test.ts
+++ b/tests/unit/documents/upload-document.test.ts
@@ -106,6 +106,9 @@ describe("completeDocumentUpload", () => {
       documentRepository,
       handReceiptRepository,
       auditRepository,
+      storagePort: new MockStoragePort({
+        existingPaths: ["account-1/document-1"],
+      }),
       now: new Date("2026-05-02T12:00:00.000Z"),
     });
 
@@ -127,6 +130,37 @@ describe("completeDocumentUpload", () => {
         targetId: "document-1",
       },
     ]);
+  });
+
+  it("rejects completion when the uploaded object cannot be verified", async () => {
+    const account = createAccount();
+    const documentRepository = new InMemoryDocumentRepository();
+    const auditRepository = new InMemoryAuditRepository();
+    const handReceiptRepository = new InMemoryHandReceiptRepository([
+      createHandReceipt(),
+    ]);
+
+    await expect(
+      completeDocumentUpload({
+        account,
+        actorId: account.userId,
+        input: {
+          documentId: "document-1",
+          filename: "signed-2062.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 1234,
+          handReceiptId: "hand-receipt-1",
+        },
+        documentRepository,
+        handReceiptRepository,
+        auditRepository,
+        storagePort: new MockStoragePort(),
+        now: new Date("2026-05-02T12:00:00.000Z"),
+      }),
+    ).rejects.toThrow("Uploaded document file was not found.");
+
+    expect(documentRepository.documents).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("rejects unsupported MIME types", async () => {


### PR DESCRIPTION
## Summary

Adds the Phase 5 document upload foundation for Field Ledger:

- Adds the documents module, receipt-scoped document metadata, tRPC router, and hand receipt UI integration.
- Adds a private Supabase Storage provider boundary for signed upload and download URLs.
- Uses a two-step upload lifecycle so metadata and `document.uploaded` activity are recorded only after the browser upload succeeds.
- Adds document RLS coverage, repository tests, integration tests, and the generated Drizzle migrations.
- Updates architecture and domain docs for the document upload boundary.

## Root Cause / Review Fixes

The initial upload flow committed metadata before the file upload completed, did not preserve hand receipt context, and kept the 20 MiB upload limit only in the router. This PR moves those rules into the documents application service and keeps the UI scoped to the current hand receipt.

## Validation

- `pnpm -s lint`
- `pnpm -s exec tsc --noEmit`
- `pnpm -s test`
- `pnpm -s test:rls`
- `pnpm -s format:check`
- `pnpm -s db:generate`
- `pnpm -s db:migrate`

Playwright E2E was not run for this publish pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Release Notes: Document Upload Foundation (Phase 5)

## Overview
Added foundational document upload capabilities to Field Ledger with Supabase Storage integration, receipt-scoped metadata management, and a two-step upload lifecycle ensuring metadata persistence only after successful file upload.

## New Features

### Document Upload & Management
- **Two-step upload workflow**: Initiate signed upload URL generation, then persist metadata and audit activity only after browser upload succeeds
- **Receipt-scoped documents**: Documents are associated with hand receipts and scoped to account ownership
- **Document listing & retrieval**: Filter documents by hand receipt with download URL generation
- **File constraints**: Supported MIME types (PDF, JPEG, PNG, WEBP, HEIC), 20 MiB upload limit

### UI Components
- **DocumentUpload component**: React component with file validation, status tracking, and signed URL upload handling
- **DocumentList component**: Display documents with download functionality and formatted metadata
- **Hand Receipt integration**: Document upload and list views now embedded in hand receipt detail page

### tRPC Router
New `documents` router with procedures:
- `initiateUpload`: Generate signed upload URL and pending document
- `completeUpload`: Persist metadata and emit audit activity after upload
- `list`: Query documents with optional hand receipt filtering
- `getById`: Retrieve document with signed download URL

## Database Changes

### New `documents` Table
- Account and hand receipt scoping with foreign keys
- File metadata: filename, MIME type, size, storage path
- Timestamps: uploaded_at, created_at, updated_at
- Composite indexes on (account_id, created_at DESC) and (account_id, hand_receipt_id)
- Unique constraint on (account_id, storage_path)
- **Row-Level Security** (RLS): Authenticated users can only access/insert their own account's documents

### Migrations
- `0021_green_maestro.sql`: Create documents table with RLS policies
- `0022_slippery_polaris.sql`: Add hand_receipt_id foreign key constraint

## Infrastructure

### Storage Provider Boundary
- **StoragePort interface**: Abstraction for signed URL generation
- **Supabase adapter**: Implementation using Supabase Storage (`documents` bucket)
- Signed upload URLs with optional expiration (default 600s for downloads)
- Environment variables: `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`

### TRPC Context & Router
- Document repository and storage port added to TRPC context
- Error translation: Maps domain errors to appropriate tRPC error codes (FORBIDDEN, BAD_REQUEST, NOT_FOUND)
- Unit-of-work pattern: Transactional document creation

## Documentation Updates
- **architecture.md**: Document upload ownership and validation boundary
- **domain-model.md**: Expanded Documents section with metadata schema, storage path format (`{account_id}/{document_id}`), and two-step workflow
- **Phase 5 PRD**: New product requirements for Documents and 2062 Assignments

## Testing Coverage

### Integration Tests
- `documents-router.test.ts`: Upload initiation, completion, hand receipt filtering, read-only rejection, MIME validation, download URL generation

### RLS Tests
- `documents-rls.test.ts`: Owner data isolation at database level
- `document-repository-rls.test.ts`: Repository enforcement of account-scoped access

### Unit Tests
- `upload-document.test.ts`: Upload validation (MIME types, size limits, read-only blocks), metadata persistence, audit event recording

### Test Support
- In-memory `DocumentRepository` for testing
- `MockStoragePort` for testing signed URL generation

## Dependencies
- Added: `@supabase/supabase-js` (^2.105.1)

## Configuration
- **supabase/config.toml**: New `documents` bucket with 20 MiB limit and restricted MIME types
- **.env.example**: Added local Supabase Storage and service role configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->