### PR TITLE
Add multi-item 2062 upload flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ build/
 # test artifacts
 test-results/
 playwright-report/
+tmp/

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -234,6 +234,11 @@ Rules:
 - One 2062 assignment belongs to one hand receipt.
 - One item can have at most one active 2062 link.
 - Items may have many historical closed 2062 links.
+- Multi-item upload starts from hand receipt detail, uses one contact and one
+  private document for the assignment, and links only selected active items from
+  that hand receipt.
+- Assignment item-link RLS also enforces same-hand-receipt scope so a row cannot
+  connect an assignment to an item from another hand receipt.
 - Uploading a 2062 for a manually signed-to item converts it to formal 2062 coverage.
 - Closing a 2062 clears current signed-to state for linked items.
 - Individual item links can be closed when one item is returned.

--- a/drizzle/0025_assignment_link_same_receipt.sql
+++ b/drizzle/0025_assignment_link_same_receipt.sql
@@ -1,0 +1,38 @@
+CREATE POLICY "assignment_item_links_same_hand_receipt_insert"
+ON "assignment_item_links"
+AS RESTRICTIVE
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM "items"
+    WHERE "items"."id" = "assignment_item_links"."item_id"
+      AND "items"."account_id" = "assignment_item_links"."account_id"
+      AND "items"."hand_receipt_id" = (
+        SELECT "assignments"."hand_receipt_id"
+        FROM "assignments"
+        WHERE "assignments"."id" = "assignment_item_links"."assignment_id"
+          AND "assignments"."account_id" = "assignment_item_links"."account_id"
+      )
+  )
+);--> statement-breakpoint
+CREATE POLICY "assignment_item_links_same_hand_receipt_update"
+ON "assignment_item_links"
+AS RESTRICTIVE
+FOR UPDATE
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1
+    FROM "items"
+    WHERE "items"."id" = "assignment_item_links"."item_id"
+      AND "items"."account_id" = "assignment_item_links"."account_id"
+      AND "items"."hand_receipt_id" = (
+        SELECT "assignments"."hand_receipt_id"
+        FROM "assignments"
+        WHERE "assignments"."id" = "assignment_item_links"."assignment_id"
+          AND "assignments"."account_id" = "assignment_item_links"."account_id"
+      )
+  )
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1777768000000,
       "tag": "0024_repair_assignment_link_closed_state_check",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1777770000000,
+      "tag": "0025_assignment_link_same_receipt",
+      "breakpoints": true
     }
   ]
 }

--- a/plans/06-documents-2062.md
+++ b/plans/06-documents-2062.md
@@ -60,19 +60,21 @@ Implement `/app/items/[itemId]/upload-2062` as a focused one-item assignment flo
 
 **User stories covered**: As a user, I can upload one 2062 and link it to multiple items from the same hand receipt.
 
+**Status**: Implemented by issue #61.
+
 ### What To Build
 
 Implement `/app/hand-receipts/[handReceiptId]/upload-2062` with contact selection, document upload, and multi-item selection limited to the current hand receipt.
 
 ### Acceptance Criteria
 
-- [ ] Flow starts from hand receipt detail.
-- [ ] User selects or creates a required contact.
-- [ ] User uploads a required document.
-- [ ] User selects at least one item from the current hand receipt.
-- [ ] Items from other hand receipts cannot be selected.
-- [ ] Linked items show signed-to state from active 2062 coverage.
-- [ ] Creation emits audit events.
+- [x] Flow starts from hand receipt detail.
+- [x] User selects or creates a required contact.
+- [x] User uploads a required document.
+- [x] User selects at least one item from the current hand receipt.
+- [x] Items from other hand receipts cannot be selected.
+- [x] Linked items show signed-to state from active 2062 coverage.
+- [x] Creation emits audit events.
 
 ---
 
@@ -129,4 +131,3 @@ Tie active 2062 constraints into item move/archive behavior.
 - [ ] Archiving an item with active 2062 is allowed with warning and closes that item link.
 - [ ] If archiving closes the last active link on a 2062, the user is prompted to close the assignment.
 - [ ] All state changes emit audit events.
-

--- a/src/app/(protected)/app/hand-receipts/[id]/upload-2062/page.tsx
+++ b/src/app/(protected)/app/hand-receipts/[id]/upload-2062/page.tsx
@@ -1,0 +1,15 @@
+import { Upload2062Flow } from "@/modules/assignments-2062/ui/upload-2062-flow";
+
+type HandReceiptUpload2062PageProps = {
+  params: Promise<{
+    id: string;
+  }>;
+};
+
+export default async function HandReceiptUpload2062Page({
+  params,
+}: HandReceiptUpload2062PageProps) {
+  const { id } = await params;
+
+  return <Upload2062Flow handReceiptId={id} />;
+}

--- a/src/modules/assignments-2062/application/create-assignment.ts
+++ b/src/modules/assignments-2062/application/create-assignment.ts
@@ -3,10 +3,15 @@ import { recordAuditEvent, type AuditRepository } from "@/modules/audit";
 import { deriveAccountCapabilities } from "@/modules/billing";
 import { createContact, type ContactRepository } from "@/modules/contacts";
 import type { DocumentRepository } from "@/modules/documents";
+import type { HandReceiptRepository } from "@/modules/hand-receipts";
 import type { ItemRepository } from "@/modules/items";
 import type { AssignmentItemLinkRepository } from "./assignment-item-link-repository";
 import type { AssignmentRepository } from "./assignment-repository";
-import type { CreateAssignmentInput } from "./types";
+import type {
+  AssignmentItemLinkRecord,
+  CreateAssignmentInput,
+  CreateAssignmentWithItemsInput,
+} from "./types";
 
 type CreateAssignmentArgs = {
   account: AccountRecord;
@@ -186,5 +191,213 @@ export async function createAssignment({
       documentFilename: document.filename,
     },
     link,
+  };
+}
+
+export async function createAssignmentWithItems({
+  account,
+  actorId,
+  input,
+  assignmentRepository,
+  assignmentItemLinkRepository,
+  auditRepository,
+  contactRepository,
+  documentRepository,
+  handReceiptRepository,
+  itemRepository,
+  now = new Date(),
+  createAssignmentId = () => globalThis.crypto.randomUUID(),
+  createAssignmentItemLinkId = () => globalThis.crypto.randomUUID(),
+}: Omit<CreateAssignmentArgs, "input"> & {
+  input: CreateAssignmentWithItemsInput;
+  handReceiptRepository: HandReceiptRepository;
+}) {
+  const capabilities = deriveAccountCapabilities(account, now);
+
+  if (capabilities.isReadOnly) {
+    throw new Error("This account is read-only.");
+  }
+
+  const uniqueItemIds = Array.from(new Set(input.itemIds));
+
+  if (uniqueItemIds.length === 0) {
+    throw new Error("Select at least one item.");
+  }
+
+  const handReceipt = await handReceiptRepository.findById(
+    account.id,
+    input.handReceiptId,
+  );
+
+  if (!handReceipt) {
+    throw new Error("Hand receipt was not found.");
+  }
+
+  if (handReceipt.status !== "active") {
+    throw new Error("Hand receipt must be active to upload a 2062.");
+  }
+
+  const contact =
+    "contactId" in input && input.contactId
+      ? await contactRepository.findById(account.id, input.contactId)
+      : await createContact({
+          account,
+          actorId,
+          input: { displayName: input.contactDisplayName ?? "" },
+          contactRepository,
+          auditRepository,
+          now,
+        });
+
+  if (!contact) {
+    throw new Error("Contact was not found.");
+  }
+
+  const document = await documentRepository.findById(
+    account.id,
+    input.documentId,
+  );
+
+  if (!document) {
+    throw new Error("Document was not found.");
+  }
+
+  if (document.handReceiptId !== input.handReceiptId) {
+    throw new Error("Document must belong to the hand receipt.");
+  }
+
+  const items = await Promise.all(
+    uniqueItemIds.map((itemId) => itemRepository.findById(account.id, itemId)),
+  );
+
+  if (items.some((item) => item === null)) {
+    throw new Error("Item was not found.");
+  }
+
+  const activeItems = items.map((item) => {
+    if (!item) {
+      throw new Error("Item was not found.");
+    }
+
+    if (item.status !== "active") {
+      throw new Error("Items must be active to upload a 2062.");
+    }
+
+    if (item.handReceiptId !== input.handReceiptId) {
+      throw new Error("Items must belong to the selected hand receipt.");
+    }
+
+    return item;
+  });
+
+  const activeLinks = await Promise.all(
+    activeItems.map((item) =>
+      assignmentItemLinkRepository.findActiveByItemId(account.id, item.id),
+    ),
+  );
+
+  if (activeLinks.some(Boolean)) {
+    throw new Active2062CoverageConflictError();
+  }
+
+  const assignment = await assignmentRepository.create({
+    id: createAssignmentId(),
+    accountId: account.id,
+    handReceiptId: input.handReceiptId,
+    contactId: contact.id,
+    documentId: document.id,
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const links: AssignmentItemLinkRecord[] = [];
+
+  try {
+    for (const item of activeItems) {
+      links.push(
+        await assignmentItemLinkRepository.create({
+          id: createAssignmentItemLinkId(),
+          accountId: account.id,
+          assignmentId: assignment.id,
+          itemId: item.id,
+          status: "active",
+          closedAt: null,
+          createdAt: now,
+          updatedAt: now,
+        }),
+      );
+    }
+  } catch (error) {
+    if (isUniqueViolation(error)) {
+      throw new Active2062CoverageConflictError();
+    }
+
+    throw error;
+  }
+
+  await Promise.all(
+    activeItems
+      .filter((item) => item.signedToContactId !== null)
+      .map(async (item) => {
+        const updatedItem = await itemRepository.update(account.id, item.id, {
+          signedToContactId: null,
+          updatedAt: now,
+        });
+
+        if (!updatedItem) {
+          throw new Error("Item signed-to state was not cleared.");
+        }
+      }),
+  );
+
+  await recordAuditEvent({
+    accountId: account.id,
+    actorId,
+    action: "assignment.created",
+    target: { type: "assignment", id: assignment.id },
+    metadata: {
+      handReceiptId: input.handReceiptId,
+      itemIds: activeItems.map((item) => item.id),
+      itemCount: activeItems.length,
+      contactId: contact.id,
+      contactName: contact.displayName,
+      documentId: document.id,
+      documentFilename: document.filename,
+      convertedFromManualSignedToCount: activeItems.filter(
+        (item) => item.signedToContactId !== null,
+      ).length,
+    },
+    occurredAt: now,
+    repository: auditRepository,
+  });
+
+  for (const item of activeItems) {
+    await recordAuditEvent({
+      accountId: account.id,
+      actorId,
+      action: "assignment_item_link.created",
+      target: { type: "item", id: item.id },
+      metadata: {
+        assignmentId: assignment.id,
+        contactId: contact.id,
+        contactName: contact.displayName,
+        documentId: document.id,
+        documentFilename: document.filename,
+        itemIdentifier: item.ecn ?? item.serialNumber ?? item.generatedId,
+      },
+      occurredAt: now,
+      repository: auditRepository,
+    });
+  }
+
+  return {
+    assignment: {
+      ...assignment,
+      contactName: contact.displayName,
+      documentFilename: document.filename,
+    },
+    links,
+    items: activeItems,
   };
 }

--- a/src/modules/assignments-2062/application/create-assignment.ts
+++ b/src/modules/assignments-2062/application/create-assignment.ts
@@ -22,6 +22,7 @@ type CreateAssignmentArgs = {
   auditRepository: AuditRepository;
   contactRepository: ContactRepository;
   documentRepository: DocumentRepository;
+  handReceiptRepository: HandReceiptRepository;
   itemRepository: ItemRepository;
   now?: Date;
   createAssignmentId?: () => string;
@@ -52,6 +53,7 @@ export async function createAssignment({
   auditRepository,
   contactRepository,
   documentRepository,
+  handReceiptRepository,
   itemRepository,
   now = new Date(),
   createAssignmentId = () => globalThis.crypto.randomUUID(),
@@ -71,6 +73,19 @@ export async function createAssignment({
 
   if (item.status !== "active") {
     throw new Error("Item must be active to upload a 2062.");
+  }
+
+  const handReceipt = await handReceiptRepository.findById(
+    account.id,
+    item.handReceiptId,
+  );
+
+  if (!handReceipt) {
+    throw new Error("Hand receipt was not found.");
+  }
+
+  if (handReceipt.status !== "active") {
+    throw new Error("Hand receipt must be active to upload a 2062.");
   }
 
   const activeLink = await assignmentItemLinkRepository.findActiveByItemId(

--- a/src/modules/assignments-2062/application/types.ts
+++ b/src/modules/assignments-2062/application/types.ts
@@ -61,3 +61,19 @@ export type CreateAssignmentInput =
       contactDisplayName: string;
       documentId: string;
     };
+
+export type CreateAssignmentWithItemsInput =
+  | {
+      handReceiptId: string;
+      itemIds: string[];
+      contactId: string;
+      contactDisplayName?: never;
+      documentId: string;
+    }
+  | {
+      handReceiptId: string;
+      itemIds: string[];
+      contactId?: never;
+      contactDisplayName: string;
+      documentId: string;
+    };

--- a/src/modules/assignments-2062/index.ts
+++ b/src/modules/assignments-2062/index.ts
@@ -5,6 +5,7 @@ export { createUnavailableAssignmentRepository } from "./application/assignment-
 export {
   Active2062CoverageConflictError,
   createAssignment,
+  createAssignmentWithItems,
 } from "./application/create-assignment";
 export { hasActive2062Coverage } from "./application/has-active-2062-coverage";
 export type {
@@ -13,6 +14,7 @@ export type {
   AssignmentRecord,
   AssignmentStatus,
   CreateAssignmentInput,
+  CreateAssignmentWithItemsInput,
   NewAssignmentItemLinkRecord,
   NewAssignmentRecord,
 } from "./application/types";

--- a/src/modules/assignments-2062/ui/upload-2062-flow.tsx
+++ b/src/modules/assignments-2062/ui/upload-2062-flow.tsx
@@ -1,0 +1,622 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ClipboardCheck,
+  FileText,
+  Loader2,
+  PackageCheck,
+  Search,
+  ShieldCheck,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ContactPicker } from "@/modules/contacts/ui/contact-picker";
+import { DocumentUpload } from "@/modules/documents/ui/document-upload";
+import type { ItemRecord } from "@/modules/items";
+import { trpc } from "@/trpc/react";
+
+type Step = "contact" | "document" | "items" | "summary";
+
+const steps: { id: Step; label: string }[] = [
+  { id: "contact", label: "Contact" },
+  { id: "document", label: "Document" },
+  { id: "items", label: "Items" },
+  { id: "summary", label: "Summary" },
+];
+
+function getPrimaryIdentifier(item: ItemRecord) {
+  if (item.ecn) {
+    return `ECN ${item.ecn}`;
+  }
+
+  if (item.serialNumber) {
+    return `Serial ${item.serialNumber}`;
+  }
+
+  return item.generatedId ?? "No identifier";
+}
+
+function itemMatchesQuery(item: ItemRecord, query: string) {
+  const normalized = query.trim().toLocaleLowerCase();
+
+  if (!normalized) {
+    return true;
+  }
+
+  return [
+    item.nomenclature,
+    item.ecn,
+    item.serialNumber,
+    item.generatedId,
+    item.signedToContactName,
+    item.active2062Coverage?.contactName,
+  ].some((value) => value?.toLocaleLowerCase().includes(normalized));
+}
+
+function StepRail({ currentStep }: { currentStep: Step }) {
+  const currentIndex = steps.findIndex((step) => step.id === currentStep);
+
+  return (
+    <ol className="grid gap-2 sm:grid-cols-4">
+      {steps.map((step, index) => {
+        const isCurrent = step.id === currentStep;
+        const isComplete = index < currentIndex;
+
+        return (
+          <li
+            className="flex items-center gap-2 rounded-md border bg-card px-3 py-2 text-xs"
+            key={step.id}
+          >
+            <span
+              className={
+                isCurrent || isComplete
+                  ? "flex size-5 items-center justify-center rounded-sm bg-primary font-mono text-[0.68rem] text-primary-foreground"
+                  : "flex size-5 items-center justify-center rounded-sm bg-secondary font-mono text-[0.68rem] text-muted-foreground"
+              }
+            >
+              {isComplete ? (
+                <CheckCircle2 aria-hidden="true" className="size-3" />
+              ) : (
+                index + 1
+              )}
+            </span>
+            <span
+              className={
+                isCurrent
+                  ? "font-semibold text-foreground"
+                  : "text-muted-foreground"
+              }
+            >
+              {step.label}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function ItemSelector({
+  disabled,
+  items,
+  selectedItemIds,
+  setSelectedItemIds,
+}: {
+  disabled: boolean;
+  items: ItemRecord[];
+  selectedItemIds: string[];
+  setSelectedItemIds: (itemIds: string[]) => void;
+}) {
+  const searchId = useId();
+  const [query, setQuery] = useState("");
+  const visibleItems = items.filter((item) => itemMatchesQuery(item, query));
+  const selectedSet = new Set(selectedItemIds);
+
+  function toggleItem(item: ItemRecord) {
+    if (disabled || item.active2062Coverage) {
+      return;
+    }
+
+    if (selectedSet.has(item.id)) {
+      setSelectedItemIds(selectedItemIds.filter((id) => id !== item.id));
+      return;
+    }
+
+    setSelectedItemIds([...selectedItemIds, item.id]);
+  }
+
+  return (
+    <section className="space-y-4 rounded-lg border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+          <PackageCheck aria-hidden="true" className="size-4" />
+        </span>
+        <div className="min-w-0 space-y-1">
+          <h2 className="text-sm font-semibold tracking-normal">
+            Select property
+          </h2>
+          <p className="text-sm leading-6 text-muted-foreground">
+            Choose active items from this hand receipt. Items already under an
+            active 2062 stay visible but cannot be selected.
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-md border bg-background px-3 py-2">
+        <label
+          className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground"
+          htmlFor={searchId}
+        >
+          <Search aria-hidden="true" className="size-3.5" />
+          Narrow items
+        </label>
+        <Input
+          disabled={disabled}
+          id={searchId}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search nomenclature, ECN, serial, or FL ID"
+          value={query}
+        />
+      </div>
+
+      {visibleItems.length === 0 ? (
+        <div className="rounded-lg border bg-background p-4 text-sm text-muted-foreground">
+          No active items match this search.
+        </div>
+      ) : (
+        <div className="divide-y rounded-lg border bg-background">
+          {visibleItems.map((item) => {
+            const isSelected = selectedSet.has(item.id);
+            const ineligible = Boolean(item.active2062Coverage);
+
+            return (
+              <label
+                className={
+                  ineligible
+                    ? "grid gap-3 p-3 text-muted-foreground sm:grid-cols-[auto_minmax(0,1fr)_auto]"
+                    : "grid cursor-pointer gap-3 p-3 transition-colors hover:bg-secondary sm:grid-cols-[auto_minmax(0,1fr)_auto]"
+                }
+                key={item.id}
+              >
+                <input
+                  checked={isSelected}
+                  className="mt-1 size-4 accent-primary"
+                  disabled={disabled || ineligible}
+                  onChange={() => toggleItem(item)}
+                  type="checkbox"
+                />
+                <span className="min-w-0">
+                  <span className="block truncate text-sm font-semibold text-foreground">
+                    {item.nomenclature}
+                  </span>
+                  <span className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                    <span className="font-mono">
+                      {getPrimaryIdentifier(item)}
+                    </span>
+                    {item.signedToContactName ? (
+                      <span>Manual signed to {item.signedToContactName}</span>
+                    ) : null}
+                  </span>
+                </span>
+                {ineligible ? (
+                  <span className="w-fit rounded-sm border px-2 py-1 font-mono text-[0.68rem] uppercase">
+                    Active 2062
+                  </span>
+                ) : isSelected ? (
+                  <span className="w-fit rounded-sm bg-primary px-2 py-1 font-mono text-[0.68rem] uppercase text-primary-foreground">
+                    Selected
+                  </span>
+                ) : null}
+              </label>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function Upload2062Flow({ handReceiptId }: { handReceiptId: string }) {
+  const router = useRouter();
+  const utilities = trpc.useUtils();
+  const [step, setStep] = useState<Step>("contact");
+  const [selectedContactId, setSelectedContactId] = useState("");
+  const [selectedContactDisplayName, setSelectedContactDisplayName] =
+    useState("");
+  const [newContactDisplayName, setNewContactDisplayName] = useState("");
+  const [selectedDocumentId, setSelectedDocumentId] = useState("");
+  const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
+  const [formError, setFormError] = useState<string | null>(null);
+  const handReceiptQuery = trpc.handReceipts.getById.useQuery({
+    id: handReceiptId,
+  });
+  const capabilitiesQuery = trpc.billing.capabilities.useQuery();
+  const documentsQuery = trpc.documents.list.useQuery({ handReceiptId });
+  const itemsQuery = trpc.items.listByHandReceipt.useQuery({
+    handReceiptId,
+    status: "active",
+  });
+  const handReceipt = handReceiptQuery.data;
+  const documents = documentsQuery.data ?? [];
+  const items = itemsQuery.data ?? [];
+  const selectedItems = items.filter(
+    (item) => selectedItemIds.includes(item.id) && !item.active2062Coverage,
+  );
+  const validSelectedItemIds = selectedItems.map((item) => item.id);
+  const selectedDocument = documents.find(
+    (document) => document.id === selectedDocumentId,
+  );
+  const selectedContactName = useMemo(() => {
+    if (newContactDisplayName) {
+      return newContactDisplayName;
+    }
+
+    return selectedContactId
+      ? selectedContactDisplayName || "Selected contact"
+      : null;
+  }, [newContactDisplayName, selectedContactDisplayName, selectedContactId]);
+  const isReadOnly = capabilitiesQuery.data?.isReadOnly ?? false;
+  const isArchived = handReceipt?.status === "archived";
+  const isDisabled = isReadOnly || isArchived;
+  const createAssignment = trpc.assignments2062.createWithItems.useMutation({
+    onSuccess: async () => {
+      await Promise.all([
+        utilities.items.listByHandReceipt.invalidate({ handReceiptId }),
+        utilities.items.search.invalidate(),
+        utilities.handReceipts.getById.invalidate({ id: handReceiptId }),
+        utilities.audit.listRecentActivity.invalidate(),
+        utilities.audit.listTargetActivity.invalidate({
+          targetType: "hand_receipt",
+          targetId: handReceiptId,
+        }),
+      ]);
+      router.push(`/app/hand-receipts/${handReceiptId}`);
+    },
+    onError: (error) => setFormError(error.message),
+  });
+
+  if (handReceiptQuery.isLoading) {
+    return (
+      <section className="space-y-4">
+        <div className="h-9 w-40 rounded-lg bg-secondary" />
+        <div className="h-24 rounded-lg border bg-card" />
+        <div className="h-96 rounded-lg border bg-card" />
+      </section>
+    );
+  }
+
+  if (handReceiptQuery.error || !handReceipt) {
+    return (
+      <section className="space-y-4">
+        <Button asChild variant="outline">
+          <Link href="/app/hand-receipts">
+            <ArrowLeft aria-hidden="true" className="size-4" />
+            Hand Receipts
+          </Link>
+        </Button>
+        <div className="rounded-lg border bg-card p-4">
+          <h1 className="text-xl font-semibold tracking-normal">
+            Hand receipt not found
+          </h1>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            This upload flow is unavailable or outside the current account.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  function goNext(nextStep: Step) {
+    setFormError(null);
+    setStep(nextStep);
+  }
+
+  function submit() {
+    setFormError(null);
+
+    if (!selectedContactId && !newContactDisplayName.trim()) {
+      setFormError("Select or create a contact before continuing.");
+      setStep("contact");
+      return;
+    }
+
+    if (!selectedDocumentId) {
+      setFormError("Select a private document before creating the 2062.");
+      setStep("document");
+      return;
+    }
+
+    if (validSelectedItemIds.length === 0) {
+      setFormError("Select at least one item.");
+      setStep("items");
+      return;
+    }
+
+    createAssignment.mutate(
+      selectedContactId
+        ? {
+            handReceiptId,
+            itemIds: validSelectedItemIds,
+            contactId: selectedContactId,
+            documentId: selectedDocumentId,
+          }
+        : {
+            handReceiptId,
+            itemIds: validSelectedItemIds,
+            contactDisplayName: newContactDisplayName.trim(),
+            documentId: selectedDocumentId,
+          },
+    );
+  }
+
+  return (
+    <section className="space-y-5">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-3">
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/app/hand-receipts/${handReceiptId}`}>
+              <ArrowLeft aria-hidden="true" className="size-4" />
+              Hand Receipt
+            </Link>
+          </Button>
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+              Upload 2062
+            </p>
+            <h1 className="max-w-3xl text-2xl font-semibold tracking-normal md:text-3xl">
+              {handReceipt.name}
+            </h1>
+          </div>
+        </div>
+        <div className="flex w-fit items-center gap-2 rounded-lg border bg-secondary px-3 py-2 font-mono text-xs text-muted-foreground">
+          <ShieldCheck aria-hidden="true" className="size-4" />
+          Formal coverage
+        </div>
+      </div>
+
+      {isDisabled ? (
+        <p className="rounded-lg border bg-secondary px-4 py-3 text-sm text-muted-foreground">
+          {isReadOnly
+            ? "This account is read-only. Existing records remain available, but new 2062 assignments are paused."
+            : "Archived hand receipts cannot receive new 2062 assignments."}
+        </p>
+      ) : null}
+
+      <StepRail currentStep={step} />
+
+      {formError ? (
+        <p
+          className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
+          role="alert"
+        >
+          {formError}
+        </p>
+      ) : null}
+
+      {step === "contact" ? (
+        <div className="space-y-4">
+          <ContactPicker
+            currentContactName={selectedContactName}
+            disabled={isDisabled || createAssignment.isPending}
+            disabledReason="2062 creation is unavailable for this hand receipt."
+            isPending={createAssignment.isPending}
+            onAssignExisting={(contact) => {
+              setSelectedContactId(contact.id);
+              setSelectedContactDisplayName(contact.displayName);
+              setNewContactDisplayName("");
+            }}
+            onAssignNew={(displayName) => {
+              setSelectedContactId("");
+              setSelectedContactDisplayName("");
+              setNewContactDisplayName(displayName);
+            }}
+            onClear={() => {
+              setSelectedContactId("");
+              setSelectedContactDisplayName("");
+              setNewContactDisplayName("");
+            }}
+          />
+          <div className="flex justify-end">
+            <Button
+              disabled={
+                isDisabled ||
+                (!selectedContactId && !newContactDisplayName.trim())
+              }
+              onClick={() => goNext("document")}
+              type="button"
+            >
+              Continue to document
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {step === "document" ? (
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          <section className="space-y-3 rounded-lg border bg-card p-4">
+            <div className="flex items-start gap-3">
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+                <FileText aria-hidden="true" className="size-4" />
+              </span>
+              <div className="min-w-0 space-y-1">
+                <h2 className="text-sm font-semibold tracking-normal">
+                  Private document
+                </h2>
+                <p className="text-sm leading-6 text-muted-foreground">
+                  Select a saved PDF or image from this hand receipt.
+                </p>
+              </div>
+            </div>
+            <select
+              aria-label="Select document"
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+              disabled={
+                isDisabled ||
+                createAssignment.isPending ||
+                documentsQuery.isLoading
+              }
+              onChange={(event) => setSelectedDocumentId(event.target.value)}
+              value={selectedDocumentId}
+            >
+              <option value="">Select document</option>
+              {documents.map((document) => (
+                <option key={document.id} value={document.id}>
+                  {document.filename}
+                </option>
+              ))}
+            </select>
+            {documents.length === 0 && !documentsQuery.isLoading ? (
+              <p className="text-sm text-muted-foreground">
+                Upload a document, then select it here.
+              </p>
+            ) : null}
+            <div className="flex justify-between gap-2">
+              <Button
+                onClick={() => goNext("contact")}
+                type="button"
+                variant="outline"
+              >
+                Back
+              </Button>
+              <Button
+                disabled={isDisabled || !selectedDocumentId}
+                onClick={() => goNext("items")}
+                type="button"
+              >
+                Continue to items
+              </Button>
+            </div>
+          </section>
+          <DocumentUpload
+            disabled={isDisabled}
+            handReceiptId={handReceiptId}
+            onUploadComplete={() =>
+              utilities.documents.list.invalidate({ handReceiptId })
+            }
+          />
+        </div>
+      ) : null}
+
+      {step === "items" ? (
+        <div className="space-y-4">
+          <ItemSelector
+            disabled={isDisabled || createAssignment.isPending}
+            items={items}
+            selectedItemIds={validSelectedItemIds}
+            setSelectedItemIds={setSelectedItemIds}
+          />
+          <div className="flex justify-between gap-2">
+            <Button
+              onClick={() => goNext("document")}
+              type="button"
+              variant="outline"
+            >
+              Back
+            </Button>
+            <Button
+              disabled={isDisabled || validSelectedItemIds.length === 0}
+              onClick={() => goNext("summary")}
+              type="button"
+            >
+              Review {validSelectedItemIds.length || ""} items
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {step === "summary" ? (
+        <section className="space-y-4 rounded-lg border bg-card p-4">
+          <div className="flex items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+              <ClipboardCheck aria-hidden="true" className="size-4" />
+            </span>
+            <div className="min-w-0 space-y-1">
+              <h2 className="text-sm font-semibold tracking-normal">
+                Filing summary
+              </h2>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Confirm the contact, document, and covered items before creating
+                active formal 2062 coverage.
+              </p>
+            </div>
+          </div>
+          <dl className="grid gap-3 md:grid-cols-3">
+            <div className="rounded-md border bg-background p-3">
+              <dt className="font-mono text-[0.68rem] uppercase text-muted-foreground">
+                Contact
+              </dt>
+              <dd className="mt-1 text-sm font-semibold">
+                {selectedContactName ?? "Not selected"}
+              </dd>
+            </div>
+            <div className="rounded-md border bg-background p-3">
+              <dt className="font-mono text-[0.68rem] uppercase text-muted-foreground">
+                Document
+              </dt>
+              <dd className="mt-1 truncate text-sm font-semibold">
+                {selectedDocument?.filename ?? "Not selected"}
+              </dd>
+            </div>
+            <div className="rounded-md border bg-background p-3">
+              <dt className="font-mono text-[0.68rem] uppercase text-muted-foreground">
+                Items
+              </dt>
+              <dd className="mt-1 text-sm font-semibold">
+                {selectedItems.length} selected
+              </dd>
+            </div>
+          </dl>
+          <div className="divide-y rounded-lg border bg-background">
+            {selectedItems.map((item) => (
+              <div
+                className="flex items-start justify-between gap-3 p-3"
+                key={item.id}
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-semibold">
+                    {item.nomenclature}
+                  </p>
+                  <p className="font-mono text-xs text-muted-foreground">
+                    {getPrimaryIdentifier(item)}
+                  </p>
+                </div>
+                <span className="rounded-sm border px-2 py-1 font-mono text-[0.68rem] uppercase text-muted-foreground">
+                  New 2062
+                </span>
+              </div>
+            ))}
+          </div>
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+            <Button
+              onClick={() => goNext("items")}
+              type="button"
+              variant="outline"
+            >
+              Back
+            </Button>
+            <Button
+              disabled={isDisabled || createAssignment.isPending}
+              onClick={submit}
+              type="button"
+            >
+              {createAssignment.isPending ? (
+                <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+              ) : (
+                <CheckCircle2 aria-hidden="true" className="size-4" />
+              )}
+              {createAssignment.isPending
+                ? "Creating assignment"
+                : "Create assignment"}
+            </Button>
+          </div>
+        </section>
+      ) : null}
+    </section>
+  );
+}

--- a/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
+++ b/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeft,
   CalendarDays,
   ClipboardList,
+  FileUp,
   History,
   Pencil,
   RotateCcw,
@@ -424,18 +425,50 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
                   records when you need preserved item history.
                 </p>
               </div>
-              {!isViewingArchivedItems ? (
-                <CreateItemForm
-                  canCreate={!isReadOnly && handReceipt.status === "active"}
-                  disabledReason={createItemDisabledReason}
-                  onSubmit={(input) =>
-                    createItemMutation.mutateAsync({
-                      handReceiptId,
-                      ...input,
-                    })
-                  }
-                />
-              ) : null}
+              <div className="flex flex-wrap gap-2">
+                {!isViewingArchivedItems ? (
+                  <>
+                    <Button
+                      asChild={!isReadOnly && handReceipt.status === "active"}
+                      disabled={isReadOnly || handReceipt.status !== "active"}
+                      size="sm"
+                      title={
+                        isReadOnly
+                          ? "2062 creation is paused while this account is read-only."
+                          : handReceipt.status !== "active"
+                            ? "Archived hand receipts cannot receive new 2062 assignments."
+                            : "Upload a 2062 for multiple items"
+                      }
+                      type="button"
+                      variant="outline"
+                    >
+                      {!isReadOnly && handReceipt.status === "active" ? (
+                        <Link
+                          href={`/app/hand-receipts/${handReceiptId}/upload-2062`}
+                        >
+                          <FileUp aria-hidden="true" className="size-4" />
+                          Upload 2062
+                        </Link>
+                      ) : (
+                        <>
+                          <FileUp aria-hidden="true" className="size-4" />
+                          Upload 2062
+                        </>
+                      )}
+                    </Button>
+                    <CreateItemForm
+                      canCreate={!isReadOnly && handReceipt.status === "active"}
+                      disabledReason={createItemDisabledReason}
+                      onSubmit={(input) =>
+                        createItemMutation.mutateAsync({
+                          handReceiptId,
+                          ...input,
+                        })
+                      }
+                    />
+                  </>
+                ) : null}
+              </div>
             </div>
             <div className="flex w-fit rounded-lg border bg-background p-1">
               <button

--- a/src/modules/items/ui/item-list.tsx
+++ b/src/modules/items/ui/item-list.tsx
@@ -71,6 +71,14 @@ export function ItemList({
                   </span>
                 </span>
               ) : null}
+              {item.active2062Coverage ? (
+                <span className="inline-flex items-center gap-1">
+                  Signed to {item.active2062Coverage.contactName}
+                  <span className="rounded-sm border bg-secondary px-1 font-mono text-[0.63rem] uppercase">
+                    DA Form 2062
+                  </span>
+                </span>
+              ) : null}
             </div>
           </div>
           {canRestore && item.status === "archived" && onRestore ? (

--- a/src/server/trpc/routers/assignments-2062.ts
+++ b/src/server/trpc/routers/assignments-2062.ts
@@ -150,6 +150,7 @@ export const assignments2062Router = createTRPCRouter({
           auditRepository: repositories.auditRepository,
           contactRepository: repositories.contactRepository,
           documentRepository: repositories.documentRepository,
+          handReceiptRepository: repositories.handReceiptRepository,
           itemRepository: repositories.itemRepository,
         }),
       ),

--- a/src/server/trpc/routers/assignments-2062.ts
+++ b/src/server/trpc/routers/assignments-2062.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import {
   Active2062CoverageConflictError,
   createAssignment,
+  createAssignmentWithItems,
 } from "@/modules/assignments-2062";
 import type {
   AppUnitOfWork,
@@ -27,6 +28,27 @@ const createAssignmentInput = z
     path: ["contactId"],
   });
 
+const createAssignmentWithItemsInput = z
+  .object({
+    handReceiptId: z.uuid(),
+    itemIds: z.array(z.uuid()),
+    contactId: z.uuid().optional(),
+    contactDisplayName: z.string().trim().min(1).max(120).optional(),
+    documentId: z.uuid(),
+  })
+  .refine((input) => input.itemIds.length > 0, {
+    message: "Select at least one item.",
+    path: ["itemIds"],
+  })
+  .refine((input) => input.contactId || input.contactDisplayName, {
+    message: "Select or create a contact.",
+    path: ["contactId"],
+  })
+  .refine((input) => !(input.contactId && input.contactDisplayName), {
+    message: "Use an existing contact or create a new one, not both.",
+    path: ["contactId"],
+  });
+
 function toTRPCError(
   error: unknown,
   context: { accountId: string; operation: string; userId: string },
@@ -37,7 +59,11 @@ function toTRPCError(
   if (
     error instanceof Active2062CoverageConflictError ||
     message === "Item must be active to upload a 2062." ||
-    message === "Document must belong to the item's hand receipt."
+    message === "Items must be active to upload a 2062." ||
+    message === "Hand receipt must be active to upload a 2062." ||
+    message === "Document must belong to the item's hand receipt." ||
+    message === "Document must belong to the hand receipt." ||
+    message === "Items must belong to the selected hand receipt."
   ) {
     throw new TRPCError({ code: "CONFLICT", message });
   }
@@ -49,12 +75,16 @@ function toTRPCError(
   if (
     message === "Item was not found." ||
     message === "Contact was not found." ||
-    message === "Document was not found."
+    message === "Document was not found." ||
+    message === "Hand receipt was not found."
   ) {
     throw new TRPCError({ code: "NOT_FOUND", message });
   }
 
-  if (message === "Contact display name is required.") {
+  if (
+    message === "Contact display name is required." ||
+    message === "Select at least one item."
+  ) {
     throw new TRPCError({ code: "BAD_REQUEST", message });
   }
 
@@ -120,6 +150,38 @@ export const assignments2062Router = createTRPCRouter({
           auditRepository: repositories.auditRepository,
           contactRepository: repositories.contactRepository,
           documentRepository: repositories.documentRepository,
+          itemRepository: repositories.itemRepository,
+        }),
+      ),
+    ),
+  createWithItems: protectedProcedure
+    .input(createAssignmentWithItemsInput)
+    .mutation(({ ctx, input }) =>
+      runInUnitOfWork(ctx, "assignments2062.createWithItems", (repositories) =>
+        createAssignmentWithItems({
+          account: ctx.account,
+          actorId: ctx.session.userId,
+          input:
+            input.contactId !== undefined
+              ? {
+                  handReceiptId: input.handReceiptId,
+                  itemIds: input.itemIds,
+                  contactId: input.contactId,
+                  documentId: input.documentId,
+                }
+              : {
+                  handReceiptId: input.handReceiptId,
+                  itemIds: input.itemIds,
+                  contactDisplayName: input.contactDisplayName ?? "",
+                  documentId: input.documentId,
+                },
+          assignmentRepository: repositories.assignmentRepository,
+          assignmentItemLinkRepository:
+            repositories.assignmentItemLinkRepository,
+          auditRepository: repositories.auditRepository,
+          contactRepository: repositories.contactRepository,
+          documentRepository: repositories.documentRepository,
+          handReceiptRepository: repositories.handReceiptRepository,
           itemRepository: repositories.itemRepository,
         }),
       ),

--- a/tests/e2e/hand-receipts.spec.ts
+++ b/tests/e2e/hand-receipts.spec.ts
@@ -171,6 +171,97 @@ test("users can open and edit item details from a hand receipt", async ({
   await expect(page.getByText("Item updated")).toBeVisible();
 });
 
+test("users can create multi-item formal 2062 coverage from hand receipt detail", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signInLocalUser(page);
+
+  await page.getByRole("button", { name: "New hand receipt" }).click();
+  await page.getByLabel("Name").fill("Multi 2062 receipt");
+  await page.getByRole("button", { name: "Create" }).click();
+  await page.getByRole("link", { name: "Open Multi 2062 receipt" }).click();
+  await expectHandReceiptDetail(page, "Multi 2062 receipt");
+
+  for (const [nomenclature, ecn] of [
+    ["Multi radio", "ECN-MULTI-1"],
+    ["Multi generator", "ECN-MULTI-2"],
+  ] as const) {
+    await page.getByRole("button", { name: "Add item" }).click();
+    const createDialog = page.getByRole("dialog", {
+      name: "Add property item",
+    });
+    await createDialog.getByLabel("Nomenclature").fill(nomenclature);
+    await createDialog.getByLabel("ECN").fill(ecn);
+    await createDialog.getByRole("button", { name: "Create item" }).click();
+    await expect(
+      page.getByRole("link", { name: `Open ${nomenclature}` }),
+    ).toBeVisible();
+  }
+
+  await page.getByRole("link", { name: "Upload 2062" }).click();
+  await expect(page).toHaveURL(
+    /\/app\/hand-receipts\/[0-9a-f-]+\/upload-2062$/,
+  );
+  await expect(
+    page.getByRole("heading", { name: "Multi 2062 receipt" }),
+  ).toBeVisible();
+
+  await page.getByLabel("Contact name").fill("SPC Multi");
+  await page.getByRole("button", { name: "Create SPC Multi" }).click();
+  await page.getByRole("button", { name: "Continue to document" }).click();
+
+  await page.getByLabel("Upload 2062 document").setInputFiles({
+    name: "multi-2062.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("%PDF-1.4\n% Field Ledger multi 2062 fixture\n"),
+  });
+  await expect(
+    page.getByText("multi-2062.pdf is saved as private document evidence."),
+  ).toBeVisible();
+  await page.getByLabel("Select document").selectOption({
+    label: "multi-2062.pdf",
+  });
+  await page.getByRole("button", { name: "Continue to items" }).click();
+
+  await page.getByLabel("Narrow items").fill("multi");
+  await page.getByLabel("Multi radio").check();
+  await page.getByLabel("Multi generator").check();
+  await page.getByRole("button", { name: "Review 2 items" }).click();
+
+  await expect(page.getByText("2 selected")).toBeVisible();
+  await expect(page.getByText("SPC Multi")).toBeVisible();
+  await expect(page.getByText("multi-2062.pdf")).toBeVisible();
+  await page.getByRole("button", { name: "Create assignment" }).click();
+
+  await expect(page).toHaveURL(/\/app\/hand-receipts\/[0-9a-f-]+$/);
+  await expect(page.getByText("DA Form 2062")).toHaveCount(2);
+  await expect(page.getByText("SPC Multi")).toHaveCount(2);
+});
+
+test("hand receipt upload 2062 flow uses desktop width without horizontal overflow", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await signInLocalUser(page);
+
+  await page.getByRole("button", { name: "New hand receipt" }).click();
+  await page.getByLabel("Name").fill("Desktop upload 2062 receipt");
+  await page.getByRole("button", { name: "Create" }).click();
+  await page
+    .getByRole("link", { name: "Open Desktop upload 2062 receipt" })
+    .click();
+  await expectHandReceiptDetail(page, "Desktop upload 2062 receipt");
+
+  await page.getByRole("link", { name: "Upload 2062" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Desktop upload 2062 receipt" }),
+  ).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.scrollWidth))
+    .toBeLessThanOrEqual(1280);
+});
+
 test("users can archive, review, and restore property items", async ({
   page,
 }) => {

--- a/tests/integration/trpc/assignments-2062-router.test.ts
+++ b/tests/integration/trpc/assignments-2062-router.test.ts
@@ -48,7 +48,7 @@ function createCaller(account = createAccount()) {
     {
       id: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
       accountId: account.id,
-      handReceiptId: "cccccccc-cccc-4ccc-cccc-cccccccccccc",
+      handReceiptId: "88888888-8888-4888-8888-888888888888",
       filename: "signed-2062.pdf",
       mimeType: "application/pdf",
       sizeBytes: 100,
@@ -57,10 +57,22 @@ function createCaller(account = createAccount()) {
       createdAt: now,
       updatedAt: now,
     },
+    {
+      id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      accountId: account.id,
+      handReceiptId: "55555555-5555-4555-8555-555555555555",
+      filename: "archived-2062.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 100,
+      storagePath: `${account.id}/cccccccc-cccc-4ccc-8ccc-cccccccccccc`,
+      uploadedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    },
   ]);
   const handReceiptRepository = new InMemoryHandReceiptRepository([
     {
-      id: "cccccccc-cccc-4ccc-cccc-cccccccccccc",
+      id: "88888888-8888-4888-8888-888888888888",
       accountId: account.id,
       name: "Primary receipt",
       notes: null,
@@ -73,14 +85,73 @@ function createCaller(account = createAccount()) {
       createdAt: now,
       updatedAt: now,
     },
+    {
+      id: "55555555-5555-4555-8555-555555555555",
+      accountId: account.id,
+      name: "Archived receipt",
+      notes: null,
+      handReceiptNumber: null,
+      holderName: null,
+      unitName: null,
+      uic: null,
+      effectiveDate: null,
+      status: "archived",
+      createdAt: now,
+      updatedAt: now,
+    },
   ]);
   const itemRepository = new InMemoryItemRepository([
     {
       id: "dddddddd-dddd-4ddd-9ddd-dddddddddddd",
       accountId: account.id,
-      handReceiptId: "cccccccc-cccc-4ccc-cccc-cccccccccccc",
+      handReceiptId: "88888888-8888-4888-8888-888888888888",
       nomenclature: "Radio",
       ecn: "ECN-1",
+      serialNumber: null,
+      generatedId: null,
+      notes: null,
+      status: "active",
+      signedToContactId: null,
+      signedToContactName: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "77777777-7777-4777-9777-777777777777",
+      accountId: account.id,
+      handReceiptId: "88888888-8888-4888-8888-888888888888",
+      nomenclature: "Generator",
+      ecn: null,
+      serialNumber: "SER-2",
+      generatedId: null,
+      notes: null,
+      status: "active",
+      signedToContactId: null,
+      signedToContactName: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "99999999-9999-4999-9999-999999999998",
+      accountId: account.id,
+      handReceiptId: "66666666-6666-4666-8666-666666666666",
+      nomenclature: "Other receipt item",
+      ecn: "OTHER-1",
+      serialNumber: null,
+      generatedId: null,
+      notes: null,
+      status: "active",
+      signedToContactId: null,
+      signedToContactName: null,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: "44444444-4444-4444-8444-444444444444",
+      accountId: account.id,
+      handReceiptId: "55555555-5555-4555-8555-555555555555",
+      nomenclature: "Archived receipt item",
+      ecn: "ARCH-1",
       serialNumber: null,
       generatedId: null,
       notes: null,
@@ -111,6 +182,7 @@ function createCaller(account = createAccount()) {
     assignmentRepository,
     contactRepository,
     auditRepository,
+    itemRepository,
     caller: appRouter.createCaller({
       session: { userId: account.userId, email: "owner@example.com" },
       account,
@@ -236,5 +308,82 @@ describe("assignments2062Router", () => {
         documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
       }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("creates a multi-item 2062 through the typed procedure", async () => {
+    const {
+      caller,
+      assignmentRepository,
+      assignmentItemLinkRepository,
+      auditRepository,
+    } = createCaller();
+
+    const result = await caller.assignments2062.createWithItems({
+      handReceiptId: "88888888-8888-4888-8888-888888888888",
+      itemIds: [
+        "dddddddd-dddd-4ddd-9ddd-dddddddddddd",
+        "77777777-7777-4777-9777-777777777777",
+      ],
+      contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+    });
+
+    expect(result.assignment).toMatchObject({ status: "active" });
+    expect(result.links).toHaveLength(2);
+    expect(assignmentRepository.assignments).toHaveLength(1);
+    expect(assignmentItemLinkRepository.links).toHaveLength(2);
+    expect(auditRepository.events.map((event) => event.action)).toEqual([
+      "assignment.created",
+      "assignment_item_link.created",
+      "assignment_item_link.created",
+    ]);
+  });
+
+  it("maps empty multi-item selection to BAD_REQUEST", async () => {
+    const { caller } = createCaller();
+
+    await expect(
+      caller.assignments2062.createWithItems({
+        handReceiptId: "88888888-8888-4888-8888-888888888888",
+        itemIds: [],
+        contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+        documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+      }),
+    ).rejects.toMatchObject({ code: "BAD_REQUEST" });
+  });
+
+  it("maps archived hand receipt multi-item creation to CONFLICT", async () => {
+    const { caller, assignmentRepository, assignmentItemLinkRepository } =
+      createCaller();
+
+    await expect(
+      caller.assignments2062.createWithItems({
+        handReceiptId: "55555555-5555-4555-8555-555555555555",
+        itemIds: ["44444444-4444-4444-8444-444444444444"],
+        contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+        documentId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Hand receipt must be active to upload a 2062.",
+    });
+    expect(assignmentRepository.assignments).toEqual([]);
+    expect(assignmentItemLinkRepository.links).toEqual([]);
+  });
+
+  it("maps cross-hand-receipt multi-item selection to CONFLICT", async () => {
+    const { caller } = createCaller();
+
+    await expect(
+      caller.assignments2062.createWithItems({
+        handReceiptId: "88888888-8888-4888-8888-888888888888",
+        itemIds: [
+          "dddddddd-dddd-4ddd-9ddd-dddddddddddd",
+          "99999999-9999-4999-9999-999999999998",
+        ],
+        contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+        documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+      }),
+    ).rejects.toMatchObject({ code: "CONFLICT" });
   });
 });

--- a/tests/integration/trpc/assignments-2062-router.test.ts
+++ b/tests/integration/trpc/assignments-2062-router.test.ts
@@ -310,6 +310,24 @@ describe("assignments2062Router", () => {
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 
+  it("maps archived hand receipt single-item creation to CONFLICT", async () => {
+    const { caller, assignmentRepository, assignmentItemLinkRepository } =
+      createCaller();
+
+    await expect(
+      caller.assignments2062.create({
+        itemId: "44444444-4444-4444-8444-444444444444",
+        contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+        documentId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Hand receipt must be active to upload a 2062.",
+    });
+    expect(assignmentRepository.assignments).toEqual([]);
+    expect(assignmentItemLinkRepository.links).toEqual([]);
+  });
+
   it("creates a multi-item 2062 through the typed procedure", async () => {
     const {
       caller,

--- a/tests/rls/assignments-2062/assignments-2062-rls.test.ts
+++ b/tests/rls/assignments-2062/assignments-2062-rls.test.ts
@@ -10,6 +10,7 @@ const ownerTwoId = "better-auth-assignment-owner-two";
 const ownerOneAccountId = "52cc4b16-96e8-49c2-ae21-b00dc36d9b0c";
 const ownerTwoAccountId = "8bc2df20-b293-4f29-a2b0-f98cb43abf3c";
 const ownerOneHandReceiptId = "f7b1d8ea-3063-4ed4-b0df-f197db9e54d6";
+const ownerOneSecondHandReceiptId = "3d49c1cf-f307-401f-8432-7b8ffc89df76";
 const ownerTwoHandReceiptId = "3d63f1fd-8dd1-48d5-bd2c-7ace6c5f496e";
 const ownerOneContactId = "853f65af-1d2a-41c4-bda9-ae18d80da2ea";
 const ownerTwoContactId = "be747d2b-efeb-421a-b900-921221af35bb";
@@ -28,6 +29,8 @@ const ownerTwoBlockedLinkId = "1c5e5430-2e21-45b2-bbd9-b58113b7c4b8";
 const ownerOneConstraintItemId = "e048fd65-5df6-4cc9-b71a-5041668284f5";
 const ownerOneConstraintAssignmentId = "40c90c2c-adf5-4d4e-9b20-6326b0c0f045";
 const ownerOneConstraintLinkId = "fc60cfcf-ad17-4b6e-b835-b6532dd03d7f";
+const ownerOneCrossReceiptItemId = "fffd0d6f-50df-4016-844c-e071080ce6b2";
+const ownerOneCrossReceiptLinkId = "79dcf63c-d35d-4b1b-8509-0e61978c445c";
 
 const sql = postgres(databaseUrl, { max: 1 });
 
@@ -67,6 +70,11 @@ describe("assignments-2062 RLS", () => {
         id: ownerOneHandReceiptId,
         account_id: ownerOneAccountId,
         name: "Owner one receipt",
+      },
+      {
+        id: ownerOneSecondHandReceiptId,
+        account_id: ownerOneAccountId,
+        name: "Owner one second receipt",
       },
       {
         id: ownerTwoHandReceiptId,
@@ -167,12 +175,12 @@ describe("assignments-2062 RLS", () => {
   });
 
   afterAll(async () => {
-    await sql`delete from assignment_item_links where id in (${ownerOneLinkId}, ${ownerTwoLinkId}, ${ownerOneInsertLinkId}, ${ownerOneConstraintLinkId})`;
+    await sql`delete from assignment_item_links where id in (${ownerOneLinkId}, ${ownerTwoLinkId}, ${ownerOneInsertLinkId}, ${ownerOneConstraintLinkId}, ${ownerOneCrossReceiptLinkId})`;
     await sql`delete from assignments where id in (${ownerOneAssignmentId}, ${ownerTwoAssignmentId}, ${ownerOneInsertAssignmentId}, ${ownerOneConstraintAssignmentId})`;
-    await sql`delete from items where id in (${ownerOneItemId}, ${ownerTwoItemId}, ${ownerOneInsertItemId}, ${ownerOneConstraintItemId})`;
+    await sql`delete from items where id in (${ownerOneItemId}, ${ownerTwoItemId}, ${ownerOneInsertItemId}, ${ownerOneConstraintItemId}, ${ownerOneCrossReceiptItemId})`;
     await sql`delete from documents where id in (${ownerOneDocumentId}, ${ownerTwoDocumentId})`;
     await sql`delete from contacts where id in (${ownerOneContactId}, ${ownerTwoContactId})`;
-    await sql`delete from hand_receipts where id in (${ownerOneHandReceiptId}, ${ownerTwoHandReceiptId})`;
+    await sql`delete from hand_receipts where id in (${ownerOneHandReceiptId}, ${ownerOneSecondHandReceiptId}, ${ownerTwoHandReceiptId})`;
     await sql`delete from accounts where id in (${ownerOneAccountId}, ${ownerTwoAccountId})`;
     await sql.end();
   });
@@ -345,6 +353,40 @@ describe("assignments-2062 RLS", () => {
         ownerOneId,
         async (transaction) =>
           transaction`update assignment_item_links set closed_at = now() where id = ${ownerOneConstraintLinkId}`,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("prevents linking an item from a different hand receipt on the same account", async () => {
+    await sql`insert into items (
+      id,
+      account_id,
+      hand_receipt_id,
+      nomenclature,
+      ecn
+    ) values (
+      ${ownerOneCrossReceiptItemId},
+      ${ownerOneAccountId},
+      ${ownerOneSecondHandReceiptId},
+      'Owner one second receipt item',
+      'RLS-2062-CROSS'
+    ) on conflict (id) do nothing`;
+
+    await expect(
+      asAuthenticatedOwner(
+        ownerOneId,
+        async (transaction) =>
+          transaction`insert into assignment_item_links (
+            id,
+            account_id,
+            assignment_id,
+            item_id
+          ) values (
+            ${ownerOneCrossReceiptLinkId},
+            ${ownerOneAccountId},
+            ${ownerOneAssignmentId},
+            ${ownerOneCrossReceiptItemId}
+          )`,
       ),
     ).rejects.toThrow();
   });

--- a/tests/unit/assignments-2062/create-assignment.test.ts
+++ b/tests/unit/assignments-2062/create-assignment.test.ts
@@ -4,12 +4,14 @@ import type { AccountRecord } from "@/modules/accounts/application/ensure-accoun
 import {
   Active2062CoverageConflictError,
   createAssignment,
+  createAssignmentWithItems,
 } from "@/modules/assignments-2062";
 import { InMemoryAssignmentItemLinkRepository } from "../../support/assignment-item-link-repository";
 import { InMemoryAssignmentRepository } from "../../support/assignment-repository";
 import { InMemoryAuditRepository } from "../../support/audit-repository";
 import { InMemoryContactRepository } from "../../support/contact-repository";
 import { InMemoryDocumentRepository } from "../../support/document-repository";
+import { InMemoryHandReceiptRepository } from "../../support/hand-receipt-repository";
 import { InMemoryItemRepository } from "../../support/item-repository";
 
 const now = new Date("2026-05-02T12:00:00.000Z");
@@ -54,6 +56,62 @@ function createRepositories() {
         createdAt: now,
         updatedAt: now,
       },
+      {
+        id: "document-archived",
+        accountId: "account-1",
+        handReceiptId: "receipt-archived",
+        filename: "archived-2062.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 100,
+        storagePath: "account-1/document-archived",
+        uploadedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]),
+    handReceiptRepository: new InMemoryHandReceiptRepository([
+      {
+        id: "receipt-1",
+        accountId: "account-1",
+        name: "Primary receipt",
+        notes: null,
+        handReceiptNumber: null,
+        holderName: null,
+        unitName: null,
+        uic: null,
+        effectiveDate: null,
+        status: "active",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "receipt-2",
+        accountId: "account-1",
+        name: "Secondary receipt",
+        notes: null,
+        handReceiptNumber: null,
+        holderName: null,
+        unitName: null,
+        uic: null,
+        effectiveDate: null,
+        status: "active",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "receipt-archived",
+        accountId: "account-1",
+        name: "Archived receipt",
+        notes: null,
+        handReceiptNumber: null,
+        holderName: null,
+        unitName: null,
+        uic: null,
+        effectiveDate: null,
+        status: "archived",
+        createdAt: now,
+        updatedAt: now,
+      },
     ]),
     itemRepository: new InMemoryItemRepository([
       {
@@ -62,6 +120,51 @@ function createRepositories() {
         handReceiptId: "receipt-1",
         nomenclature: "Radio",
         ecn: "ECN-1",
+        serialNumber: null,
+        generatedId: null,
+        notes: null,
+        status: "active",
+        signedToContactId: null,
+        signedToContactName: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "item-2",
+        accountId: "account-1",
+        handReceiptId: "receipt-1",
+        nomenclature: "Generator",
+        ecn: null,
+        serialNumber: "SER-2",
+        generatedId: null,
+        notes: null,
+        status: "active",
+        signedToContactId: "contact-1",
+        signedToContactName: "SPC Rivera",
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "item-other-receipt",
+        accountId: "account-1",
+        handReceiptId: "receipt-2",
+        nomenclature: "Truck",
+        ecn: "ECN-3",
+        serialNumber: null,
+        generatedId: null,
+        notes: null,
+        status: "active",
+        signedToContactId: null,
+        signedToContactName: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: "item-archived-receipt",
+        accountId: "account-1",
+        handReceiptId: "receipt-archived",
+        nomenclature: "Archived radio",
+        ecn: "ARCH-1",
         serialNumber: null,
         generatedId: null,
         notes: null,
@@ -258,6 +361,157 @@ describe("createAssignment", () => {
         now,
       }),
     ).rejects.toThrow("Item was not found.");
+  });
+
+  it("creates one assignment with multiple same-hand-receipt item links", async () => {
+    const repositories = createRepositories();
+    let linkSequence = 0;
+
+    const result = await createAssignmentWithItems({
+      account: createAccount(),
+      actorId: "owner-1",
+      input: {
+        handReceiptId: "receipt-1",
+        itemIds: ["item-1", "item-2"],
+        contactId: "contact-1",
+        documentId: "document-1",
+      },
+      ...repositories,
+      now,
+      createAssignmentId: () => "assignment-1",
+      createAssignmentItemLinkId: () => `link-${++linkSequence}`,
+    });
+
+    expect(result.assignment).toMatchObject({
+      id: "assignment-1",
+      handReceiptId: "receipt-1",
+      contactId: "contact-1",
+      documentId: "document-1",
+      status: "active",
+    });
+    expect(result.links).toHaveLength(2);
+    expect(result.links.map((link) => link.itemId)).toEqual([
+      "item-1",
+      "item-2",
+    ]);
+    await expect(
+      repositories.itemRepository.findById("account-1", "item-2"),
+    ).resolves.toMatchObject({ signedToContactId: null });
+    expect(
+      repositories.auditRepository.events.map((event) => event.action),
+    ).toEqual([
+      "assignment.created",
+      "assignment_item_link.created",
+      "assignment_item_link.created",
+    ]);
+  });
+
+  it("blocks multi-item creation with an empty selection", async () => {
+    const repositories = createRepositories();
+
+    await expect(
+      createAssignmentWithItems({
+        account: createAccount(),
+        actorId: "owner-1",
+        input: {
+          handReceiptId: "receipt-1",
+          itemIds: [],
+          contactId: "contact-1",
+          documentId: "document-1",
+        },
+        ...repositories,
+        now,
+      }),
+    ).rejects.toThrow("Select at least one item.");
+  });
+
+  it("blocks multi-item creation against an archived hand receipt before mutating records", async () => {
+    const repositories = createRepositories();
+
+    await expect(
+      createAssignmentWithItems({
+        account: createAccount(),
+        actorId: "owner-1",
+        input: {
+          handReceiptId: "receipt-archived",
+          itemIds: ["item-archived-receipt"],
+          contactId: "contact-1",
+          documentId: "document-archived",
+        },
+        ...repositories,
+        now,
+      }),
+    ).rejects.toThrow("Hand receipt must be active to upload a 2062.");
+    expect(repositories.assignmentRepository.assignments).toEqual([]);
+    expect(repositories.assignmentItemLinkRepository.links).toEqual([]);
+    expect(repositories.auditRepository.events).toEqual([]);
+  });
+
+  it("blocks items from another hand receipt", async () => {
+    const repositories = createRepositories();
+
+    await expect(
+      createAssignmentWithItems({
+        account: createAccount(),
+        actorId: "owner-1",
+        input: {
+          handReceiptId: "receipt-1",
+          itemIds: ["item-1", "item-other-receipt"],
+          contactId: "contact-1",
+          documentId: "document-1",
+        },
+        ...repositories,
+        now,
+      }),
+    ).rejects.toThrow("Items must belong to the selected hand receipt.");
+  });
+
+  it("blocks multi-item creation when any item already has active coverage", async () => {
+    const repositories = createRepositories();
+    repositories.assignmentItemLinkRepository.links.push({
+      id: "existing-link",
+      accountId: "account-1",
+      assignmentId: "existing-assignment",
+      itemId: "item-2",
+      status: "active",
+      closedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await expect(
+      createAssignmentWithItems({
+        account: createAccount(),
+        actorId: "owner-1",
+        input: {
+          handReceiptId: "receipt-1",
+          itemIds: ["item-1", "item-2"],
+          contactId: "contact-1",
+          documentId: "document-1",
+        },
+        ...repositories,
+        now,
+      }),
+    ).rejects.toBeInstanceOf(Active2062CoverageConflictError);
+  });
+
+  it("blocks multi-item creation for read-only accounts", async () => {
+    const repositories = createRepositories();
+
+    await expect(
+      createAssignmentWithItems({
+        account: createAccount({ accessState: "paused_read_only" }),
+        actorId: "owner-1",
+        input: {
+          handReceiptId: "receipt-1",
+          itemIds: ["item-1"],
+          contactId: "contact-1",
+          documentId: "document-1",
+        },
+        ...repositories,
+        now,
+      }),
+    ).rejects.toThrow("This account is read-only.");
   });
 
   it("blocks creation when the contact does not exist", async () => {

--- a/tests/unit/assignments-2062/create-assignment.test.ts
+++ b/tests/unit/assignments-2062/create-assignment.test.ts
@@ -363,6 +363,27 @@ describe("createAssignment", () => {
     ).rejects.toThrow("Item was not found.");
   });
 
+  it("blocks single-item creation against an archived hand receipt before mutating records", async () => {
+    const repositories = createRepositories();
+
+    await expect(
+      createAssignment({
+        account: createAccount(),
+        actorId: "owner-1",
+        input: {
+          itemId: "item-archived-receipt",
+          contactId: "contact-1",
+          documentId: "document-archived",
+        },
+        ...repositories,
+        now,
+      }),
+    ).rejects.toThrow("Hand receipt must be active to upload a 2062.");
+    expect(repositories.assignmentRepository.assignments).toEqual([]);
+    expect(repositories.assignmentItemLinkRepository.links).toEqual([]);
+    expect(repositories.auditRepository.events).toEqual([]);
+  });
+
   it("creates one assignment with multiple same-hand-receipt item links", async () => {
     const repositories = createRepositories();
     let linkSequence = 0;


### PR DESCRIPTION
## Summary
- add the hand receipt-level Upload 2062 flow for selecting multiple active items and attaching one signed document
- add `assignments2062.createWithItems` and the same-hand-receipt RLS protection for assignment links
- enforce active hand receipt status in the service so archived receipts cannot receive new active 2062 coverage
- update docs, plan notes, unit/integration/RLS/e2e coverage for the new flow

## Review Finding Addressed
- Fixed the service-layer gap where direct callers could create multi-item 2062 coverage against an archived hand receipt. `createAssignmentWithItems` now loads the hand receipt and rejects missing or non-active receipts before creating contacts, assignments, links, or audit events.

## Validation
- `pnpm test:unit -- tests/unit/assignments-2062/create-assignment.test.ts`
- `pnpm test:integration -- tests/integration/trpc/assignments-2062-router.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm format:check`

Prior slice validation before this review fix also covered `pnpm db:migrate`, RLS, and focused e2e checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

### Features
- Multi-item 2062 Upload Flow: Add a hand-receipt-level upload workflow that lets users select multiple active items from a single hand receipt and attach one signed DA Form 2062. New page: /app/hand-receipts/[id]/upload-2062. UI flow includes contact selection/creation, private document selection/upload, item multi-select, and a summary/submit step.

### Improvements
- Service-layer validation: createAssignmentWithItems (and single-item create) now load and require the hand receipt to be active before creating contacts, assignments, links, or audit events — preventing archived receipts from receiving new 2062 coverage.
- Same-hand-receipt scoping: assignment item-link creation enforces that linked items belong to the same hand receipt as the assignment (both at RLS and service layers).
- Item status display: Item list shows an “Signed to {contactName}” chip when active 2062 coverage exists.
- Hand receipt UI: “Upload 2062” action added to hand receipt detail next to item controls (shown only for active receipts and non-read-only accounts).

### Database Changes
- New migration: 0025_assignment_link_same_receipt.sql
  - Adds RLS policies on assignment_item_links:
    - assignment_item_links_same_hand_receipt_insert (INSERT, WITH CHECK)
    - assignment_item_links_same_hand_receipt_update (UPDATE, WITH CHECK)
  - Policies enforce account and hand_receipt membership consistency between assignments and linked items.

### API / Router
- assignments2062 router: new createWithItems mutation supporting multi-item assignment creation with input validation (non-empty itemIds, contact or contactDisplayName, documentId). Error mapping updated to surface conflicts and not-found cases appropriately.

### Testing
- Added comprehensive coverage:
  - Unit tests for createAssignment and createAssignmentWithItems (including archived-receipt, cross-receipt, active-coverage, empty-itemIds, and read-only account cases).
  - Integration tests for the assignments2062 router (including archived-hand-receipt and cross-receipt validations).
  - RLS tests asserting cross-hand-receipt inserts are blocked.
  - E2E tests covering the full Upload 2062 flow (file upload, item selection, assignment creation) and a desktop layout overflow check.

### Documentation / Plans
- Updated domain model docs to document the multi-item 2062 workflow and RLS scoping rules.
- plans/06-documents-2062.md: Phase 3 (Hand Receipt Multi-Item Upload) marked implemented with updated acceptance criteria.

### Miscellaneous
- Exported createAssignmentWithItems and associated types; added frontend Upload2062Flow component and integrated navigation from hand receipt detail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #61 