### PR TITLE
[codex] Add active 2062 coverage surfaces

### DIFF
--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -234,6 +234,12 @@ Rules:
 - One 2062 assignment belongs to one hand receipt.
 - One item can have at most one active 2062 link.
 - Items may have many historical closed 2062 links.
+- Active 2062s list formal assignment records only. Manual signed-to state does
+  not appear in the Active 2062s list because it has no DA Form 2062 document.
+- 2062 coverage on item detail means current formal coverage plus historical
+  closed links for that item.
+- Hand receipt 2062 context means active formal assignments scoped to that hand
+  receipt.
 - Multi-item upload starts from hand receipt detail, uses one contact and one
   private document for the assignment, and links only selected active items from
   that hand receipt.

--- a/scripts/check-trpc-foundation.ts
+++ b/scripts/check-trpc-foundation.ts
@@ -53,6 +53,9 @@ async function main() {
       async findById() {
         return null;
       },
+      async findManyByIds() {
+        return [];
+      },
       async update() {
         throw new Error("Foundation check should not update hand receipts.");
       },

--- a/src/app/(protected)/app/active-2062s/page.tsx
+++ b/src/app/(protected)/app/active-2062s/page.tsx
@@ -1,14 +1,5 @@
-import { ReceiptText } from "lucide-react";
-
-import { PlaceholderPage } from "@/components/shell/placeholder-page";
+import { Active2062sWorkspace } from "@/modules/assignments-2062/ui/active-2062s-workspace";
 
 export default function Active2062sPage() {
-  return (
-    <PlaceholderPage
-      description="Active 2062s will show formal DA Form 2062 assignments only, with linked items and close-out paths when that workflow lands."
-      icon={ReceiptText}
-      sections={["Formal assignments", "Linked items", "Close workflow"]}
-      title="Active 2062s"
-    />
-  );
+  return <Active2062sWorkspace />;
 }

--- a/src/modules/assignments-2062/application/assignment-item-link-repository.ts
+++ b/src/modules/assignments-2062/application/assignment-item-link-repository.ts
@@ -1,6 +1,7 @@
 import type {
   AssignmentItemLinkRecord,
   AssignmentStatus,
+  CoverageHistoryEntry,
   NewAssignmentItemLinkRecord,
 } from "./types";
 
@@ -19,6 +20,11 @@ export interface AssignmentItemLinkRepository {
     itemId: string,
     options?: { status?: AssignmentStatus },
   ): Promise<AssignmentItemLinkRecord[]>;
+  findByItemIdWithAssignment(
+    accountId: string,
+    itemId: string,
+    options?: { status?: AssignmentStatus },
+  ): Promise<CoverageHistoryEntry[]>;
   findByAssignmentId(
     accountId: string,
     assignmentId: string,
@@ -45,6 +51,9 @@ export function createUnavailableAssignmentItemLinkRepository(): AssignmentItemL
       throw new Error("An authenticated database session is required.");
     },
     async findByItemId() {
+      throw new Error("An authenticated database session is required.");
+    },
+    async findByItemIdWithAssignment() {
       throw new Error("An authenticated database session is required.");
     },
     async findByAssignmentId() {

--- a/src/modules/assignments-2062/application/assignment-item-link-repository.ts
+++ b/src/modules/assignments-2062/application/assignment-item-link-repository.ts
@@ -30,6 +30,10 @@ export interface AssignmentItemLinkRepository {
     assignmentId: string,
     options?: { status?: AssignmentStatus },
   ): Promise<AssignmentItemLinkRecord[]>;
+  countActiveByAssignmentIds(
+    accountId: string,
+    assignmentIds: string[],
+  ): Promise<Map<string, number>>;
   updateStatus(
     accountId: string,
     linkId: string,
@@ -57,6 +61,9 @@ export function createUnavailableAssignmentItemLinkRepository(): AssignmentItemL
       throw new Error("An authenticated database session is required.");
     },
     async findByAssignmentId() {
+      throw new Error("An authenticated database session is required.");
+    },
+    async countActiveByAssignmentIds() {
       throw new Error("An authenticated database session is required.");
     },
     async updateStatus() {

--- a/src/modules/assignments-2062/application/assignment-item-link-repository.ts
+++ b/src/modules/assignments-2062/application/assignment-item-link-repository.ts
@@ -14,6 +14,11 @@ export interface AssignmentItemLinkRepository {
     accountId: string,
     itemId: string,
   ): Promise<AssignmentItemLinkRecord | null>;
+  findByItemId(
+    accountId: string,
+    itemId: string,
+    options?: { status?: AssignmentStatus },
+  ): Promise<AssignmentItemLinkRecord[]>;
   findByAssignmentId(
     accountId: string,
     assignmentId: string,
@@ -37,6 +42,9 @@ export function createUnavailableAssignmentItemLinkRepository(): AssignmentItemL
       throw new Error("An authenticated database session is required.");
     },
     async findActiveByItemId() {
+      throw new Error("An authenticated database session is required.");
+    },
+    async findByItemId() {
       throw new Error("An authenticated database session is required.");
     },
     async findByAssignmentId() {

--- a/src/modules/assignments-2062/application/create-assignment.ts
+++ b/src/modules/assignments-2062/application/create-assignment.ts
@@ -12,6 +12,20 @@ import type {
   CreateAssignmentInput,
   CreateAssignmentWithItemsInput,
 } from "./types";
+import {
+  AccountReadOnlyError,
+  Active2062CoverageConflictError,
+  ContactDisplayNameRequiredError,
+  ContactNotFoundError,
+  DocumentNotFoundError,
+  DocumentReceiptMismatchError,
+  EmptyItemSelectionError,
+  HandReceiptNotActiveError,
+  HandReceiptNotFoundError,
+  ItemNotActiveError,
+  ItemNotFoundError,
+  ItemReceiptMismatchError,
+} from "./types";
 
 type CreateAssignmentArgs = {
   account: AccountRecord;
@@ -38,12 +52,6 @@ function isUniqueViolation(error: unknown) {
   );
 }
 
-export class Active2062CoverageConflictError extends Error {
-  constructor() {
-    super("Item already has active 2062 coverage.");
-  }
-}
-
 export async function createAssignment({
   account,
   actorId,
@@ -62,17 +70,17 @@ export async function createAssignment({
   const capabilities = deriveAccountCapabilities(account, now);
 
   if (capabilities.isReadOnly) {
-    throw new Error("This account is read-only.");
+    throw new AccountReadOnlyError();
   }
 
   const item = await itemRepository.findById(account.id, input.itemId);
 
   if (!item) {
-    throw new Error("Item was not found.");
+    throw new ItemNotFoundError();
   }
 
   if (item.status !== "active") {
-    throw new Error("Item must be active to upload a 2062.");
+    throw new ItemNotActiveError();
   }
 
   const handReceipt = await handReceiptRepository.findById(
@@ -81,11 +89,11 @@ export async function createAssignment({
   );
 
   if (!handReceipt) {
-    throw new Error("Hand receipt was not found.");
+    throw new HandReceiptNotFoundError();
   }
 
   if (handReceipt.status !== "active") {
-    throw new Error("Hand receipt must be active to upload a 2062.");
+    throw new HandReceiptNotActiveError();
   }
 
   const activeLink = await assignmentItemLinkRepository.findActiveByItemId(
@@ -95,6 +103,10 @@ export async function createAssignment({
 
   if (activeLink) {
     throw new Active2062CoverageConflictError();
+  }
+
+  if ("contactDisplayName" in input && !input.contactDisplayName?.trim()) {
+    throw new ContactDisplayNameRequiredError();
   }
 
   const contact =
@@ -110,7 +122,7 @@ export async function createAssignment({
         });
 
   if (!contact) {
-    throw new Error("Contact was not found.");
+    throw new ContactNotFoundError();
   }
 
   const document = await documentRepository.findById(
@@ -119,11 +131,13 @@ export async function createAssignment({
   );
 
   if (!document) {
-    throw new Error("Document was not found.");
+    throw new DocumentNotFoundError();
   }
 
   if (document.handReceiptId !== item.handReceiptId) {
-    throw new Error("Document must belong to the item's hand receipt.");
+    throw new DocumentReceiptMismatchError(
+      "Document must belong to the item's hand receipt.",
+    );
   }
 
   const convertedFromManualSignedTo = item.signedToContactId !== null;
@@ -230,13 +244,13 @@ export async function createAssignmentWithItems({
   const capabilities = deriveAccountCapabilities(account, now);
 
   if (capabilities.isReadOnly) {
-    throw new Error("This account is read-only.");
+    throw new AccountReadOnlyError();
   }
 
   const uniqueItemIds = Array.from(new Set(input.itemIds));
 
   if (uniqueItemIds.length === 0) {
-    throw new Error("Select at least one item.");
+    throw new EmptyItemSelectionError();
   }
 
   const handReceipt = await handReceiptRepository.findById(
@@ -245,11 +259,15 @@ export async function createAssignmentWithItems({
   );
 
   if (!handReceipt) {
-    throw new Error("Hand receipt was not found.");
+    throw new HandReceiptNotFoundError();
   }
 
   if (handReceipt.status !== "active") {
-    throw new Error("Hand receipt must be active to upload a 2062.");
+    throw new HandReceiptNotActiveError();
+  }
+
+  if ("contactDisplayName" in input && !input.contactDisplayName?.trim()) {
+    throw new ContactDisplayNameRequiredError();
   }
 
   const contact =
@@ -265,7 +283,7 @@ export async function createAssignmentWithItems({
         });
 
   if (!contact) {
-    throw new Error("Contact was not found.");
+    throw new ContactNotFoundError();
   }
 
   const document = await documentRepository.findById(
@@ -274,11 +292,11 @@ export async function createAssignmentWithItems({
   );
 
   if (!document) {
-    throw new Error("Document was not found.");
+    throw new DocumentNotFoundError();
   }
 
   if (document.handReceiptId !== input.handReceiptId) {
-    throw new Error("Document must belong to the hand receipt.");
+    throw new DocumentReceiptMismatchError();
   }
 
   const items = await Promise.all(
@@ -286,20 +304,20 @@ export async function createAssignmentWithItems({
   );
 
   if (items.some((item) => item === null)) {
-    throw new Error("Item was not found.");
+    throw new ItemNotFoundError();
   }
 
   const activeItems = items.map((item) => {
     if (!item) {
-      throw new Error("Item was not found.");
+      throw new ItemNotFoundError();
     }
 
     if (item.status !== "active") {
-      throw new Error("Items must be active to upload a 2062.");
+      throw new ItemNotActiveError("Items must be active to upload a 2062.");
     }
 
     if (item.handReceiptId !== input.handReceiptId) {
-      throw new Error("Items must belong to the selected hand receipt.");
+      throw new ItemReceiptMismatchError();
     }
 
     return item;

--- a/src/modules/assignments-2062/application/list-active-assignments.ts
+++ b/src/modules/assignments-2062/application/list-active-assignments.ts
@@ -1,5 +1,8 @@
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
-import type { HandReceiptRepository } from "@/modules/hand-receipts";
+import type {
+  HandReceiptRecord,
+  HandReceiptRepository,
+} from "@/modules/hand-receipts";
 import type { AssignmentItemLinkRepository } from "./assignment-item-link-repository";
 import type { AssignmentRepository } from "./assignment-repository";
 import type {
@@ -21,6 +24,12 @@ type SummaryDependencies = Omit<
   "assignmentRepository"
 > & {
   assignment: AssignmentRecord;
+};
+
+type BatchSummaryDependencies = {
+  assignment: AssignmentRecord;
+  activeLinkCount: number;
+  handReceipt: HandReceiptRecord | null;
 };
 
 type CoverageHistoryEntryDependencies = {
@@ -72,6 +81,66 @@ async function toActiveAssignmentSummary({
   };
 }
 
+function toActiveAssignmentSummaryBatch({
+  activeLinkCount,
+  assignment,
+  handReceipt,
+}: BatchSummaryDependencies): ActiveAssignmentSummary | null {
+  if (assignment.status !== "active" || !handReceipt) {
+    return null;
+  }
+
+  return {
+    id: assignment.id,
+    handReceiptId: assignment.handReceiptId,
+    handReceiptName: handReceipt.name,
+    contactId: assignment.contactId,
+    contactName: assignment.contactName ?? "Unknown contact",
+    documentId: assignment.documentId,
+    documentFilename: assignment.documentFilename ?? "2062 document",
+    itemCount: activeLinkCount,
+    status: "active",
+    createdAt: assignment.createdAt,
+    updatedAt: assignment.updatedAt,
+  };
+}
+
+async function summarizeActiveAssignments({
+  account,
+  assignments,
+  assignmentItemLinkRepository,
+  handReceiptRepository,
+}: Omit<AssignmentQueryDependencies, "assignmentRepository"> & {
+  assignments: AssignmentRecord[];
+}): Promise<ActiveAssignmentSummary[]> {
+  const assignmentIds = assignments.map((assignment) => assignment.id);
+  const handReceiptIds = [
+    ...new Set(assignments.map((assignment) => assignment.handReceiptId)),
+  ];
+
+  const [handReceipts, activeLinkCounts] = await Promise.all([
+    handReceiptRepository.findManyByIds(account.id, handReceiptIds),
+    assignmentItemLinkRepository.countActiveByAssignmentIds(
+      account.id,
+      assignmentIds,
+    ),
+  ]);
+
+  const handReceiptsById = new Map(
+    handReceipts.map((handReceipt) => [handReceipt.id, handReceipt]),
+  );
+
+  return assignments
+    .map((assignment) =>
+      toActiveAssignmentSummaryBatch({
+        activeLinkCount: activeLinkCounts.get(assignment.id) ?? 0,
+        assignment,
+        handReceipt: handReceiptsById.get(assignment.handReceiptId) ?? null,
+      }),
+    )
+    .filter((summary): summary is ActiveAssignmentSummary => Boolean(summary));
+}
+
 function coverageEntryToHistoricalAssignmentLink({
   assignmentId,
   closedAt,
@@ -112,20 +181,12 @@ export async function listActiveAssignments({
     status: "active",
   });
 
-  const summaries = await Promise.all(
-    assignments.map((assignment) =>
-      toActiveAssignmentSummary({
-        account,
-        assignment,
-        assignmentItemLinkRepository,
-        handReceiptRepository,
-      }),
-    ),
-  );
-
-  return summaries.filter((summary): summary is ActiveAssignmentSummary =>
-    Boolean(summary),
-  );
+  return summarizeActiveAssignments({
+    account,
+    assignments,
+    assignmentItemLinkRepository,
+    handReceiptRepository,
+  });
 }
 
 export async function getHandReceiptAssignments({
@@ -143,20 +204,12 @@ export async function getHandReceiptAssignments({
     { status: "active" },
   );
 
-  const summaries = await Promise.all(
-    assignments.map((assignment) =>
-      toActiveAssignmentSummary({
-        account,
-        assignment,
-        assignmentItemLinkRepository,
-        handReceiptRepository,
-      }),
-    ),
-  );
-
-  return summaries.filter((summary): summary is ActiveAssignmentSummary =>
-    Boolean(summary),
-  );
+  return summarizeActiveAssignments({
+    account,
+    assignments,
+    assignmentItemLinkRepository,
+    handReceiptRepository,
+  });
 }
 
 export async function getItemCoverage({

--- a/src/modules/assignments-2062/application/list-active-assignments.ts
+++ b/src/modules/assignments-2062/application/list-active-assignments.ts
@@ -1,0 +1,219 @@
+import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import type { HandReceiptRepository } from "@/modules/hand-receipts";
+import type { AssignmentItemLinkRepository } from "./assignment-item-link-repository";
+import type { AssignmentRepository } from "./assignment-repository";
+import type {
+  ActiveAssignmentSummary,
+  AssignmentRecord,
+  HistoricalAssignmentLink,
+  ItemCoverageResult,
+} from "./types";
+
+type AssignmentQueryDependencies = {
+  account: AccountRecord;
+  assignmentItemLinkRepository: AssignmentItemLinkRepository;
+  assignmentRepository: AssignmentRepository;
+  handReceiptRepository: HandReceiptRepository;
+};
+
+type SummaryDependencies = Omit<
+  AssignmentQueryDependencies,
+  "assignmentRepository"
+> & {
+  assignment: AssignmentRecord;
+};
+
+type HistoricalLinkDependencies = {
+  account: AccountRecord;
+  assignment: AssignmentRecord;
+  closedAt: Date | null;
+  createdAt: Date;
+  handReceiptRepository: HandReceiptRepository;
+  linkId: string;
+};
+
+async function toActiveAssignmentSummary({
+  account,
+  assignment,
+  assignmentItemLinkRepository,
+  handReceiptRepository,
+}: SummaryDependencies): Promise<ActiveAssignmentSummary | null> {
+  if (assignment.status !== "active") {
+    return null;
+  }
+
+  const [handReceipt, activeLinks] = await Promise.all([
+    handReceiptRepository.findById(account.id, assignment.handReceiptId),
+    assignmentItemLinkRepository.findByAssignmentId(account.id, assignment.id, {
+      status: "active",
+    }),
+  ]);
+
+  if (!handReceipt) {
+    return null;
+  }
+
+  return {
+    id: assignment.id,
+    handReceiptId: assignment.handReceiptId,
+    handReceiptName: handReceipt.name,
+    contactId: assignment.contactId,
+    contactName: assignment.contactName ?? "Unknown contact",
+    documentId: assignment.documentId,
+    documentFilename: assignment.documentFilename ?? "2062 document",
+    itemCount: activeLinks.length,
+    status: "active",
+    createdAt: assignment.createdAt,
+    updatedAt: assignment.updatedAt,
+  };
+}
+
+async function toHistoricalAssignmentLink({
+  account,
+  assignment,
+  handReceiptRepository,
+  linkId,
+  closedAt,
+  createdAt,
+}: HistoricalLinkDependencies): Promise<HistoricalAssignmentLink | null> {
+  if (!closedAt) {
+    return null;
+  }
+
+  const handReceipt = await handReceiptRepository.findById(
+    account.id,
+    assignment.handReceiptId,
+  );
+
+  if (!handReceipt) {
+    return null;
+  }
+
+  return {
+    linkId,
+    assignmentId: assignment.id,
+    handReceiptId: assignment.handReceiptId,
+    handReceiptName: handReceipt.name,
+    contactId: assignment.contactId,
+    contactName: assignment.contactName ?? "Unknown contact",
+    documentId: assignment.documentId,
+    documentFilename: assignment.documentFilename ?? "2062 document",
+    closedAt,
+    createdAt,
+  };
+}
+
+export async function listActiveAssignments({
+  account,
+  assignmentItemLinkRepository,
+  assignmentRepository,
+  handReceiptRepository,
+}: AssignmentQueryDependencies): Promise<ActiveAssignmentSummary[]> {
+  const assignments = await assignmentRepository.findByAccountId(account.id, {
+    status: "active",
+  });
+
+  const summaries = await Promise.all(
+    assignments.map((assignment) =>
+      toActiveAssignmentSummary({
+        account,
+        assignment,
+        assignmentItemLinkRepository,
+        handReceiptRepository,
+      }),
+    ),
+  );
+
+  return summaries.filter((summary): summary is ActiveAssignmentSummary =>
+    Boolean(summary),
+  );
+}
+
+export async function getHandReceiptAssignments({
+  account,
+  assignmentItemLinkRepository,
+  assignmentRepository,
+  handReceiptId,
+  handReceiptRepository,
+}: AssignmentQueryDependencies & {
+  handReceiptId: string;
+}): Promise<ActiveAssignmentSummary[]> {
+  const assignments = await assignmentRepository.findByHandReceiptId(
+    account.id,
+    handReceiptId,
+    { status: "active" },
+  );
+
+  const summaries = await Promise.all(
+    assignments.map((assignment) =>
+      toActiveAssignmentSummary({
+        account,
+        assignment,
+        assignmentItemLinkRepository,
+        handReceiptRepository,
+      }),
+    ),
+  );
+
+  return summaries.filter((summary): summary is ActiveAssignmentSummary =>
+    Boolean(summary),
+  );
+}
+
+export async function getItemCoverage({
+  account,
+  assignmentItemLinkRepository,
+  assignmentRepository,
+  handReceiptRepository,
+  itemId,
+}: AssignmentQueryDependencies & {
+  itemId: string;
+}): Promise<ItemCoverageResult> {
+  const [activeLink, historicalLinks] = await Promise.all([
+    assignmentItemLinkRepository.findActiveByItemId(account.id, itemId),
+    assignmentItemLinkRepository.findByItemId(account.id, itemId, {
+      status: "closed",
+    }),
+  ]);
+
+  const activeAssignment = activeLink
+    ? await assignmentRepository.findById(account.id, activeLink.assignmentId)
+    : null;
+  const current = activeAssignment
+    ? await toActiveAssignmentSummary({
+        account,
+        assignment: activeAssignment,
+        assignmentItemLinkRepository,
+        handReceiptRepository,
+      })
+    : null;
+
+  const history = await Promise.all(
+    historicalLinks.map(async (link) => {
+      const assignment = await assignmentRepository.findById(
+        account.id,
+        link.assignmentId,
+      );
+
+      if (!assignment) {
+        return null;
+      }
+
+      return toHistoricalAssignmentLink({
+        account,
+        assignment,
+        closedAt: link.closedAt,
+        createdAt: link.createdAt,
+        handReceiptRepository,
+        linkId: link.id,
+      });
+    }),
+  );
+
+  return {
+    current,
+    history: history.filter((link): link is HistoricalAssignmentLink =>
+      Boolean(link),
+    ),
+  };
+}

--- a/src/modules/assignments-2062/application/list-active-assignments.ts
+++ b/src/modules/assignments-2062/application/list-active-assignments.ts
@@ -23,13 +23,17 @@ type SummaryDependencies = Omit<
   assignment: AssignmentRecord;
 };
 
-type HistoricalLinkDependencies = {
-  account: AccountRecord;
-  assignment: AssignmentRecord;
+type CoverageHistoryEntryDependencies = {
   closedAt: Date | null;
   createdAt: Date;
-  handReceiptRepository: HandReceiptRepository;
   linkId: string;
+  assignmentId: string;
+  handReceiptId: string;
+  handReceiptName: string;
+  contactId: string;
+  contactName: string;
+  documentId: string;
+  documentFilename: string;
 };
 
 async function toActiveAssignmentSummary({
@@ -68,36 +72,31 @@ async function toActiveAssignmentSummary({
   };
 }
 
-async function toHistoricalAssignmentLink({
-  account,
-  assignment,
-  handReceiptRepository,
-  linkId,
+function coverageEntryToHistoricalAssignmentLink({
+  assignmentId,
   closedAt,
+  contactId,
+  contactName,
   createdAt,
-}: HistoricalLinkDependencies): Promise<HistoricalAssignmentLink | null> {
+  documentFilename,
+  documentId,
+  handReceiptId,
+  handReceiptName,
+  linkId,
+}: CoverageHistoryEntryDependencies): HistoricalAssignmentLink | null {
   if (!closedAt) {
-    return null;
-  }
-
-  const handReceipt = await handReceiptRepository.findById(
-    account.id,
-    assignment.handReceiptId,
-  );
-
-  if (!handReceipt) {
     return null;
   }
 
   return {
     linkId,
-    assignmentId: assignment.id,
-    handReceiptId: assignment.handReceiptId,
-    handReceiptName: handReceipt.name,
-    contactId: assignment.contactId,
-    contactName: assignment.contactName ?? "Unknown contact",
-    documentId: assignment.documentId,
-    documentFilename: assignment.documentFilename ?? "2062 document",
+    assignmentId,
+    handReceiptId,
+    handReceiptName,
+    contactId,
+    contactName,
+    documentId,
+    documentFilename,
     closedAt,
     createdAt,
   };
@@ -169,11 +168,15 @@ export async function getItemCoverage({
 }: AssignmentQueryDependencies & {
   itemId: string;
 }): Promise<ItemCoverageResult> {
-  const [activeLink, historicalLinks] = await Promise.all([
+  const [activeLink, historicalEntries] = await Promise.all([
     assignmentItemLinkRepository.findActiveByItemId(account.id, itemId),
-    assignmentItemLinkRepository.findByItemId(account.id, itemId, {
-      status: "closed",
-    }),
+    assignmentItemLinkRepository.findByItemIdWithAssignment(
+      account.id,
+      itemId,
+      {
+        status: "closed",
+      },
+    ),
   ]);
 
   const activeAssignment = activeLink
@@ -188,26 +191,8 @@ export async function getItemCoverage({
       })
     : null;
 
-  const history = await Promise.all(
-    historicalLinks.map(async (link) => {
-      const assignment = await assignmentRepository.findById(
-        account.id,
-        link.assignmentId,
-      );
-
-      if (!assignment) {
-        return null;
-      }
-
-      return toHistoricalAssignmentLink({
-        account,
-        assignment,
-        closedAt: link.closedAt,
-        createdAt: link.createdAt,
-        handReceiptRepository,
-        linkId: link.id,
-      });
-    }),
+  const history = historicalEntries.map(
+    coverageEntryToHistoricalAssignmentLink,
   );
 
   return {

--- a/src/modules/assignments-2062/application/types.ts
+++ b/src/modules/assignments-2062/application/types.ts
@@ -48,6 +48,38 @@ export type Active2062Coverage = {
   documentFilename: string;
 };
 
+export type ActiveAssignmentSummary = {
+  id: string;
+  handReceiptId: string;
+  handReceiptName: string;
+  contactId: string;
+  contactName: string;
+  documentId: string;
+  documentFilename: string;
+  itemCount: number;
+  status: "active";
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type HistoricalAssignmentLink = {
+  linkId: string;
+  assignmentId: string;
+  handReceiptId: string;
+  handReceiptName: string;
+  contactId: string;
+  contactName: string;
+  documentId: string;
+  documentFilename: string;
+  closedAt: Date;
+  createdAt: Date;
+};
+
+export type ItemCoverageResult = {
+  current: ActiveAssignmentSummary | null;
+  history: HistoricalAssignmentLink[];
+};
+
 export type CreateAssignmentInput =
   | {
       itemId: string;

--- a/src/modules/assignments-2062/application/types.ts
+++ b/src/modules/assignments-2062/application/types.ts
@@ -24,6 +24,22 @@ export type AssignmentItemLinkRecord = {
   updatedAt: Date;
 };
 
+export type CoverageHistoryEntry = {
+  linkId: string;
+  assignmentId: string;
+  itemId: string;
+  status: AssignmentStatus;
+  closedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  handReceiptId: string;
+  handReceiptName: string;
+  contactId: string;
+  contactName: string;
+  documentId: string;
+  documentFilename: string;
+};
+
 export type NewAssignmentRecord = Omit<
   AssignmentRecord,
   "contactName" | "documentFilename" | "createdAt" | "updatedAt"
@@ -109,3 +125,93 @@ export type CreateAssignmentWithItemsInput =
       contactDisplayName: string;
       documentId: string;
     };
+
+/**
+ * Expected assignments-2062 failures use typed errors so API adapters can map
+ * them to status codes without depending on user-facing message text. Add a
+ * new typed error when callers should handle the failure deliberately; keep
+ * plain Error for unexpected internal failures.
+ */
+export class AccountReadOnlyError extends Error {
+  constructor() {
+    super("This account is read-only.");
+    this.name = "AccountReadOnlyError";
+  }
+}
+
+export class Active2062CoverageConflictError extends Error {
+  constructor() {
+    super("Item already has active 2062 coverage.");
+    this.name = "Active2062CoverageConflictError";
+  }
+}
+
+export class ContactDisplayNameRequiredError extends Error {
+  constructor() {
+    super("Contact display name is required.");
+    this.name = "ContactDisplayNameRequiredError";
+  }
+}
+
+export class ContactNotFoundError extends Error {
+  constructor() {
+    super("Contact was not found.");
+    this.name = "ContactNotFoundError";
+  }
+}
+
+export class DocumentNotFoundError extends Error {
+  constructor() {
+    super("Document was not found.");
+    this.name = "DocumentNotFoundError";
+  }
+}
+
+export class DocumentReceiptMismatchError extends Error {
+  constructor(message = "Document must belong to the hand receipt.") {
+    super(message);
+    this.name = "DocumentReceiptMismatchError";
+  }
+}
+
+export class EmptyItemSelectionError extends Error {
+  constructor() {
+    super("Select at least one item.");
+    this.name = "EmptyItemSelectionError";
+  }
+}
+
+export class HandReceiptNotActiveError extends Error {
+  constructor() {
+    super("Hand receipt must be active to upload a 2062.");
+    this.name = "HandReceiptNotActiveError";
+  }
+}
+
+export class HandReceiptNotFoundError extends Error {
+  constructor() {
+    super("Hand receipt was not found.");
+    this.name = "HandReceiptNotFoundError";
+  }
+}
+
+export class ItemNotActiveError extends Error {
+  constructor(message = "Item must be active to upload a 2062.") {
+    super(message);
+    this.name = "ItemNotActiveError";
+  }
+}
+
+export class ItemNotFoundError extends Error {
+  constructor() {
+    super("Item was not found.");
+    this.name = "ItemNotFoundError";
+  }
+}
+
+export class ItemReceiptMismatchError extends Error {
+  constructor() {
+    super("Items must belong to the selected hand receipt.");
+    this.name = "ItemReceiptMismatchError";
+  }
+}

--- a/src/modules/assignments-2062/index.ts
+++ b/src/modules/assignments-2062/index.ts
@@ -3,7 +3,6 @@ export { createUnavailableAssignmentItemLinkRepository } from "./application/ass
 export type { AssignmentRepository } from "./application/assignment-repository";
 export { createUnavailableAssignmentRepository } from "./application/assignment-repository";
 export {
-  Active2062CoverageConflictError,
   createAssignment,
   createAssignmentWithItems,
 } from "./application/create-assignment";
@@ -13,12 +12,27 @@ export {
   getItemCoverage,
   listActiveAssignments,
 } from "./application/list-active-assignments";
+export {
+  AccountReadOnlyError,
+  Active2062CoverageConflictError,
+  ContactDisplayNameRequiredError,
+  ContactNotFoundError,
+  DocumentNotFoundError,
+  DocumentReceiptMismatchError,
+  EmptyItemSelectionError,
+  HandReceiptNotActiveError,
+  HandReceiptNotFoundError,
+  ItemNotActiveError,
+  ItemNotFoundError,
+  ItemReceiptMismatchError,
+} from "./application/types";
 export type {
   ActiveAssignmentSummary,
   Active2062Coverage,
   AssignmentItemLinkRecord,
   AssignmentRecord,
   AssignmentStatus,
+  CoverageHistoryEntry,
   CreateAssignmentInput,
   CreateAssignmentWithItemsInput,
   HistoricalAssignmentLink,

--- a/src/modules/assignments-2062/index.ts
+++ b/src/modules/assignments-2062/index.ts
@@ -8,13 +8,21 @@ export {
   createAssignmentWithItems,
 } from "./application/create-assignment";
 export { hasActive2062Coverage } from "./application/has-active-2062-coverage";
+export {
+  getHandReceiptAssignments,
+  getItemCoverage,
+  listActiveAssignments,
+} from "./application/list-active-assignments";
 export type {
+  ActiveAssignmentSummary,
   Active2062Coverage,
   AssignmentItemLinkRecord,
   AssignmentRecord,
   AssignmentStatus,
   CreateAssignmentInput,
   CreateAssignmentWithItemsInput,
+  HistoricalAssignmentLink,
+  ItemCoverageResult,
   NewAssignmentItemLinkRecord,
   NewAssignmentRecord,
 } from "./application/types";

--- a/src/modules/assignments-2062/infrastructure/drizzle-assignment-item-link-repository.ts
+++ b/src/modules/assignments-2062/infrastructure/drizzle-assignment-item-link-repository.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 
 import { assignmentItemLinks } from "@/db/schema";
 import type {
@@ -78,6 +78,30 @@ function createAssignmentItemLinkRepository(
       );
 
       return row ? toLinkRecord(row) : null;
+    },
+    async findByItemId(accountId, itemId, options = {}) {
+      const filters = [
+        eq(assignmentItemLinks.accountId, accountId),
+        eq(assignmentItemLinks.itemId, itemId),
+      ];
+
+      if (options.status) {
+        filters.push(eq(assignmentItemLinks.status, options.status));
+      }
+
+      const rows = await run((transaction) =>
+        transaction
+          .select()
+          .from(assignmentItemLinks)
+          .where(and(...filters))
+          .orderBy(
+            desc(assignmentItemLinks.closedAt),
+            desc(assignmentItemLinks.updatedAt),
+            desc(assignmentItemLinks.createdAt),
+          ),
+      );
+
+      return rows.map(toLinkRecord);
     },
     async findByAssignmentId(accountId, assignmentId, options = {}) {
       const filters = [

--- a/src/modules/assignments-2062/infrastructure/drizzle-assignment-item-link-repository.ts
+++ b/src/modules/assignments-2062/infrastructure/drizzle-assignment-item-link-repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, count, desc, eq, inArray, sql } from "drizzle-orm";
 
 import {
   assignmentItemLinks,
@@ -193,6 +193,30 @@ function createAssignmentItemLinkRepository(
       );
 
       return rows.map(toLinkRecord);
+    },
+    async countActiveByAssignmentIds(accountId, assignmentIds) {
+      if (assignmentIds.length === 0) {
+        return new Map();
+      }
+
+      const rows = await run((transaction) =>
+        transaction
+          .select({
+            assignmentId: assignmentItemLinks.assignmentId,
+            count: count(),
+          })
+          .from(assignmentItemLinks)
+          .where(
+            and(
+              eq(assignmentItemLinks.accountId, accountId),
+              eq(assignmentItemLinks.status, "active"),
+              inArray(assignmentItemLinks.assignmentId, assignmentIds),
+            ),
+          )
+          .groupBy(assignmentItemLinks.assignmentId),
+      );
+
+      return new Map(rows.map((row) => [row.assignmentId, row.count]));
     },
     async updateStatus(accountId, linkId, status, updatedAt, closedAt = null) {
       const [updated] = await run((transaction) =>

--- a/src/modules/assignments-2062/infrastructure/drizzle-assignment-item-link-repository.ts
+++ b/src/modules/assignments-2062/infrastructure/drizzle-assignment-item-link-repository.ts
@@ -1,9 +1,16 @@
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 
-import { assignmentItemLinks } from "@/db/schema";
+import {
+  assignmentItemLinks,
+  assignments,
+  contacts,
+  documents,
+  handReceipts,
+} from "@/db/schema";
 import type {
   AssignmentItemLinkRecord,
   AssignmentItemLinkRepository,
+  CoverageHistoryEntry,
 } from "@/modules/assignments-2062";
 import type {
   AuthenticatedDatabaseSession,
@@ -28,6 +35,30 @@ function toLinkRecord(row: LinkRow): AssignmentItemLinkRecord {
     closedAt: row.closedAt,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+  };
+}
+
+function toCoverageHistoryEntry(row: {
+  link: LinkRow;
+  assignment: typeof assignments.$inferSelect;
+  contact: typeof contacts.$inferSelect;
+  document: typeof documents.$inferSelect;
+  handReceipt: typeof handReceipts.$inferSelect;
+}): CoverageHistoryEntry {
+  return {
+    linkId: row.link.id,
+    assignmentId: row.link.assignmentId,
+    itemId: row.link.itemId,
+    status: row.link.status,
+    closedAt: row.link.closedAt,
+    createdAt: row.link.createdAt,
+    updatedAt: row.link.updatedAt,
+    handReceiptId: row.assignment.handReceiptId,
+    handReceiptName: row.handReceipt.name,
+    contactId: row.assignment.contactId,
+    contactName: row.contact.displayName,
+    documentId: row.assignment.documentId,
+    documentFilename: row.document.filename,
   };
 }
 
@@ -102,6 +133,47 @@ function createAssignmentItemLinkRepository(
       );
 
       return rows.map(toLinkRecord);
+    },
+    async findByItemIdWithAssignment(accountId, itemId, options = {}) {
+      const filters = [
+        eq(assignmentItemLinks.accountId, accountId),
+        eq(assignmentItemLinks.itemId, itemId),
+      ];
+
+      if (options.status) {
+        filters.push(eq(assignmentItemLinks.status, options.status));
+      }
+
+      const rows = await run((transaction) =>
+        transaction
+          .select({
+            link: assignmentItemLinks,
+            assignment: assignments,
+            contact: contacts,
+            document: documents,
+            handReceipt: handReceipts,
+          })
+          .from(assignmentItemLinks)
+          .innerJoin(
+            assignments,
+            eq(assignmentItemLinks.assignmentId, assignments.id),
+          )
+          .innerJoin(contacts, eq(assignments.contactId, contacts.id))
+          .innerJoin(documents, eq(assignments.documentId, documents.id))
+          .innerJoin(
+            handReceipts,
+            eq(assignments.handReceiptId, handReceipts.id),
+          )
+          .where(and(...filters))
+          .orderBy(
+            sql`case when ${assignmentItemLinks.status} = 'active' then 0 else 1 end`,
+            desc(assignmentItemLinks.closedAt),
+            desc(assignmentItemLinks.updatedAt),
+            desc(assignmentItemLinks.createdAt),
+          ),
+      );
+
+      return rows.map(toCoverageHistoryEntry);
     },
     async findByAssignmentId(accountId, assignmentId, options = {}) {
       const filters = [

--- a/src/modules/assignments-2062/ui/active-2062s-empty-state.tsx
+++ b/src/modules/assignments-2062/ui/active-2062s-empty-state.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+import { ReceiptText } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+export function Active2062sEmptyState() {
+  return (
+    <section className="rounded-lg border bg-card p-4 text-card-foreground">
+      <div className="flex items-start gap-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+          <ReceiptText aria-hidden="true" className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="space-y-1">
+            <h2 className="text-sm font-semibold tracking-normal">
+              No active 2062s
+            </h2>
+            <p className="text-sm leading-6 text-muted-foreground">
+              Formal 2062 assignments will appear here after you upload a
+              private document and link it to property.
+            </p>
+          </div>
+          <Button asChild size="sm" variant="outline">
+            <Link href="/app/hand-receipts">Open hand receipts</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/modules/assignments-2062/ui/active-2062s-workspace.tsx
+++ b/src/modules/assignments-2062/ui/active-2062s-workspace.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/trpc/react";
+import { Active2062sEmptyState } from "./active-2062s-empty-state";
+import { AssignmentList } from "./assignment-list-item";
+
+export function Active2062sWorkspace() {
+  const assignmentsQuery = trpc.assignments2062.list.useQuery();
+  const assignments = assignmentsQuery.data ?? [];
+
+  function renderContent() {
+    if (assignmentsQuery.isLoading) {
+      return (
+        <div className="space-y-2" data-testid="active-2062s-loading">
+          <div className="h-24 rounded-lg border bg-card" />
+          <div className="h-24 rounded-lg border bg-card" />
+          <div className="h-24 rounded-lg border bg-card" />
+        </div>
+      );
+    }
+
+    if (assignmentsQuery.error) {
+      return (
+        <div
+          className="space-y-3 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive"
+          role="alert"
+        >
+          <p className="font-medium">Active 2062s could not be loaded.</p>
+          <p className="leading-6">{assignmentsQuery.error.message}</p>
+          <Button
+            onClick={() => void assignmentsQuery.refetch()}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Retry
+          </Button>
+        </div>
+      );
+    }
+
+    if (assignments.length === 0) {
+      return <Active2062sEmptyState />;
+    }
+
+    return <AssignmentList assignments={assignments} />;
+  }
+
+  return (
+    <section className="space-y-5">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+          Formal assignments
+        </p>
+        <h1 className="text-2xl font-semibold tracking-normal md:text-3xl">
+          Active 2062s
+        </h1>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          Review DA Form 2062 assignments that are currently active. Manual
+          signed-to records stay out of this list.
+        </p>
+      </div>
+      {renderContent()}
+    </section>
+  );
+}

--- a/src/modules/assignments-2062/ui/assignment-list-item.tsx
+++ b/src/modules/assignments-2062/ui/assignment-list-item.tsx
@@ -1,0 +1,74 @@
+import Link from "next/link";
+import { CalendarDays, ClipboardList, ReceiptText } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { ActiveAssignmentSummary } from "@/modules/assignments-2062";
+
+function formatDate(value: Date | string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
+export function AssignmentList({
+  assignments,
+}: {
+  assignments: ActiveAssignmentSummary[];
+}) {
+  return (
+    <div className="divide-y rounded-lg border bg-card text-card-foreground">
+      {assignments.map((assignment) => (
+        <article
+          className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+          key={assignment.id}
+        >
+          <div className="flex min-w-0 items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+              <ReceiptText aria-hidden="true" className="size-4" />
+            </span>
+            <div className="min-w-0 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-sm font-semibold tracking-normal">
+                  {assignment.contactName}
+                </h2>
+                <span className="rounded-sm border bg-secondary px-2 py-1 font-mono text-[0.68rem] uppercase text-muted-foreground">
+                  Active
+                </span>
+                <span className="rounded-sm border bg-secondary px-2 py-1 font-mono text-[0.68rem] uppercase text-muted-foreground">
+                  {assignment.itemCount}{" "}
+                  {assignment.itemCount === 1 ? "item" : "items"}
+                </span>
+              </div>
+              <div className="flex flex-col gap-1 text-sm text-muted-foreground sm:flex-row sm:flex-wrap sm:items-center sm:gap-3">
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <ClipboardList
+                    aria-hidden="true"
+                    className="size-4 shrink-0"
+                  />
+                  <span className="truncate">{assignment.handReceiptName}</span>
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                  <CalendarDays
+                    aria-hidden="true"
+                    className="size-4 shrink-0"
+                  />
+                  Created {formatDate(assignment.createdAt)}
+                </span>
+              </div>
+              <p className="break-words text-sm text-muted-foreground">
+                {assignment.documentFilename}
+              </p>
+            </div>
+          </div>
+          <Button asChild className="w-full sm:w-auto" size="sm">
+            <Link href={`/app/hand-receipts/${assignment.handReceiptId}`}>
+              Open context
+            </Link>
+          </Button>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/src/modules/assignments-2062/ui/hand-receipt-2062-context.tsx
+++ b/src/modules/assignments-2062/ui/hand-receipt-2062-context.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import Link from "next/link";
+import { ReceiptText } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/trpc/react";
+
+export function HandReceipt2062Context({
+  handReceiptId,
+  isReadOnly,
+  isReceiptActive,
+}: {
+  handReceiptId: string;
+  isReadOnly: boolean;
+  isReceiptActive: boolean;
+}) {
+  const assignmentsQuery =
+    trpc.assignments2062.getHandReceiptAssignments.useQuery({
+      handReceiptId,
+    });
+  const assignments = assignmentsQuery.data ?? [];
+  const canUpload = !isReadOnly && isReceiptActive;
+
+  return (
+    <section className="space-y-3 rounded-lg border bg-card p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+            <ReceiptText aria-hidden="true" className="size-4" />
+          </span>
+          <div className="space-y-1">
+            <h2 className="text-sm font-semibold tracking-normal">
+              Active 2062s
+            </h2>
+            <p className="text-sm leading-6 text-muted-foreground">
+              Formal assignments tied to this hand receipt.
+            </p>
+          </div>
+        </div>
+        <Button
+          asChild={canUpload}
+          disabled={!canUpload}
+          size="sm"
+          title={
+            isReadOnly
+              ? "2062 creation is paused while this account is read-only."
+              : isReceiptActive
+                ? "Upload a 2062 for multiple items"
+                : "Archived hand receipts cannot receive new 2062 assignments."
+          }
+          type="button"
+          variant="outline"
+        >
+          {canUpload ? (
+            <Link href={`/app/hand-receipts/${handReceiptId}/upload-2062`}>
+              Upload 2062
+            </Link>
+          ) : (
+            <>Upload 2062</>
+          )}
+        </Button>
+      </div>
+
+      {assignmentsQuery.isLoading ? (
+        <div className="h-24 rounded-lg border bg-secondary" />
+      ) : assignmentsQuery.error ? (
+        <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {assignmentsQuery.error.message}
+        </p>
+      ) : assignments.length === 0 ? (
+        <p className="rounded-lg border bg-background px-3 py-2 text-sm leading-6 text-muted-foreground">
+          No active 2062 assignments for this hand receipt.
+        </p>
+      ) : (
+        <div className="divide-y rounded-lg border bg-background">
+          {assignments.map((assignment) => (
+            <div
+              className="flex flex-col gap-2 px-3 py-3 sm:flex-row sm:items-center sm:justify-between"
+              key={assignment.id}
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium text-foreground">
+                  {assignment.contactName}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {assignment.itemCount}{" "}
+                  {assignment.itemCount === 1 ? "item" : "items"} covered
+                </p>
+              </div>
+              <Button asChild size="sm" variant="ghost">
+                <Link href="/app/active-2062s">View</Link>
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/modules/assignments-2062/ui/item-coverage-section.tsx
+++ b/src/modules/assignments-2062/ui/item-coverage-section.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import Link from "next/link";
+import { FileText, History } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { trpc } from "@/trpc/react";
+
+function formatDate(value: Date | string | null) {
+  if (!value) {
+    return "Not set";
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+}
+
+export function ItemCoverageSection({
+  isReadOnly,
+  itemId,
+  itemStatus,
+  signedToContactName,
+}: {
+  isReadOnly: boolean;
+  itemId: string;
+  itemStatus: "active" | "archived";
+  signedToContactName: string | null;
+}) {
+  const coverageQuery = trpc.assignments2062.getItemCoverage.useQuery({
+    itemId,
+  });
+  const coverage = coverageQuery.data;
+  const canUpload = itemStatus === "active" && !coverage?.current;
+
+  return (
+    <section className="rounded-lg border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+          <FileText aria-hidden="true" className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="space-y-1">
+            <h2 className="text-sm font-semibold tracking-normal">
+              2062 Coverage
+            </h2>
+            {coverageQuery.isLoading ? (
+              <div className="h-20 rounded-lg border bg-secondary" />
+            ) : coverageQuery.error ? (
+              <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {coverageQuery.error.message}
+              </p>
+            ) : coverage?.current ? (
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-sm font-medium text-foreground">
+                    {coverage.current.contactName}
+                  </p>
+                  <span className="rounded-sm border bg-secondary px-2 py-1 font-mono text-[0.68rem] uppercase text-muted-foreground">
+                    DA Form 2062
+                  </span>
+                </div>
+                <p className="break-words text-sm text-muted-foreground">
+                  {coverage.current.documentFilename}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {coverage.current.handReceiptName} -{" "}
+                  {coverage.current.itemCount}{" "}
+                  {coverage.current.itemCount === 1 ? "item" : "items"}
+                </p>
+              </div>
+            ) : signedToContactName ? (
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-sm font-medium text-foreground">
+                    Manual signed-to state
+                  </p>
+                  <span className="rounded-sm border bg-secondary px-2 py-1 font-mono text-[0.68rem] uppercase text-muted-foreground">
+                    Informal
+                  </span>
+                </div>
+                <p className="text-sm leading-6 text-muted-foreground">
+                  Manual signed-to state can be converted by uploading a formal
+                  2062.
+                </p>
+              </div>
+            ) : (
+              <p className="text-sm leading-6 text-muted-foreground">
+                No formal 2062 coverage is active for this item.
+              </p>
+            )}
+          </div>
+
+          {coverage && coverage.history.length > 0 ? (
+            <div className="space-y-2 border-t pt-3">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                <History aria-hidden="true" className="size-4" />
+                History
+              </div>
+              <div className="space-y-2">
+                {coverage.history.map((link) => (
+                  <div
+                    className="rounded-md border bg-background px-3 py-2 text-sm"
+                    key={link.linkId}
+                  >
+                    <p className="font-medium text-foreground">
+                      {link.contactName}
+                    </p>
+                    <p className="text-muted-foreground">
+                      Closed {formatDate(link.closedAt)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          {canUpload && !isReadOnly ? (
+            <Button asChild size="sm">
+              <Link href={`/app/items/${itemId}/upload-2062`}>
+                <FileText aria-hidden="true" className="size-4" />
+                Upload 2062
+              </Link>
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/modules/assignments-2062/ui/item-coverage-section.tsx
+++ b/src/modules/assignments-2062/ui/item-coverage-section.tsx
@@ -33,7 +33,11 @@ export function ItemCoverageSection({
     itemId,
   });
   const coverage = coverageQuery.data;
-  const canUpload = itemStatus === "active" && !coverage?.current;
+  const canUpload =
+    coverageQuery.isSuccess &&
+    coverage !== undefined &&
+    itemStatus === "active" &&
+    !coverage.current;
 
   return (
     <section className="rounded-lg border bg-card p-4">

--- a/src/modules/assignments-2062/ui/upload-2062-flow.tsx
+++ b/src/modules/assignments-2062/ui/upload-2062-flow.tsx
@@ -267,7 +267,15 @@ export function Upload2062Flow({ handReceiptId }: { handReceiptId: string }) {
   const createAssignment = trpc.assignments2062.createWithItems.useMutation({
     onSuccess: async () => {
       await Promise.all([
+        utilities.assignments2062.list.invalidate(),
+        utilities.assignments2062.getHandReceiptAssignments.invalidate({
+          handReceiptId,
+        }),
+        ...validSelectedItemIds.map((itemId) =>
+          utilities.assignments2062.getItemCoverage.invalidate({ itemId }),
+        ),
         utilities.items.listByHandReceipt.invalidate({ handReceiptId }),
+        utilities.items.list.invalidate(),
         utilities.items.search.invalidate(),
         utilities.handReceipts.getById.invalidate({ id: handReceiptId }),
         utilities.audit.listRecentActivity.invalidate(),

--- a/src/modules/assignments-2062/ui/upload-2062-form.tsx
+++ b/src/modules/assignments-2062/ui/upload-2062-form.tsx
@@ -35,7 +35,18 @@ export function Upload2062Form({
   const createAssignment = trpc.assignments2062.create.useMutation({
     onSuccess: async () => {
       await Promise.all([
+        utilities.assignments2062.list.invalidate(),
+        utilities.assignments2062.getItemCoverage.invalidate({
+          itemId: item.id,
+        }),
+        utilities.assignments2062.getHandReceiptAssignments.invalidate({
+          handReceiptId: item.handReceiptId,
+        }),
         utilities.items.getById.invalidate({ id: item.id }),
+        utilities.items.listByHandReceipt.invalidate({
+          handReceiptId: item.handReceiptId,
+          status: "active",
+        }),
         utilities.items.search.invalidate(),
         utilities.audit.listRecentActivity.invalidate(),
         utilities.audit.listTargetActivity.invalidate({

--- a/src/modules/hand-receipts/application/hand-receipt-repository.ts
+++ b/src/modules/hand-receipts/application/hand-receipt-repository.ts
@@ -15,6 +15,10 @@ export interface HandReceiptRepository {
     accountId: string,
     handReceiptId: string,
   ): Promise<HandReceiptRecord | null>;
+  findManyByIds(
+    accountId: string,
+    handReceiptIds: string[],
+  ): Promise<HandReceiptRecord[]>;
   update(
     accountId: string,
     handReceiptId: string,
@@ -32,6 +36,9 @@ export function createUnavailableHandReceiptRepository(): HandReceiptRepository 
       throw new Error("An authenticated database session is required.");
     },
     async findById() {
+      throw new Error("An authenticated database session is required.");
+    },
+    async findManyByIds() {
       throw new Error("An authenticated database session is required.");
     },
     async update() {

--- a/src/modules/hand-receipts/infrastructure/drizzle-hand-receipt-repository.ts
+++ b/src/modules/hand-receipts/infrastructure/drizzle-hand-receipt-repository.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq } from "drizzle-orm";
+import { and, count, desc, eq, inArray } from "drizzle-orm";
 
 import { handReceipts } from "@/db/schema";
 import type { HandReceiptRepository } from "@/modules/hand-receipts";
@@ -86,6 +86,25 @@ function createHandReceiptRepository(
       );
 
       return row ? toHandReceiptRecord(row) : null;
+    },
+    async findManyByIds(accountId, handReceiptIds) {
+      if (handReceiptIds.length === 0) {
+        return [];
+      }
+
+      const rows = await run((transaction) =>
+        transaction
+          .select()
+          .from(handReceipts)
+          .where(
+            and(
+              eq(handReceipts.accountId, accountId),
+              inArray(handReceipts.id, handReceiptIds),
+            ),
+          ),
+      );
+
+      return rows.map(toHandReceiptRecord);
     },
     async update(accountId, handReceiptId, updates) {
       const [updatedHandReceipt] = await run(async (transaction) => {

--- a/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
+++ b/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
@@ -7,7 +7,6 @@ import {
   ArrowLeft,
   CalendarDays,
   ClipboardList,
-  FileUp,
   History,
   Pencil,
   RotateCcw,
@@ -23,6 +22,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { ActivityList } from "@/modules/audit/ui/activity-list";
+import { HandReceipt2062Context } from "@/modules/assignments-2062/ui/hand-receipt-2062-context";
 import { DocumentList } from "@/modules/documents/ui/document-list";
 import { DocumentUpload } from "@/modules/documents/ui/document-upload";
 import type { HandReceiptRecord } from "@/modules/hand-receipts";
@@ -428,34 +428,6 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
               <div className="flex flex-wrap gap-2">
                 {!isViewingArchivedItems ? (
                   <>
-                    <Button
-                      asChild={!isReadOnly && handReceipt.status === "active"}
-                      disabled={isReadOnly || handReceipt.status !== "active"}
-                      size="sm"
-                      title={
-                        isReadOnly
-                          ? "2062 creation is paused while this account is read-only."
-                          : handReceipt.status !== "active"
-                            ? "Archived hand receipts cannot receive new 2062 assignments."
-                            : "Upload a 2062 for multiple items"
-                      }
-                      type="button"
-                      variant="outline"
-                    >
-                      {!isReadOnly && handReceipt.status === "active" ? (
-                        <Link
-                          href={`/app/hand-receipts/${handReceiptId}/upload-2062`}
-                        >
-                          <FileUp aria-hidden="true" className="size-4" />
-                          Upload 2062
-                        </Link>
-                      ) : (
-                        <>
-                          <FileUp aria-hidden="true" className="size-4" />
-                          Upload 2062
-                        </>
-                      )}
-                    </Button>
                     <CreateItemForm
                       canCreate={!isReadOnly && handReceipt.status === "active"}
                       disabledReason={createItemDisabledReason}
@@ -534,6 +506,11 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
             )}
           </section>
           <div className="space-y-3">
+            <HandReceipt2062Context
+              handReceiptId={handReceiptId}
+              isReadOnly={isReadOnly}
+              isReceiptActive={handReceipt.status === "active"}
+            />
             <DocumentUpload
               disabled={isReadOnly || handReceipt.status !== "active"}
               handReceiptId={handReceiptId}

--- a/src/modules/items/ui/item-detail.tsx
+++ b/src/modules/items/ui/item-detail.tsx
@@ -7,7 +7,6 @@ import {
   ArrowLeft,
   ArrowRightLeft,
   ClipboardList,
-  FileText,
   Hash,
   History,
   PackageSearch,
@@ -26,6 +25,7 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { ActivityList } from "@/modules/audit/ui/activity-list";
+import { ItemCoverageSection } from "@/modules/assignments-2062/ui/item-coverage-section";
 import { ContactPicker } from "@/modules/contacts/ui/contact-picker";
 import type { HandReceiptRecord } from "@/modules/hand-receipts";
 import type { ItemRecord } from "@/modules/items";
@@ -74,75 +74,6 @@ function MetadataRow({
         {value || "Not set"}
       </dd>
     </div>
-  );
-}
-
-function Active2062Section({
-  isReadOnly,
-  item,
-}: {
-  isReadOnly: boolean;
-  item: ItemRecord;
-}) {
-  const canUpload = item.status === "active" && !item.active2062Coverage;
-
-  return (
-    <section className="rounded-lg border bg-card p-4">
-      <div className="flex items-start gap-3">
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
-          <FileText aria-hidden="true" className="size-4" />
-        </span>
-        <div className="min-w-0 flex-1 space-y-3">
-          <div className="space-y-1">
-            <h2 className="text-sm font-semibold tracking-normal">
-              Active 2062s
-            </h2>
-            {item.active2062Coverage ? (
-              <div className="space-y-2">
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="text-sm font-medium text-foreground">
-                    {item.active2062Coverage.contactName}
-                  </p>
-                  <span className="rounded-sm border bg-secondary px-2 py-1 font-mono text-[0.68rem] uppercase text-muted-foreground">
-                    DA Form 2062
-                  </span>
-                </div>
-                <p className="break-words text-sm text-muted-foreground">
-                  {item.active2062Coverage.documentFilename}
-                </p>
-              </div>
-            ) : item.signedToContactName ? (
-              <div className="space-y-2">
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="text-sm font-medium text-foreground">
-                    Manual signed-to state
-                  </p>
-                  <span className="rounded-sm border bg-secondary px-2 py-1 font-mono text-[0.68rem] uppercase text-muted-foreground">
-                    Informal
-                  </span>
-                </div>
-                <p className="text-sm leading-6 text-muted-foreground">
-                  Manual signed-to state can be converted by uploading a formal
-                  2062.
-                </p>
-              </div>
-            ) : (
-              <p className="text-sm leading-6 text-muted-foreground">
-                No formal 2062 coverage is active for this item.
-              </p>
-            )}
-          </div>
-          {canUpload && !isReadOnly ? (
-            <Button asChild size="sm">
-              <Link href={`/app/items/${item.id}/upload-2062`}>
-                <FileText aria-hidden="true" className="size-4" />
-                Upload 2062
-              </Link>
-            </Button>
-          ) : null}
-        </div>
-      </div>
-    </section>
   );
 }
 
@@ -647,7 +578,12 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
           isReadOnly={isReadOnly}
           itemId={item.id}
         />
-        <Active2062Section isReadOnly={isReadOnly} item={item} />
+        <ItemCoverageSection
+          isReadOnly={isReadOnly}
+          itemId={item.id}
+          itemStatus={item.status}
+          signedToContactName={item.signedToContactName ?? null}
+        />
       </div>
 
       <section className="space-y-3">

--- a/src/server/trpc/routers/assignments-2062.ts
+++ b/src/server/trpc/routers/assignments-2062.ts
@@ -150,34 +150,45 @@ async function runInUnitOfWork<T>(
 
 export const assignments2062Router = createTRPCRouter({
   list: protectedProcedure.query(({ ctx }) =>
-    listActiveAssignments({
-      account: ctx.account,
-      assignmentItemLinkRepository: ctx.assignmentItemLinkRepository,
-      assignmentRepository: ctx.assignmentRepository,
-      handReceiptRepository: ctx.handReceiptRepository,
-    }),
+    runInUnitOfWork(ctx, "assignments2062.list", (repositories) =>
+      listActiveAssignments({
+        account: ctx.account,
+        assignmentItemLinkRepository: repositories.assignmentItemLinkRepository,
+        assignmentRepository: repositories.assignmentRepository,
+        handReceiptRepository: repositories.handReceiptRepository,
+      }),
+    ),
   ),
   getItemCoverage: protectedProcedure
     .input(z.object({ itemId: z.uuid() }))
     .query(({ ctx, input }) =>
-      getItemCoverage({
-        account: ctx.account,
-        assignmentItemLinkRepository: ctx.assignmentItemLinkRepository,
-        assignmentRepository: ctx.assignmentRepository,
-        handReceiptRepository: ctx.handReceiptRepository,
-        itemId: input.itemId,
-      }),
+      runInUnitOfWork(ctx, "assignments2062.getItemCoverage", (repositories) =>
+        getItemCoverage({
+          account: ctx.account,
+          assignmentItemLinkRepository:
+            repositories.assignmentItemLinkRepository,
+          assignmentRepository: repositories.assignmentRepository,
+          handReceiptRepository: repositories.handReceiptRepository,
+          itemId: input.itemId,
+        }),
+      ),
     ),
   getHandReceiptAssignments: protectedProcedure
     .input(z.object({ handReceiptId: z.uuid() }))
     .query(({ ctx, input }) =>
-      getHandReceiptAssignments({
-        account: ctx.account,
-        assignmentItemLinkRepository: ctx.assignmentItemLinkRepository,
-        assignmentRepository: ctx.assignmentRepository,
-        handReceiptId: input.handReceiptId,
-        handReceiptRepository: ctx.handReceiptRepository,
-      }),
+      runInUnitOfWork(
+        ctx,
+        "assignments2062.getHandReceiptAssignments",
+        (repositories) =>
+          getHandReceiptAssignments({
+            account: ctx.account,
+            assignmentItemLinkRepository:
+              repositories.assignmentItemLinkRepository,
+            assignmentRepository: repositories.assignmentRepository,
+            handReceiptId: input.handReceiptId,
+            handReceiptRepository: repositories.handReceiptRepository,
+          }),
+      ),
     ),
   create: protectedProcedure
     .input(createAssignmentInput)

--- a/src/server/trpc/routers/assignments-2062.ts
+++ b/src/server/trpc/routers/assignments-2062.ts
@@ -5,6 +5,9 @@ import {
   Active2062CoverageConflictError,
   createAssignment,
   createAssignmentWithItems,
+  getHandReceiptAssignments,
+  getItemCoverage,
+  listActiveAssignments,
 } from "@/modules/assignments-2062";
 import type {
   AppUnitOfWork,
@@ -125,6 +128,36 @@ async function runInUnitOfWork<T>(
 }
 
 export const assignments2062Router = createTRPCRouter({
+  list: protectedProcedure.query(({ ctx }) =>
+    listActiveAssignments({
+      account: ctx.account,
+      assignmentItemLinkRepository: ctx.assignmentItemLinkRepository,
+      assignmentRepository: ctx.assignmentRepository,
+      handReceiptRepository: ctx.handReceiptRepository,
+    }),
+  ),
+  getItemCoverage: protectedProcedure
+    .input(z.object({ itemId: z.uuid() }))
+    .query(({ ctx, input }) =>
+      getItemCoverage({
+        account: ctx.account,
+        assignmentItemLinkRepository: ctx.assignmentItemLinkRepository,
+        assignmentRepository: ctx.assignmentRepository,
+        handReceiptRepository: ctx.handReceiptRepository,
+        itemId: input.itemId,
+      }),
+    ),
+  getHandReceiptAssignments: protectedProcedure
+    .input(z.object({ handReceiptId: z.uuid() }))
+    .query(({ ctx, input }) =>
+      getHandReceiptAssignments({
+        account: ctx.account,
+        assignmentItemLinkRepository: ctx.assignmentItemLinkRepository,
+        assignmentRepository: ctx.assignmentRepository,
+        handReceiptId: input.handReceiptId,
+        handReceiptRepository: ctx.handReceiptRepository,
+      }),
+    ),
   create: protectedProcedure
     .input(createAssignmentInput)
     .mutation(({ ctx, input }) =>

--- a/src/server/trpc/routers/assignments-2062.ts
+++ b/src/server/trpc/routers/assignments-2062.ts
@@ -2,11 +2,22 @@ import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
 import {
+  AccountReadOnlyError,
   Active2062CoverageConflictError,
+  ContactDisplayNameRequiredError,
+  ContactNotFoundError,
   createAssignment,
   createAssignmentWithItems,
+  DocumentNotFoundError,
+  DocumentReceiptMismatchError,
+  EmptyItemSelectionError,
   getHandReceiptAssignments,
   getItemCoverage,
+  HandReceiptNotActiveError,
+  HandReceiptNotFoundError,
+  ItemNotActiveError,
+  ItemNotFoundError,
+  ItemReceiptMismatchError,
   listActiveAssignments,
 } from "@/modules/assignments-2062";
 import type {
@@ -59,35 +70,19 @@ function toTRPCError(
   const message =
     error instanceof Error ? error.message : "Unable to create 2062.";
 
-  if (
-    error instanceof Active2062CoverageConflictError ||
-    message === "Item must be active to upload a 2062." ||
-    message === "Items must be active to upload a 2062." ||
-    message === "Hand receipt must be active to upload a 2062." ||
-    message === "Document must belong to the item's hand receipt." ||
-    message === "Document must belong to the hand receipt." ||
-    message === "Items must belong to the selected hand receipt."
-  ) {
+  if (isConflictError(error)) {
     throw new TRPCError({ code: "CONFLICT", message });
   }
 
-  if (message === "This account is read-only.") {
+  if (error instanceof AccountReadOnlyError) {
     throw new TRPCError({ code: "FORBIDDEN", message });
   }
 
-  if (
-    message === "Item was not found." ||
-    message === "Contact was not found." ||
-    message === "Document was not found." ||
-    message === "Hand receipt was not found."
-  ) {
+  if (isNotFoundError(error)) {
     throw new TRPCError({ code: "NOT_FOUND", message });
   }
 
-  if (
-    message === "Contact display name is required." ||
-    message === "Select at least one item."
-  ) {
+  if (isBadRequestError(error)) {
     throw new TRPCError({ code: "BAD_REQUEST", message });
   }
 
@@ -101,6 +96,32 @@ function toTRPCError(
     code: "INTERNAL_SERVER_ERROR",
     message: "Unable to create 2062.",
   });
+}
+
+function isConflictError(error: unknown) {
+  return (
+    error instanceof Active2062CoverageConflictError ||
+    error instanceof DocumentReceiptMismatchError ||
+    error instanceof HandReceiptNotActiveError ||
+    error instanceof ItemNotActiveError ||
+    error instanceof ItemReceiptMismatchError
+  );
+}
+
+function isNotFoundError(error: unknown) {
+  return (
+    error instanceof ContactNotFoundError ||
+    error instanceof DocumentNotFoundError ||
+    error instanceof HandReceiptNotFoundError ||
+    error instanceof ItemNotFoundError
+  );
+}
+
+function isBadRequestError(error: unknown) {
+  return (
+    error instanceof ContactDisplayNameRequiredError ||
+    error instanceof EmptyItemSelectionError
+  );
 }
 
 async function runInUnitOfWork<T>(

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -53,7 +53,7 @@ test("mobile shell uses bottom navigation and exposes More surfaces", async ({
   await page.getByRole("link", { name: "Active 2062s" }).click();
   await expect(page).toHaveURL(/\/app\/active-2062s$/);
   await expect(
-    page.getByRole("heading", { name: "Active 2062s" }),
+    page.getByRole("heading", { exact: true, name: "Active 2062s" }),
   ).toBeVisible();
 });
 

--- a/tests/e2e/hand-receipts.spec.ts
+++ b/tests/e2e/hand-receipts.spec.ts
@@ -148,7 +148,7 @@ test("users can open and edit item details from a hand receipt", async ({
     page.getByRole("heading", { name: "Requirements" }),
   ).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Active 2062s" }),
+    page.getByRole("heading", { name: "2062 Coverage" }),
   ).toBeVisible();
   await expect(page.getByText("Arms room")).toBeVisible();
 
@@ -236,7 +236,16 @@ test("users can create multi-item formal 2062 coverage from hand receipt detail"
 
   await expect(page).toHaveURL(/\/app\/hand-receipts\/[0-9a-f-]+$/);
   await expect(page.getByText("DA Form 2062")).toHaveCount(2);
-  await expect(page.getByText("SPC Multi")).toHaveCount(2);
+  await expect(page.getByText("SPC Multi")).toHaveCount(3);
+  await expect(page.getByText("2 items covered")).toBeVisible();
+
+  await page.goto("/app/active-2062s");
+  await expect(
+    page.getByRole("heading", { name: "Active 2062s" }),
+  ).toBeVisible();
+  await expect(page.getByText("SPC Multi")).toBeVisible();
+  await expect(page.getByText("Multi 2062 receipt")).toBeVisible();
+  await expect(page.getByText("2 items")).toBeVisible();
 });
 
 test("hand receipt upload 2062 flow uses desktop width without horizontal overflow", async ({

--- a/tests/integration/trpc/assignments-2062-router.test.ts
+++ b/tests/integration/trpc/assignments-2062-router.test.ts
@@ -404,4 +404,115 @@ describe("assignments2062Router", () => {
       }),
     ).rejects.toMatchObject({ code: "CONFLICT" });
   });
+
+  it("lists active formal 2062 assignments without manual signed-to records", async () => {
+    const { caller, assignmentItemLinkRepository, assignmentRepository } =
+      createCaller();
+
+    await caller.assignments2062.createWithItems({
+      handReceiptId: "88888888-8888-4888-8888-888888888888",
+      itemIds: [
+        "dddddddd-dddd-4ddd-9ddd-dddddddddddd",
+        "77777777-7777-4777-9777-777777777777",
+      ],
+      contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+    });
+    const createdAssignment = assignmentRepository.assignments[0];
+    const createdLink = assignmentItemLinkRepository.links[0];
+
+    if (!createdAssignment || !createdLink) {
+      throw new Error("Missing created assignment fixture.");
+    }
+
+    assignmentRepository.assignments[0] = {
+      ...createdAssignment,
+      contactName: "SPC Rivera",
+      documentFilename: "signed-2062.pdf",
+    };
+    assignmentRepository.assignments.push({
+      ...createdAssignment,
+      id: "11111111-1111-4111-8111-111111111111",
+      status: "closed",
+      createdAt: new Date("2026-04-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-02T12:00:00.000Z"),
+    });
+    assignmentItemLinkRepository.links.push({
+      ...createdLink,
+      id: "22222222-2222-4222-8222-222222222222",
+      assignmentId: "11111111-1111-4111-8111-111111111111",
+      itemId: "99999999-9999-4999-9999-999999999998",
+      status: "closed",
+      closedAt: new Date("2026-04-02T12:00:00.000Z"),
+      createdAt: new Date("2026-04-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-02T12:00:00.000Z"),
+    });
+
+    await expect(caller.assignments2062.list()).resolves.toEqual([
+      expect.objectContaining({
+        id: createdAssignment.id,
+        contactName: "SPC Rivera",
+        handReceiptName: "Primary receipt",
+        itemCount: 2,
+        status: "active",
+      }),
+    ]);
+  });
+
+  it("returns current and historical item coverage through the typed procedure", async () => {
+    const { caller, assignmentItemLinkRepository, assignmentRepository } =
+      createCaller();
+
+    await caller.assignments2062.create({
+      itemId: "dddddddd-dddd-4ddd-9ddd-dddddddddddd",
+      contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+    });
+    const activeAssignment = assignmentRepository.assignments[0];
+    const activeLink = assignmentItemLinkRepository.links[0];
+
+    if (!activeAssignment || !activeLink) {
+      throw new Error("Missing active assignment fixture.");
+    }
+
+    assignmentRepository.assignments[0] = {
+      ...activeAssignment,
+      contactName: "SPC Rivera",
+      documentFilename: "signed-2062.pdf",
+    };
+    assignmentRepository.assignments.push({
+      ...activeAssignment,
+      id: "33333333-3333-4333-8333-333333333333",
+      status: "closed",
+      createdAt: new Date("2026-04-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-02T12:00:00.000Z"),
+    });
+    assignmentItemLinkRepository.links.push({
+      ...activeLink,
+      id: "44444444-4444-4444-8444-444444444444",
+      assignmentId: "33333333-3333-4333-8333-333333333333",
+      status: "closed",
+      closedAt: new Date("2026-04-02T12:00:00.000Z"),
+      createdAt: new Date("2026-04-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-02T12:00:00.000Z"),
+    });
+
+    await expect(
+      caller.assignments2062.getItemCoverage({
+        itemId: "dddddddd-dddd-4ddd-9ddd-dddddddddddd",
+      }),
+    ).resolves.toMatchObject({
+      current: {
+        id: activeAssignment.id,
+        contactName: "SPC Rivera",
+        itemCount: 1,
+      },
+      history: [
+        {
+          assignmentId: "33333333-3333-4333-8333-333333333333",
+          linkId: "44444444-4444-4444-8444-444444444444",
+        },
+      ],
+    });
+  });
 });

--- a/tests/integration/trpc/assignments-2062-router.test.ts
+++ b/tests/integration/trpc/assignments-2062-router.test.ts
@@ -483,6 +483,8 @@ describe("assignments2062Router", () => {
     assignmentRepository.assignments.push({
       ...activeAssignment,
       id: "33333333-3333-4333-8333-333333333333",
+      contactName: "SPC Rivera",
+      documentFilename: "closed-2062.pdf",
       status: "closed",
       createdAt: new Date("2026-04-01T12:00:00.000Z"),
       updatedAt: new Date("2026-04-02T12:00:00.000Z"),
@@ -495,6 +497,15 @@ describe("assignments2062Router", () => {
       closedAt: new Date("2026-04-02T12:00:00.000Z"),
       createdAt: new Date("2026-04-01T12:00:00.000Z"),
       updatedAt: new Date("2026-04-02T12:00:00.000Z"),
+    });
+    assignmentItemLinkRepository.assignmentContexts.push({
+      assignmentId: "33333333-3333-4333-8333-333333333333",
+      handReceiptId: "88888888-8888-4888-8888-888888888888",
+      handReceiptName: "Primary receipt",
+      contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      contactName: "SPC Rivera",
+      documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+      documentFilename: "closed-2062.pdf",
     });
 
     await expect(

--- a/tests/support/assignment-item-link-repository.ts
+++ b/tests/support/assignment-item-link-repository.ts
@@ -17,6 +17,27 @@ type AssignmentLinkContext = Pick<
   | "documentFilename"
 >;
 
+function compareLinksByRecency(
+  left: Pick<AssignmentItemLinkRecord, "closedAt" | "createdAt" | "updatedAt">,
+  right: Pick<AssignmentItemLinkRecord, "closedAt" | "createdAt" | "updatedAt">,
+) {
+  const closedDelta =
+    (right.closedAt?.getTime() ?? Number.NEGATIVE_INFINITY) -
+    (left.closedAt?.getTime() ?? Number.NEGATIVE_INFINITY);
+
+  if (closedDelta !== 0) {
+    return closedDelta;
+  }
+
+  const updatedDelta = right.updatedAt.getTime() - left.updatedAt.getTime();
+
+  if (updatedDelta !== 0) {
+    return updatedDelta;
+  }
+
+  return right.createdAt.getTime() - left.createdAt.getTime();
+}
+
 export class InMemoryAssignmentItemLinkRepository implements AssignmentItemLinkRepository {
   links: AssignmentItemLinkRecord[] = [];
   assignmentContexts: AssignmentLinkContext[] = [];
@@ -86,13 +107,7 @@ export class InMemoryAssignmentItemLinkRepository implements AssignmentItemLinkR
         (link) =>
           options.status === undefined || link.status === options.status,
       )
-      .sort((left, right) => {
-        const leftTime = left.closedAt?.getTime() ?? left.updatedAt.getTime();
-        const rightTime =
-          right.closedAt?.getTime() ?? right.updatedAt.getTime();
-
-        return rightTime - leftTime;
-      });
+      .sort(compareLinksByRecency);
   }
 
   async findByItemIdWithAssignment(
@@ -138,11 +153,7 @@ export class InMemoryAssignmentItemLinkRepository implements AssignmentItemLinkR
           return left.status === "active" ? -1 : 1;
         }
 
-        const leftTime = left.closedAt?.getTime() ?? left.updatedAt.getTime();
-        const rightTime =
-          right.closedAt?.getTime() ?? right.updatedAt.getTime();
-
-        return rightTime - leftTime;
+        return compareLinksByRecency(left, right);
       });
   }
 
@@ -160,6 +171,25 @@ export class InMemoryAssignmentItemLinkRepository implements AssignmentItemLinkR
         (link) =>
           options.status === undefined || link.status === options.status,
       );
+  }
+
+  async countActiveByAssignmentIds(accountId: string, assignmentIds: string[]) {
+    const assignmentIdSet = new Set(assignmentIds);
+    const counts = new Map<string, number>();
+
+    for (const link of this.links) {
+      if (
+        link.accountId !== accountId ||
+        link.status !== "active" ||
+        !assignmentIdSet.has(link.assignmentId)
+      ) {
+        continue;
+      }
+
+      counts.set(link.assignmentId, (counts.get(link.assignmentId) ?? 0) + 1);
+    }
+
+    return counts;
   }
 
   async updateStatus(

--- a/tests/support/assignment-item-link-repository.ts
+++ b/tests/support/assignment-item-link-repository.ts
@@ -58,6 +58,26 @@ export class InMemoryAssignmentItemLinkRepository implements AssignmentItemLinkR
     );
   }
 
+  async findByItemId(
+    accountId: string,
+    itemId: string,
+    options: { status?: AssignmentStatus } = {},
+  ) {
+    return this.links
+      .filter((link) => link.accountId === accountId && link.itemId === itemId)
+      .filter(
+        (link) =>
+          options.status === undefined || link.status === options.status,
+      )
+      .sort((left, right) => {
+        const leftTime = left.closedAt?.getTime() ?? left.updatedAt.getTime();
+        const rightTime =
+          right.closedAt?.getTime() ?? right.updatedAt.getTime();
+
+        return rightTime - leftTime;
+      });
+  }
+
   async findByAssignmentId(
     accountId: string,
     assignmentId: string,

--- a/tests/support/assignment-item-link-repository.ts
+++ b/tests/support/assignment-item-link-repository.ts
@@ -2,14 +2,31 @@ import type {
   AssignmentItemLinkRecord,
   AssignmentItemLinkRepository,
   AssignmentStatus,
+  CoverageHistoryEntry,
   NewAssignmentItemLinkRecord,
 } from "@/modules/assignments-2062";
 
+type AssignmentLinkContext = Pick<
+  CoverageHistoryEntry,
+  | "assignmentId"
+  | "handReceiptId"
+  | "handReceiptName"
+  | "contactId"
+  | "contactName"
+  | "documentId"
+  | "documentFilename"
+>;
+
 export class InMemoryAssignmentItemLinkRepository implements AssignmentItemLinkRepository {
   links: AssignmentItemLinkRecord[] = [];
+  assignmentContexts: AssignmentLinkContext[] = [];
 
-  constructor(links: AssignmentItemLinkRecord[] = []) {
+  constructor(
+    links: AssignmentItemLinkRecord[] = [],
+    assignmentContexts: AssignmentLinkContext[] = [],
+  ) {
     this.links = [...links];
+    this.assignmentContexts = [...assignmentContexts];
   }
 
   async create(link: NewAssignmentItemLinkRecord) {
@@ -70,6 +87,57 @@ export class InMemoryAssignmentItemLinkRepository implements AssignmentItemLinkR
           options.status === undefined || link.status === options.status,
       )
       .sort((left, right) => {
+        const leftTime = left.closedAt?.getTime() ?? left.updatedAt.getTime();
+        const rightTime =
+          right.closedAt?.getTime() ?? right.updatedAt.getTime();
+
+        return rightTime - leftTime;
+      });
+  }
+
+  async findByItemIdWithAssignment(
+    accountId: string,
+    itemId: string,
+    options: { status?: AssignmentStatus } = {},
+  ) {
+    return this.links
+      .filter((link) => link.accountId === accountId && link.itemId === itemId)
+      .filter(
+        (link) =>
+          options.status === undefined || link.status === options.status,
+      )
+      .map((link): CoverageHistoryEntry | null => {
+        const context = this.assignmentContexts.find(
+          (assignmentContext) =>
+            assignmentContext.assignmentId === link.assignmentId,
+        );
+
+        if (!context) {
+          return null;
+        }
+
+        return {
+          linkId: link.id,
+          assignmentId: link.assignmentId,
+          itemId: link.itemId,
+          status: link.status,
+          closedAt: link.closedAt,
+          createdAt: link.createdAt,
+          updatedAt: link.updatedAt,
+          handReceiptId: context.handReceiptId,
+          handReceiptName: context.handReceiptName,
+          contactId: context.contactId,
+          contactName: context.contactName,
+          documentId: context.documentId,
+          documentFilename: context.documentFilename,
+        };
+      })
+      .filter((entry): entry is CoverageHistoryEntry => Boolean(entry))
+      .sort((left, right) => {
+        if (left.status !== right.status) {
+          return left.status === "active" ? -1 : 1;
+        }
+
         const leftTime = left.closedAt?.getTime() ?? left.updatedAt.getTime();
         const rightTime =
           right.closedAt?.getTime() ?? right.updatedAt.getTime();

--- a/tests/support/hand-receipt-repository.ts
+++ b/tests/support/hand-receipt-repository.ts
@@ -49,6 +49,16 @@ export class InMemoryHandReceiptRepository implements HandReceiptRepository {
     );
   }
 
+  async findManyByIds(accountId: string, handReceiptIds: string[]) {
+    const handReceiptIdSet = new Set(handReceiptIds);
+
+    return this.handReceipts.filter(
+      (handReceipt) =>
+        handReceipt.accountId === accountId &&
+        handReceiptIdSet.has(handReceipt.id),
+    );
+  }
+
   async update(
     accountId: string,
     handReceiptId: string,

--- a/tests/unit/assignments-2062/assignment-repositories.test.ts
+++ b/tests/unit/assignments-2062/assignment-repositories.test.ts
@@ -71,4 +71,68 @@ describe("assignment test repositories", () => {
       constraint: "assignment_item_links_one_active_item_idx",
     });
   });
+
+  it("matches item-link recency tie-breakers used by the database repository", async () => {
+    const sameClosedAt = new Date("2026-05-02T14:00:00.000Z");
+    const sameUpdatedAt = new Date("2026-05-02T15:00:00.000Z");
+    const repository = new InMemoryAssignmentItemLinkRepository(
+      [
+        {
+          id: "closed-link-older-created",
+          accountId: "account-1",
+          assignmentId: "assignment-1",
+          itemId: "item-1",
+          status: "closed",
+          closedAt: sameClosedAt,
+          createdAt: older,
+          updatedAt: sameUpdatedAt,
+        },
+        {
+          id: "closed-link-newer-created",
+          accountId: "account-1",
+          assignmentId: "assignment-2",
+          itemId: "item-1",
+          status: "closed",
+          closedAt: sameClosedAt,
+          createdAt: newer,
+          updatedAt: sameUpdatedAt,
+        },
+      ],
+      [
+        {
+          assignmentId: "assignment-1",
+          handReceiptId: "receipt-1",
+          handReceiptName: "Primary receipt",
+          contactId: "contact-1",
+          contactName: "SPC Rivera",
+          documentId: "document-1",
+          documentFilename: "older.pdf",
+        },
+        {
+          assignmentId: "assignment-2",
+          handReceiptId: "receipt-1",
+          handReceiptName: "Primary receipt",
+          contactId: "contact-2",
+          contactName: "SGT Morgan",
+          documentId: "document-2",
+          documentFilename: "newer.pdf",
+        },
+      ],
+    );
+
+    await expect(
+      repository.findByItemId("account-1", "item-1", { status: "closed" }),
+    ).resolves.toEqual([
+      expect.objectContaining({ id: "closed-link-newer-created" }),
+      expect.objectContaining({ id: "closed-link-older-created" }),
+    ]);
+    await expect(
+      repository.findByItemIdWithAssignment("account-1", "item-1", {
+        status: "closed",
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ linkId: "closed-link-newer-created" }),
+      expect.objectContaining({ linkId: "closed-link-older-created" }),
+    ]);
+  });
 });

--- a/tests/unit/assignments-2062/create-assignment.test.ts
+++ b/tests/unit/assignments-2062/create-assignment.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
 import {
+  AccountReadOnlyError,
   Active2062CoverageConflictError,
+  ContactNotFoundError,
   createAssignment,
   createAssignmentWithItems,
+  EmptyItemSelectionError,
+  HandReceiptNotActiveError,
+  ItemReceiptMismatchError,
 } from "@/modules/assignments-2062";
 import { InMemoryAssignmentItemLinkRepository } from "../../support/assignment-item-link-repository";
 import { InMemoryAssignmentRepository } from "../../support/assignment-repository";
@@ -378,7 +383,7 @@ describe("createAssignment", () => {
         ...repositories,
         now,
       }),
-    ).rejects.toThrow("Hand receipt must be active to upload a 2062.");
+    ).rejects.toBeInstanceOf(HandReceiptNotActiveError);
     expect(repositories.assignmentRepository.assignments).toEqual([]);
     expect(repositories.assignmentItemLinkRepository.links).toEqual([]);
     expect(repositories.auditRepository.events).toEqual([]);
@@ -443,7 +448,7 @@ describe("createAssignment", () => {
         ...repositories,
         now,
       }),
-    ).rejects.toThrow("Select at least one item.");
+    ).rejects.toMatchObject(new EmptyItemSelectionError());
   });
 
   it("blocks multi-item creation against an archived hand receipt before mutating records", async () => {
@@ -484,7 +489,7 @@ describe("createAssignment", () => {
         ...repositories,
         now,
       }),
-    ).rejects.toThrow("Items must belong to the selected hand receipt.");
+    ).rejects.toBeInstanceOf(ItemReceiptMismatchError);
   });
 
   it("blocks multi-item creation when any item already has active coverage", async () => {
@@ -532,7 +537,7 @@ describe("createAssignment", () => {
         ...repositories,
         now,
       }),
-    ).rejects.toThrow("This account is read-only.");
+    ).rejects.toBeInstanceOf(AccountReadOnlyError);
   });
 
   it("blocks creation when the contact does not exist", async () => {
@@ -550,7 +555,7 @@ describe("createAssignment", () => {
         ...repositories,
         now,
       }),
-    ).rejects.toThrow("Contact was not found.");
+    ).rejects.toBeInstanceOf(ContactNotFoundError);
   });
 
   it("blocks creation when the document does not exist", async () => {

--- a/tests/unit/assignments-2062/create-assignment.test.ts
+++ b/tests/unit/assignments-2062/create-assignment.test.ts
@@ -448,7 +448,7 @@ describe("createAssignment", () => {
         ...repositories,
         now,
       }),
-    ).rejects.toMatchObject(new EmptyItemSelectionError());
+    ).rejects.toBeInstanceOf(EmptyItemSelectionError);
   });
 
   it("blocks multi-item creation against an archived hand receipt before mutating records", async () => {

--- a/tests/unit/assignments-2062/list-coverage.test.ts
+++ b/tests/unit/assignments-2062/list-coverage.test.ts
@@ -83,6 +83,26 @@ function createRepositories() {
         updatedAt: newer,
       },
     ],
+    [
+      {
+        assignmentId: "assignment-active",
+        handReceiptId: "receipt-1",
+        handReceiptName: "Primary receipt",
+        contactId: "contact-1",
+        contactName: "SPC Rivera",
+        documentId: "document-1",
+        documentFilename: "active-2062.pdf",
+      },
+      {
+        assignmentId: "assignment-closed",
+        handReceiptId: "receipt-1",
+        handReceiptName: "Primary receipt",
+        contactId: "contact-2",
+        contactName: "SGT Morgan",
+        documentId: "document-2",
+        documentFilename: "closed-2062.pdf",
+      },
+    ],
   );
   const handReceiptRepository = new InMemoryHandReceiptRepository([
     {
@@ -147,6 +167,71 @@ describe("2062 list and coverage queries", () => {
         },
       ],
     });
+  });
+
+  it("returns multiple historical links newest first without per-link assignment lookups", async () => {
+    const repositories = createRepositories();
+
+    repositories.assignmentRepository.assignments.push({
+      id: "assignment-older-closed",
+      accountId: account.id,
+      handReceiptId: "receipt-1",
+      contactId: "contact-3",
+      contactName: "SSG Carter",
+      documentId: "document-3",
+      documentFilename: "older-2062.pdf",
+      status: "closed",
+      createdAt: older,
+      updatedAt: older,
+    });
+    repositories.assignmentItemLinkRepository.links.push({
+      id: "link-older-closed",
+      accountId: account.id,
+      assignmentId: "assignment-older-closed",
+      itemId: "item-1",
+      status: "closed",
+      closedAt: older,
+      createdAt: older,
+      updatedAt: older,
+    });
+    repositories.assignmentItemLinkRepository.assignmentContexts.push({
+      assignmentId: "assignment-older-closed",
+      handReceiptId: "receipt-1",
+      handReceiptName: "Primary receipt",
+      contactId: "contact-3",
+      contactName: "SSG Carter",
+      documentId: "document-3",
+      documentFilename: "older-2062.pdf",
+    });
+
+    let assignmentFinds = 0;
+    const originalFindById = repositories.assignmentRepository.findById.bind(
+      repositories.assignmentRepository,
+    );
+    repositories.assignmentRepository.findById = async (...args) => {
+      assignmentFinds += 1;
+      return originalFindById(...args);
+    };
+
+    const coverage = await getItemCoverage({
+      account,
+      itemId: "item-1",
+      ...repositories,
+    });
+
+    expect(coverage.history).toMatchObject([
+      {
+        assignmentId: "assignment-closed",
+        contactName: "SGT Morgan",
+        documentFilename: "closed-2062.pdf",
+      },
+      {
+        assignmentId: "assignment-older-closed",
+        contactName: "SSG Carter",
+        documentFilename: "older-2062.pdf",
+      },
+    ]);
+    expect(assignmentFinds).toBe(1);
   });
 
   it("scopes hand receipt assignment context to active formal assignments", async () => {

--- a/tests/unit/assignments-2062/list-coverage.test.ts
+++ b/tests/unit/assignments-2062/list-coverage.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import {
+  getHandReceiptAssignments,
+  getItemCoverage,
+  listActiveAssignments,
+} from "@/modules/assignments-2062";
+import { InMemoryAssignmentItemLinkRepository } from "../../support/assignment-item-link-repository";
+import { InMemoryAssignmentRepository } from "../../support/assignment-repository";
+import { InMemoryHandReceiptRepository } from "../../support/hand-receipt-repository";
+
+const older = new Date("2026-05-01T12:00:00.000Z");
+const newer = new Date("2026-05-02T12:00:00.000Z");
+
+const account: AccountRecord = {
+  id: "account-1",
+  userId: "owner-1",
+  accessState: "active",
+  subscriptionTier: "base",
+  trialStartsAt: new Date("2026-04-01T12:00:00.000Z"),
+  trialEndsAt: new Date("2100-01-01T00:00:00.000Z"),
+  onboardingCompletedAt: null,
+};
+
+function createRepositories() {
+  const assignmentRepository = new InMemoryAssignmentRepository([
+    {
+      id: "assignment-active",
+      accountId: account.id,
+      handReceiptId: "receipt-1",
+      contactId: "contact-1",
+      contactName: "SPC Rivera",
+      documentId: "document-1",
+      documentFilename: "active-2062.pdf",
+      status: "active",
+      createdAt: newer,
+      updatedAt: newer,
+    },
+    {
+      id: "assignment-closed",
+      accountId: account.id,
+      handReceiptId: "receipt-1",
+      contactId: "contact-2",
+      contactName: "SGT Morgan",
+      documentId: "document-2",
+      documentFilename: "closed-2062.pdf",
+      status: "closed",
+      createdAt: older,
+      updatedAt: older,
+    },
+  ]);
+  const assignmentItemLinkRepository = new InMemoryAssignmentItemLinkRepository(
+    [
+      {
+        id: "link-active-1",
+        accountId: account.id,
+        assignmentId: "assignment-active",
+        itemId: "item-1",
+        status: "active",
+        closedAt: null,
+        createdAt: newer,
+        updatedAt: newer,
+      },
+      {
+        id: "link-active-2",
+        accountId: account.id,
+        assignmentId: "assignment-active",
+        itemId: "item-2",
+        status: "active",
+        closedAt: null,
+        createdAt: newer,
+        updatedAt: newer,
+      },
+      {
+        id: "link-closed",
+        accountId: account.id,
+        assignmentId: "assignment-closed",
+        itemId: "item-1",
+        status: "closed",
+        closedAt: newer,
+        createdAt: older,
+        updatedAt: newer,
+      },
+    ],
+  );
+  const handReceiptRepository = new InMemoryHandReceiptRepository([
+    {
+      id: "receipt-1",
+      accountId: account.id,
+      name: "Primary receipt",
+      notes: null,
+      handReceiptNumber: null,
+      holderName: null,
+      unitName: null,
+      uic: null,
+      effectiveDate: null,
+      status: "active",
+      createdAt: older,
+      updatedAt: older,
+    },
+  ]);
+
+  return {
+    assignmentItemLinkRepository,
+    assignmentRepository,
+    handReceiptRepository,
+  };
+}
+
+describe("2062 list and coverage queries", () => {
+  it("lists active formal assignments with hand receipt context and item counts", async () => {
+    const repositories = createRepositories();
+
+    await expect(
+      listActiveAssignments({ account, ...repositories }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "assignment-active",
+        contactName: "SPC Rivera",
+        documentFilename: "active-2062.pdf",
+        handReceiptName: "Primary receipt",
+        itemCount: 2,
+        status: "active",
+      }),
+    ]);
+  });
+
+  it("separates current and historical 2062 coverage for an item", async () => {
+    const repositories = createRepositories();
+
+    await expect(
+      getItemCoverage({ account, itemId: "item-1", ...repositories }),
+    ).resolves.toMatchObject({
+      current: {
+        id: "assignment-active",
+        contactName: "SPC Rivera",
+        itemCount: 2,
+      },
+      history: [
+        {
+          assignmentId: "assignment-closed",
+          contactName: "SGT Morgan",
+          documentFilename: "closed-2062.pdf",
+          handReceiptName: "Primary receipt",
+          linkId: "link-closed",
+        },
+      ],
+    });
+  });
+
+  it("scopes hand receipt assignment context to active formal assignments", async () => {
+    const repositories = createRepositories();
+
+    await expect(
+      getHandReceiptAssignments({
+        account,
+        handReceiptId: "receipt-1",
+        ...repositories,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "assignment-active",
+        handReceiptId: "receipt-1",
+        itemCount: 2,
+      }),
+    ]);
+  });
+});

--- a/tests/unit/assignments-2062/list-coverage.test.ts
+++ b/tests/unit/assignments-2062/list-coverage.test.ts
@@ -146,6 +146,86 @@ describe("2062 list and coverage queries", () => {
     ]);
   });
 
+  it("batches active assignment summary lookups", async () => {
+    const repositories = createRepositories();
+
+    repositories.assignmentRepository.assignments.push({
+      id: "assignment-active-2",
+      accountId: account.id,
+      handReceiptId: "receipt-2",
+      contactId: "contact-2",
+      contactName: "SGT Morgan",
+      documentId: "document-2",
+      documentFilename: "active-2-2062.pdf",
+      status: "active",
+      createdAt: older,
+      updatedAt: older,
+    });
+    repositories.handReceiptRepository.handReceipts.push({
+      id: "receipt-2",
+      accountId: account.id,
+      name: "Secondary receipt",
+      notes: null,
+      handReceiptNumber: null,
+      holderName: null,
+      unitName: null,
+      uic: null,
+      effectiveDate: null,
+      status: "active",
+      createdAt: older,
+      updatedAt: older,
+    });
+    repositories.assignmentItemLinkRepository.links.push({
+      id: "link-active-3",
+      accountId: account.id,
+      assignmentId: "assignment-active-2",
+      itemId: "item-3",
+      status: "active",
+      closedAt: null,
+      createdAt: older,
+      updatedAt: older,
+    });
+
+    let handReceiptFinds = 0;
+    let handReceiptBatchFinds = 0;
+    let linkFinds = 0;
+    let linkBatchCounts = 0;
+    const originalFindManyByIds =
+      repositories.handReceiptRepository.findManyByIds.bind(
+        repositories.handReceiptRepository,
+      );
+    const originalCountActiveByAssignmentIds =
+      repositories.assignmentItemLinkRepository.countActiveByAssignmentIds.bind(
+        repositories.assignmentItemLinkRepository,
+      );
+
+    repositories.handReceiptRepository.findById = async () => {
+      handReceiptFinds += 1;
+      return null;
+    };
+    repositories.handReceiptRepository.findManyByIds = async (...args) => {
+      handReceiptBatchFinds += 1;
+      return originalFindManyByIds(...args);
+    };
+    repositories.assignmentItemLinkRepository.findByAssignmentId = async () => {
+      linkFinds += 1;
+      return [];
+    };
+    repositories.assignmentItemLinkRepository.countActiveByAssignmentIds =
+      async (...args) => {
+        linkBatchCounts += 1;
+        return originalCountActiveByAssignmentIds(...args);
+      };
+
+    const summaries = await listActiveAssignments({ account, ...repositories });
+
+    expect(summaries).toHaveLength(2);
+    expect(handReceiptFinds).toBe(0);
+    expect(linkFinds).toBe(0);
+    expect(handReceiptBatchFinds).toBe(1);
+    expect(linkBatchCounts).toBe(1);
+  });
+
   it("separates current and historical 2062 coverage for an item", async () => {
     const repositories = createRepositories();
 


### PR DESCRIPTION
## Summary

- add application-level read services and tRPC queries for Active 2062s, item coverage, and hand receipt 2062 context
- replace the Active 2062s placeholder with a real formal-assignment list and empty state
- add item and hand receipt 2062 coverage panels, plus docs and focused tests
- fix the architecture-audit finding by ordering historical item coverage links newest-first in the Drizzle adapter

## Validation

- pnpm vitest run tests/unit/assignments-2062/list-coverage.test.ts tests/integration/trpc/assignments-2062-router.test.ts
- pnpm typecheck
- pnpm lint
- pnpm format:check

## Notes

This PR is ready for review, not a draft.

Closes #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Release Notes: Active 2062s Coverage Surfaces

## Overview
Adds formal Active 2062 review and coverage surfaces: a dedicated Active 2062s workspace, item coverage panel, and hand receipt context that expose typed application queries and enforce formal-only filtering.

## Features

### Active 2062s Review Surface
- New client workspace at /app/active-2062s rendering formal Active 2062 assignments.
- Lists per-assignment details: contact, item count, hand receipt context, status/date, document filename, and “Open context” action.
- Explicit empty state with CTA when no formal assignments exist.
- Responsive layout for mobile, tablet, and desktop.

### Item Coverage Panel
- New ItemCoverageSection on item detail pages.
- Shows current formal 2062 coverage (contact, DA Form 2062 tag, document filename, item count) or readable fallback when only manual signed-to exists.
- History subsection lists past closed coverage entries (newest-first).
- Upload CTA for uncovered active items when allowed.

### Hand Receipt 2062 Context
- New HandReceipt2062Context on hand receipt detail pages.
- Shows active formal assignments scoped to the receipt with item counts and contact names.
- Context-aware “Upload 2062” control (disabled with explanatory tooltip when not allowed) and link to Active 2062s list.

## API & Application Layer
- New application functions: listActiveAssignments, getHandReceiptAssignments, getItemCoverage.
- Repository API changes: AssignmentItemLinkRepository replaces findActiveByItemId with findByItemId and adds findByItemIdWithAssignment (supports optional status filtering).
- New exported types: ActiveAssignmentSummary, CoverageHistoryEntry, HistoricalAssignmentLink, ItemCoverageResult.
- Domain-specific typed errors introduced and used throughout create flows and queries.

## Server / tRPC
- Added protected tRPC queries:
  - assignments2062.list
  - assignments2062.getItemCoverage (input: { itemId: uuid })
  - assignments2062.getHandReceiptAssignments (input: { handReceiptId: uuid })
- toTRPCError mapping refactored to classify domain errors by error classes.

## Data & Ordering
- Historical coverage links ordered newest-first (descending by closedAt/updatedAt) to address architecture-audit finding.

## Cache & Upload Flow
- Upload/create flows now invalidate a broader set of caches: assignments lists (overall and by hand receipt), per-item coverage entries, hand-receipt assignments, and related item lists.

## Testing
- New and updated tests:
  - Unit tests for listActiveAssignments, getItemCoverage, getHandReceiptAssignments (coverage computation, formal-only filtering, newest-first ordering, single assignment fetch optimization).
  - Integration tests for tRPC procedures covering active vs. closed records.
  - E2E updates for navigation, headings, empty states, and item/receipt coverage assertions.

## Documentation
- Domain model docs updated to clarify:
  - “Active 2062s” = formal assignment records only (exclude manual signed-to).
  - Item coverage includes current formal coverage + historical closed links.
  - Hand receipt 2062 context scoped to active formal assignments for that receipt.

## Miscellaneous
- UI: Replaced placeholder with Active2062sWorkspace; new components added (AssignmentList, Active2062sEmptyState, ItemCoverageSection, HandReceipt2062Context, Upload flow invalidations).
- Tests/support: In-memory repository updated to support coverage history contexts and new lookup APIs.

## Closes
Issue #62 (Active 2062s List and Coverage Surfaces)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->