### PR TITLE
[codex] Enforce active 2062 item workflow constraints

### DIFF
--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -147,12 +147,16 @@ Rules:
 - Search results show hand receipt context and the strongest available
   identifier matches so users can confirm the correct property record before
   opening detail.
-- Item with active 2062 coverage cannot move to another hand receipt until the
+- An item with active 2062 coverage cannot move to another hand receipt until the
   active 2062 link is closed.
+- Archiving an item with active 2062 coverage is a deliberate accountability
+  action. The app warns the user, archives the item, closes only that item's
+  active 2062 link, clears current signed-to state for that item, and preserves
+  the linked document, closed link history, and item activity history.
+- If archiving closes the final active item link on a 2062 assignment, the
+  assignment closes so empty active assignments do not linger.
 - When item requirements exist, archived items should suppress day-to-day
   requirement reminders while remaining available for historical review.
-- Items with active 2062 coverage cannot be archived until the active 2062 link
-  is closed by the 2062 workflow.
 
 ## Contacts
 

--- a/docs/hand-receipt-archive-behavior.md
+++ b/docs/hand-receipt-archive-behavior.md
@@ -32,13 +32,17 @@ Future requirement work should treat hand receipt status as a workflow input and
 decide whether suppressed reminders remain visible in historical or detail-only
 contexts.
 
-## Future 2062 Boundary
+## 2062 Boundary
 
-Active 2062 behavior at archive time is intentionally deferred to the 2062
-implementation phase. This slice does not create, close, relink, or warn on
-formal 2062 assignments.
+Item archive behavior now handles active 2062 coverage in the item workflow:
+the user receives a warning, the item is archived, only that item's active
+2062 link is closed, and the linked document plus closed-link history are
+preserved. If that item was the final active link on the assignment, the
+assignment closes.
 
-Future 2062 work should decide whether a hand receipt with active 2062s can be
-archived directly, requires a confirmation warning, or requires active 2062s to
-be closed first. Until that workflow exists, archive only changes the hand
-receipt lifecycle state and preserves audit history.
+Hand receipt archive behavior for receipts with active 2062 assignments remains
+outside this item-workflow slice. Future hand receipt archive work should decide
+whether a hand receipt with active 2062s can be archived directly, requires a
+confirmation warning, or requires active 2062s to be closed first. Until that
+workflow exists, hand receipt archive only changes the hand receipt lifecycle
+state and preserves audit history.

--- a/docs/prd/field-ledger-phase-5-documents-2062-prd.md
+++ b/docs/prd/field-ledger-phase-5-documents-2062-prd.md
@@ -74,8 +74,8 @@ Finally, item workflows will enforce active 2062 meaning. An item with active
 link is closed. Archiving an item with active 2062 coverage is allowed only as
 a deliberate accountability action that warns the user and closes the item
 link. If archiving closes the last active item link on an assignment, the user
-should be prompted to close the assignment. All meaningful state changes emit
-audit/activity events.
+is warned before confirmation and the assignment closes explicitly. All
+meaningful state changes emit audit/activity events.
 
 ## User Stories
 
@@ -224,8 +224,8 @@ audit/activity events.
   the active link is closed.
 - Allow archiving an item with active 2062 coverage only as a deliberate action
   that warns the user and closes that item link.
-- If archiving closes the final active item link on a 2062 assignment, prompt
-  the user to close the assignment.
+- If archiving closes the final active item link on a 2062 assignment, warn the
+  user before confirmation and close the assignment explicitly.
 - Keep routes thin: routes compose module UI and call typed procedures; document
   storage rules and 2062 assignment rules live in module application services.
 - Protect document, 2062 assignment, and 2062 item-link tables with RLS.

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -128,6 +128,15 @@ Due windows:
 - Allow past return date and block future return dates.
 - Preserve item history and document.
 
+### Move Or Archive Covered Items
+
+- Move dialog blocks items with active 2062 coverage and explains that the
+  active item link must be closed before moving to another hand receipt.
+- Archive dialog warns when an item has active 2062 coverage.
+- Confirmed archive closes only that item's active 2062 link, preserves the
+  document and history, and tells the user when the archived item is the final
+  active link on the assignment.
+
 ## UI Constraints
 
 - Item UI must work well with no item photo.

--- a/src/modules/assignments-2062/application/close-assignment.ts
+++ b/src/modules/assignments-2062/application/close-assignment.ts
@@ -35,6 +35,7 @@ type RemoveItemLinkInput = {
   actorId: string;
   itemLinkId: string;
   closedOn?: string;
+  closeReason?: "item_archived" | "user_removed";
   assignmentRepository: AssignmentRepository;
   assignmentItemLinkRepository: AssignmentItemLinkRepository;
   auditRepository: AuditRepository;
@@ -200,6 +201,7 @@ export async function removeAssignmentItemLink({
   actorId,
   itemLinkId,
   closedOn,
+  closeReason = "user_removed",
   assignmentRepository,
   assignmentItemLinkRepository,
   auditRepository,
@@ -259,6 +261,7 @@ export async function removeAssignmentItemLink({
       name: updatedItem.nomenclature,
       assignmentId: assignment.id,
       closedOn: closeDate,
+      reason: closeReason,
       handReceiptId: assignment.handReceiptId,
       contactId: assignment.contactId,
       contactName: assignment.contactName ?? null,
@@ -307,7 +310,10 @@ export async function removeAssignmentItemLink({
         contactName: assignment.contactName ?? null,
         documentId: assignment.documentId,
         documentFilename: assignment.documentFilename ?? null,
-        reason: "last_item_link_removed",
+        reason:
+          closeReason === "item_archived"
+            ? "last_item_archived"
+            : "last_item_link_removed",
       },
       occurredAt: now,
       repository: auditRepository,

--- a/src/modules/assignments-2062/application/has-active-2062-coverage.ts
+++ b/src/modules/assignments-2062/application/has-active-2062-coverage.ts
@@ -1,5 +1,12 @@
 import type { AssignmentItemLinkRepository } from "./assignment-item-link-repository";
 
+export type Active2062CoverageInfo = {
+  hasActiveCoverage: true;
+  itemLinkId: string;
+  assignmentId: string;
+  isLastActiveLink: boolean;
+};
+
 export async function hasActive2062Coverage({
   accountId,
   itemId,
@@ -15,4 +22,37 @@ export async function hasActive2062Coverage({
   );
 
   return link !== null;
+}
+
+export async function getActive2062CoverageInfo({
+  accountId,
+  itemId,
+  assignmentItemLinkRepository,
+}: {
+  accountId: string;
+  itemId: string;
+  assignmentItemLinkRepository: AssignmentItemLinkRepository;
+}): Promise<Active2062CoverageInfo | null> {
+  const link = await assignmentItemLinkRepository.findActiveByItemId(
+    accountId,
+    itemId,
+  );
+
+  if (!link) {
+    return null;
+  }
+
+  const activeAssignmentLinks =
+    await assignmentItemLinkRepository.findByAssignmentId(
+      accountId,
+      link.assignmentId,
+      { status: "active" },
+    );
+
+  return {
+    hasActiveCoverage: true,
+    itemLinkId: link.id,
+    assignmentId: link.assignmentId,
+    isLastActiveLink: activeAssignmentLinks.length === 1,
+  };
 }

--- a/src/modules/assignments-2062/application/types.ts
+++ b/src/modules/assignments-2062/application/types.ts
@@ -71,6 +71,8 @@ export type Active2062Coverage = {
   documentFilename: string;
 };
 
+export type { Active2062CoverageInfo } from "./has-active-2062-coverage";
+
 export type ActiveAssignmentSummary = {
   id: string;
   handReceiptId: string;

--- a/src/modules/assignments-2062/index.ts
+++ b/src/modules/assignments-2062/index.ts
@@ -10,7 +10,10 @@ export {
   createAssignment,
   createAssignmentWithItems,
 } from "./application/create-assignment";
-export { hasActive2062Coverage } from "./application/has-active-2062-coverage";
+export {
+  getActive2062CoverageInfo,
+  hasActive2062Coverage,
+} from "./application/has-active-2062-coverage";
 export {
   getHandReceiptAssignments,
   getItemCoverage,
@@ -39,6 +42,7 @@ export type {
   ActiveAssignmentSummary,
   ActiveAssignmentItemSummary,
   Active2062Coverage,
+  Active2062CoverageInfo,
   AssignmentItemLinkRecord,
   AssignmentRecord,
   AssignmentStatus,

--- a/src/modules/items/application/archive-item.ts
+++ b/src/modules/items/application/archive-item.ts
@@ -1,4 +1,5 @@
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import type { Active2062CoverageInfo } from "@/modules/assignments-2062";
 import { recordAuditEvent, type AuditRepository } from "@/modules/audit";
 import { deriveAccountCapabilities } from "@/modules/billing";
 import type { ItemRepository } from "./item-repository";
@@ -10,7 +11,8 @@ type LifecycleItemInput = {
   itemId: string;
   itemRepository: ItemRepository;
   auditRepository: AuditRepository;
-  hasActive2062Coverage?: Active2062CoverageLookup;
+  getActive2062CoverageInfo?: Active2062CoverageInfoLookup;
+  closeActive2062ItemLink?: CloseActive2062ItemLink;
   now?: Date;
 };
 
@@ -20,13 +22,18 @@ type ItemLifecycleTransition = {
   auditAction: "item.archived" | "item.restored";
 };
 
-type Active2062CoverageLookup = (input: {
+type Active2062CoverageInfoLookup = (input: {
   accountId: string;
   itemId: string;
-}) => boolean | Promise<boolean>;
+}) => Active2062CoverageInfo | null | Promise<Active2062CoverageInfo | null>;
 
-function defaultHasActive2062Coverage() {
-  return false;
+type CloseActive2062ItemLink = (input: {
+  itemLinkId: string;
+  now: Date;
+}) => unknown | Promise<unknown>;
+
+function defaultGetActive2062CoverageInfo() {
+  return null;
 }
 
 async function changeItemLifecycleStatus({
@@ -35,7 +42,8 @@ async function changeItemLifecycleStatus({
   itemId,
   itemRepository,
   auditRepository,
-  hasActive2062Coverage = defaultHasActive2062Coverage,
+  getActive2062CoverageInfo = defaultGetActive2062CoverageInfo,
+  closeActive2062ItemLink,
   now = new Date(),
   transition,
 }: LifecycleItemInput & { transition: ItemLifecycleTransition }) {
@@ -55,13 +63,13 @@ async function changeItemLifecycleStatus({
     throw new Error(transition.alreadyInTargetMessage);
   }
 
-  if (
-    transition.targetStatus === "archived" &&
-    (await hasActive2062Coverage({ accountId: account.id, itemId }))
-  ) {
-    throw new Error(
-      "Cannot archive item with active 2062 coverage until the active link is closed.",
-    );
+  const active2062Coverage =
+    transition.targetStatus === "archived"
+      ? await getActive2062CoverageInfo({ accountId: account.id, itemId })
+      : null;
+
+  if (active2062Coverage && !closeActive2062ItemLink) {
+    throw new Error("Active 2062 link closure is unavailable.");
   }
 
   const updated = await itemRepository.update(account.id, itemId, {
@@ -88,6 +96,15 @@ async function changeItemLifecycleStatus({
     occurredAt: now,
     repository: auditRepository,
   });
+
+  if (active2062Coverage) {
+    await closeActive2062ItemLink?.({
+      itemLinkId: active2062Coverage.itemLinkId,
+      now,
+    });
+
+    return (await itemRepository.findById(account.id, itemId)) ?? updated;
+  }
 
   return updated;
 }

--- a/src/modules/items/ui/item-detail.tsx
+++ b/src/modules/items/ui/item-detail.tsx
@@ -6,6 +6,7 @@ import {
   Archive,
   ArrowLeft,
   ArrowRightLeft,
+  AlertTriangle,
   ClipboardList,
   Hash,
   History,
@@ -166,6 +167,9 @@ function MoveItemDialog({
   isOpen,
   item,
   isMoving,
+  isMoveBlocked,
+  moveCoverageError,
+  isMoveCoverageLoading,
   moveTargets,
   onMove,
   onOpenChange,
@@ -175,6 +179,9 @@ function MoveItemDialog({
   isOpen: boolean;
   item: ItemRecord;
   isMoving: boolean;
+  isMoveBlocked: boolean;
+  moveCoverageError: string | null;
+  isMoveCoverageLoading: boolean;
   moveTargets: HandReceiptRecord[];
   onMove: () => void;
   onOpenChange: (isOpen: boolean) => void;
@@ -191,28 +198,64 @@ function MoveItemDialog({
             record, identifiers, and activity history stay preserved.
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-2">
-          <Label htmlFor="target-hand-receipt">Target hand receipt</Label>
-          {moveTargets.length > 0 ? (
-            <select
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
-              id="target-hand-receipt"
-              onChange={(event) => onTargetChange(event.target.value)}
-              value={targetHandReceiptId}
-            >
-              <option value="">Select active receipt</option>
-              {moveTargets.map((receipt) => (
-                <option key={receipt.id} value={receipt.id}>
-                  {receipt.name}
-                </option>
-              ))}
-            </select>
-          ) : (
-            <p className="rounded-lg border bg-secondary px-3 py-2 text-sm text-muted-foreground">
-              Create another active hand receipt before moving this item.
-            </p>
-          )}
-        </div>
+        {isMoveCoverageLoading ? (
+          <p className="rounded-lg border bg-secondary px-3 py-2 text-sm text-muted-foreground">
+            Checking active 2062 coverage...
+          </p>
+        ) : moveCoverageError ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-3 text-sm text-destructive">
+            <div className="flex items-start gap-2">
+              <AlertTriangle
+                aria-hidden="true"
+                className="mt-0.5 size-4 shrink-0"
+              />
+              <div className="space-y-1">
+                <p className="font-medium">Coverage check failed</p>
+                <p className="leading-6">{moveCoverageError}</p>
+              </div>
+            </div>
+          </div>
+        ) : isMoveBlocked ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-3 text-sm text-destructive">
+            <div className="flex items-start gap-2">
+              <AlertTriangle
+                aria-hidden="true"
+                className="mt-0.5 size-4 shrink-0"
+              />
+              <div className="space-y-1">
+                <p className="font-medium">Move blocked by active 2062</p>
+                <p className="leading-6">
+                  Close this item&apos;s active 2062 link before moving it to
+                  another hand receipt. Use the 2062 Coverage section on this
+                  item to review the active assignment.
+                </p>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <Label htmlFor="target-hand-receipt">Target hand receipt</Label>
+            {moveTargets.length > 0 ? (
+              <select
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
+                id="target-hand-receipt"
+                onChange={(event) => onTargetChange(event.target.value)}
+                value={targetHandReceiptId}
+              >
+                <option value="">Select active receipt</option>
+                {moveTargets.map((receipt) => (
+                  <option key={receipt.id} value={receipt.id}>
+                    {receipt.name}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <p className="rounded-lg border bg-secondary px-3 py-2 text-sm text-muted-foreground">
+                Create another active hand receipt before moving this item.
+              </p>
+            )}
+          </div>
+        )}
         <DialogFooter>
           <Button
             disabled={isMoving}
@@ -223,7 +266,13 @@ function MoveItemDialog({
             Cancel
           </Button>
           <Button
-            disabled={!targetHandReceiptId || isMoving}
+            disabled={
+              !targetHandReceiptId ||
+              isMoving ||
+              isMoveCoverageLoading ||
+              Boolean(moveCoverageError) ||
+              isMoveBlocked
+            }
             onClick={onMove}
             type="button"
           >
@@ -257,6 +306,14 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
     status: "active",
   });
   const capabilitiesQuery = trpc.billing.capabilities.useQuery();
+  const moveCoverageQuery = trpc.items.hasActive2062Coverage.useQuery(
+    { id: itemId },
+    { enabled: isMoveDialogOpen },
+  );
+  const archiveCoverageQuery = trpc.items.getActive2062CoverageInfo.useQuery(
+    { id: itemId },
+    { enabled: isArchiveDialogOpen },
+  );
   const item = itemQuery.data;
   const handReceipt = handReceiptQuery.data;
   const moveTargets =
@@ -264,6 +321,10 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
       (receipt) => receipt.id !== item?.handReceiptId,
     ) ?? [];
   const isReadOnly = capabilitiesQuery.data?.isReadOnly ?? false;
+  const archiveCoverage = archiveCoverageQuery.data;
+  const archiveHasActive2062 =
+    archiveCoverage?.hasActiveCoverage === true;
+  const archiveCoverageError = archiveCoverageQuery.error?.message ?? null;
   const archiveMutation = trpc.items.archive.useMutation({
     onSuccess: async (archived) => {
       setIsArchiveDialogOpen(false);
@@ -359,6 +420,10 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
         targetType: "item",
         targetId: itemId,
       }),
+      utilities.assignments2062.getItemCoverage.invalidate({ itemId }),
+      utilities.assignments2062.list.invalidate(),
+      utilities.items.hasActive2062Coverage.invalidate({ id: itemId }),
+      utilities.items.getActive2062CoverageInfo.invalidate({ id: itemId }),
     ]);
   }
 
@@ -446,6 +511,9 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
       ) : null}
 
       <MoveItemDialog
+        isMoveBlocked={moveCoverageQuery.data?.hasActiveCoverage ?? false}
+        moveCoverageError={moveCoverageQuery.error?.message ?? null}
+        isMoveCoverageLoading={moveCoverageQuery.isFetching}
         isMoving={moveMutation.isPending}
         isOpen={isMoveDialogOpen}
         item={item}
@@ -471,6 +539,44 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
               preserved and can be restored later.
             </DialogDescription>
           </DialogHeader>
+          {archiveCoverageQuery.isFetching ? (
+            <p className="rounded-lg border bg-secondary px-3 py-2 text-sm text-muted-foreground">
+              Checking active 2062 coverage...
+            </p>
+          ) : archiveCoverageError ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-3 text-sm text-destructive">
+              <div className="flex items-start gap-2">
+                <AlertTriangle
+                  aria-hidden="true"
+                  className="mt-0.5 size-4 shrink-0"
+                />
+                <div className="space-y-1">
+                  <p className="font-medium">Coverage check failed</p>
+                  <p className="leading-6">{archiveCoverageError}</p>
+                </div>
+              </div>
+            </div>
+          ) : archiveHasActive2062 ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-3 text-sm text-destructive">
+              <div className="flex items-start gap-2">
+                <AlertTriangle
+                  aria-hidden="true"
+                  className="mt-0.5 size-4 shrink-0"
+                />
+                <div className="space-y-1">
+                  <p className="font-medium">
+                    Archiving will close the active 2062 link
+                  </p>
+                  <p className="leading-6">
+                    The linked document and item history stay preserved.
+                    {archiveCoverage?.isLastActiveLink
+                      ? " This is the last active item on the 2062, so the assignment will close."
+                      : " Other active items on the same 2062 stay covered."}
+                  </p>
+                </div>
+              </div>
+            </div>
+          ) : null}
           <DialogFooter>
             <Button
               disabled={archiveMutation.isPending}
@@ -481,13 +587,21 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
               Cancel
             </Button>
             <Button
-              disabled={archiveMutation.isPending}
+              disabled={
+                archiveMutation.isPending ||
+                archiveCoverageQuery.isFetching ||
+                Boolean(archiveCoverageError)
+              }
               onClick={() => archiveMutation.mutate({ id: item.id })}
               type="button"
               variant="destructive"
             >
               <Archive aria-hidden="true" className="size-4" />
-              {archiveMutation.isPending ? "Archiving" : "Archive"}
+              {archiveMutation.isPending
+                ? "Archiving"
+                : archiveHasActive2062
+                  ? "Archive and close link"
+                  : "Archive"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -532,7 +646,10 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
         <DetailSummary
           isReadOnly={isReadOnly}
           item={item}
-          onArchive={() => setIsArchiveDialogOpen(true)}
+          onArchive={() => {
+            setLifecycleError(null);
+            setIsArchiveDialogOpen(true);
+          }}
           onEdit={() => setIsEditing(true)}
           onMove={() => {
             setLifecycleError(null);

--- a/src/server/trpc/routers/items.ts
+++ b/src/server/trpc/routers/items.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 import {
   getActive2062CoverageInfo,
   hasActive2062Coverage,
+  ItemLinkAlreadyClosedError,
+  ItemLinkNotFoundError,
   removeAssignmentItemLink,
 } from "@/modules/assignments-2062";
 import {
@@ -126,6 +128,20 @@ function toTRPCError(
 ): never {
   const message =
     error instanceof Error ? error.message : "Unable to update item.";
+
+  if (error instanceof ItemLinkNotFoundError) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message,
+    });
+  }
+
+  if (error instanceof ItemLinkAlreadyClosedError) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message,
+    });
+  }
 
   switch (message) {
     case "This account is read-only.":

--- a/src/server/trpc/routers/items.ts
+++ b/src/server/trpc/routers/items.ts
@@ -1,7 +1,11 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
-import { hasActive2062Coverage } from "@/modules/assignments-2062";
+import {
+  getActive2062CoverageInfo,
+  hasActive2062Coverage,
+  removeAssignmentItemLink,
+} from "@/modules/assignments-2062";
 import {
   assignSignedTo,
   assignSignedToWithNewContact,
@@ -154,7 +158,6 @@ function toTRPCError(
     case "Cannot move item from an archived hand receipt.":
     case "Cannot move item to an archived hand receipt.":
     case "Cannot move item with active 2062 coverage.":
-    case "Cannot archive item with active 2062 coverage until the active link is closed.":
     case "Cannot change manual signed-to state while active 2062 coverage exists.":
       throw new TRPCError({
         code: "CONFLICT",
@@ -250,6 +253,36 @@ export const itemsRouter = createTRPCRouter({
 
       return item;
     }),
+  hasActive2062Coverage: protectedProcedure
+    .input(itemIdInput)
+    .query(async ({ ctx, input }) => {
+      const activeCoverage = await hasActive2062Coverage({
+        accountId: ctx.account.id,
+        itemId: input.id,
+        assignmentItemLinkRepository: ctx.assignmentItemLinkRepository,
+      });
+
+      return { hasActiveCoverage: activeCoverage };
+    }),
+  getActive2062CoverageInfo: protectedProcedure
+    .input(itemIdInput)
+    .query(async ({ ctx, input }) => {
+      const activeCoverage = await getActive2062CoverageInfo({
+        accountId: ctx.account.id,
+        itemId: input.id,
+        assignmentItemLinkRepository: ctx.assignmentItemLinkRepository,
+      });
+
+      if (!activeCoverage) {
+        return { hasActiveCoverage: false as const };
+      }
+
+      return {
+        hasActiveCoverage: true as const,
+        assignmentId: activeCoverage.assignmentId,
+        isLastActiveLink: activeCoverage.isLastActiveLink,
+      };
+    }),
   checkDuplicateIdentifier: protectedProcedure
     .input(checkDuplicateIdentifierInput)
     .query(({ ctx, input }) =>
@@ -339,12 +372,25 @@ export const itemsRouter = createTRPCRouter({
             itemId: input.id,
             auditRepository: repositories.auditRepository,
             itemRepository: repositories.itemRepository,
-            hasActive2062Coverage: ({ accountId, itemId }) =>
-              hasActive2062Coverage({
+            getActive2062CoverageInfo: ({ accountId, itemId }) =>
+              getActive2062CoverageInfo({
                 accountId,
                 itemId,
                 assignmentItemLinkRepository:
                   repositories.assignmentItemLinkRepository,
+              }),
+            closeActive2062ItemLink: ({ itemLinkId, now }) =>
+              removeAssignmentItemLink({
+                account: ctx.account,
+                actorId: ctx.session.userId,
+                itemLinkId,
+                closeReason: "item_archived",
+                assignmentRepository: repositories.assignmentRepository,
+                assignmentItemLinkRepository:
+                  repositories.assignmentItemLinkRepository,
+                auditRepository: repositories.auditRepository,
+                itemRepository: repositories.itemRepository,
+                now,
               }),
           }),
       );

--- a/tests/e2e/items.spec.ts
+++ b/tests/e2e/items.spec.ts
@@ -199,6 +199,79 @@ test("users can create single-item formal 2062 coverage from item detail", async
   await expect(page.getByText("Item linked to 2062")).toBeVisible();
 });
 
+test("item workflows warn and block around active 2062 coverage", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signInLocalUser(page);
+
+  await page.getByRole("button", { name: "New hand receipt" }).click();
+  await page.getByLabel("Name").fill("2062 source receipt");
+  await page.getByRole("button", { name: "Create" }).click();
+  await page.goto("/app/hand-receipts");
+  await page.getByRole("button", { name: "New hand receipt" }).click();
+  await page.getByLabel("Name").fill("2062 target receipt");
+  await page.getByRole("button", { name: "Create" }).click();
+  await page.goto("/app/hand-receipts");
+  await page.getByRole("link", { name: "Open 2062 source receipt" }).click();
+
+  await page.getByRole("button", { name: "Add item" }).click();
+  const createItemDialog = page.getByRole("dialog", {
+    name: "Add property item",
+  });
+  await createItemDialog.getByLabel("Nomenclature").fill("2062 blocked radio");
+  await createItemDialog.getByLabel("ECN").fill("ECN-2062-BLOCK");
+  await createItemDialog.getByRole("button", { name: "Create item" }).click();
+  await page.getByRole("link", { name: "Open 2062 blocked radio" }).click();
+
+  await page.getByLabel("Contact name").fill("SGT Morgan");
+  await page.getByRole("button", { name: "Create SGT Morgan" }).click();
+  await page.getByRole("link", { name: "Upload 2062" }).first().click();
+  await page.getByLabel("Upload 2062 document").setInputFiles({
+    name: "blocked-2062.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("%PDF-1.4\n% Field Ledger blocked 2062 fixture\n"),
+  });
+  await page.getByLabel("Select document").selectOption({
+    label: "blocked-2062.pdf",
+  });
+  await page.getByRole("button", { name: "Create 2062" }).click();
+
+  await page.getByRole("button", { name: "Move" }).click();
+  const moveDialog = page.getByRole("dialog", { name: "Move item" });
+  await expect(
+    moveDialog.getByText("Move blocked by active 2062"),
+  ).toBeVisible();
+  await expect(
+    moveDialog.getByText("Close this item's active 2062 link before moving"),
+  ).toBeVisible();
+  await expect(moveDialog.getByRole("button", { name: "Move" })).toBeDisabled();
+  await moveDialog.getByRole("button", { name: "Cancel" }).click();
+
+  await page.getByRole("button", { name: "Archive item" }).click();
+  const archiveDialog = page.getByRole("dialog", {
+    name: "Archive this item?",
+  });
+  await expect(
+    archiveDialog.getByText("Archiving will close the active 2062 link"),
+  ).toBeVisible();
+  await expect(
+    archiveDialog.getByText("The linked document and item history stay preserved."),
+  ).toBeVisible();
+  await expect(
+    archiveDialog.getByText(
+      "This is the last active item on the 2062, so the assignment will close.",
+    ),
+  ).toBeVisible();
+  await archiveDialog
+    .getByRole("button", { name: "Archive and close link" })
+    .click();
+
+  await expect(page.getByText("archived property item")).toBeVisible();
+  await expect(page.getByText("Item archived")).toBeVisible();
+  await expect(page.getByText("Item removed from 2062")).toBeVisible();
+});
+
 test("archived item records appear only when deliberately included", async ({
   page,
 }) => {

--- a/tests/e2e/items.spec.ts
+++ b/tests/e2e/items.spec.ts
@@ -232,6 +232,9 @@ test("item workflows warn and block around active 2062 coverage", async ({
     mimeType: "application/pdf",
     buffer: Buffer.from("%PDF-1.4\n% Field Ledger blocked 2062 fixture\n"),
   });
+  await expect(
+    page.getByText("blocked-2062.pdf is saved as private document evidence."),
+  ).toBeVisible();
   await page.getByLabel("Select document").selectOption({
     label: "blocked-2062.pdf",
   });

--- a/tests/integration/trpc/items-router.test.ts
+++ b/tests/integration/trpc/items-router.test.ts
@@ -694,7 +694,7 @@ describe("itemsRouter", () => {
     ]);
   });
 
-  it("blocks manual signed-to and archive mutations when active 2062 coverage exists", async () => {
+  it("blocks manual signed-to changes when active 2062 coverage exists", async () => {
     const auditRepository = new InMemoryAuditRepository();
     const assignmentItemLinkRepository =
       new InMemoryAssignmentItemLinkRepository([
@@ -760,15 +760,267 @@ describe("itemsRouter", () => {
       message:
         "Cannot change manual signed-to state while active 2062 coverage exists.",
     });
-    await expect(
-      caller.items.archive({ id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c" }),
-    ).rejects.toMatchObject({
-      code: "CONFLICT",
-      message:
-        "Cannot archive item with active 2062 coverage until the active link is closed.",
-    });
     expect(contactRepository.contacts).toHaveLength(1);
     expect(auditRepository.events).toEqual([]);
+  });
+
+  it("blocks moves with active 2062 coverage and exposes move preflight state", async () => {
+    const assignmentItemLinkRepository =
+      new InMemoryAssignmentItemLinkRepository([
+        {
+          id: "3dbd4b63-4d13-4e91-b27c-3f2211cd8494",
+          accountId: "account-1",
+          assignmentId: "26975a26-42c7-4307-b883-d676482f1545",
+          itemId: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+          status: "active",
+          closedAt: null,
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ]);
+    const auditRepository = new InMemoryAuditRepository();
+    const itemRepository = new InMemoryItemRepository([
+      {
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        nomenclature: "Covered move radio",
+        ecn: "ECN-703",
+        serialNumber: null,
+        generatedId: null,
+        notes: null,
+        status: "active",
+        createdAt: new Date("2026-04-29T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-29T12:00:00.000Z"),
+      },
+    ]);
+    const caller = createCaller({
+      assignmentItemLinkRepository,
+      auditRepository,
+      itemRepository,
+    });
+
+    await expect(
+      caller.items.hasActive2062Coverage({
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+      }),
+    ).resolves.toEqual({ hasActiveCoverage: true });
+    await expect(
+      caller.items.move({
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+        targetHandReceiptId: "14ad8e43-8ca5-484d-b10c-7cf436647040",
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Cannot move item with active 2062 coverage.",
+    });
+    expect(itemRepository.items[0]?.handReceiptId).toBe(
+      "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+    );
+    expect(auditRepository.events).toEqual([]);
+  });
+
+  it("archives covered items by closing only that active 2062 link", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+    const assignmentRepository = new InMemoryAssignmentRepository([
+      {
+        id: "26975a26-42c7-4307-b883-d676482f1545",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        contactId: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+        contactName: "SSG Rivera",
+        documentId: "86f8e191-bb5c-48ca-9868-4f2b8e0480ea",
+        documentFilename: "signed-2062.pdf",
+        status: "active",
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+    ]);
+    const assignmentItemLinkRepository =
+      new InMemoryAssignmentItemLinkRepository([
+        {
+          id: "3dbd4b63-4d13-4e91-b27c-3f2211cd8494",
+          accountId: "account-1",
+          assignmentId: "26975a26-42c7-4307-b883-d676482f1545",
+          itemId: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+          status: "active",
+          closedAt: null,
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+        {
+          id: "941cbef0-b703-4327-8440-2ad719dcb098",
+          accountId: "account-1",
+          assignmentId: "26975a26-42c7-4307-b883-d676482f1545",
+          itemId: "53cc548f-1493-406b-ae47-7037dd1ca610",
+          status: "active",
+          closedAt: null,
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ]);
+    const itemRepository = new InMemoryItemRepository([
+      {
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        nomenclature: "Covered radio",
+        ecn: "ECN-704",
+        serialNumber: null,
+        generatedId: null,
+        notes: null,
+        status: "active",
+        signedToContactId: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+        createdAt: new Date("2026-04-29T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-29T12:00:00.000Z"),
+      },
+      {
+        id: "53cc548f-1493-406b-ae47-7037dd1ca610",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        nomenclature: "Still covered radio",
+        ecn: "ECN-705",
+        serialNumber: null,
+        generatedId: null,
+        notes: null,
+        status: "active",
+        signedToContactId: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+        createdAt: new Date("2026-04-29T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-29T12:00:00.000Z"),
+      },
+    ]);
+    const caller = createCaller({
+      assignmentItemLinkRepository,
+      assignmentRepository,
+      auditRepository,
+      itemRepository,
+    });
+
+    await expect(
+      caller.items.getActive2062CoverageInfo({
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+      }),
+    ).resolves.toEqual({
+      hasActiveCoverage: true,
+      assignmentId: "26975a26-42c7-4307-b883-d676482f1545",
+      isLastActiveLink: false,
+    });
+    await expect(
+      caller.items.archive({ id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c" }),
+    ).resolves.toMatchObject({
+      id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+      status: "archived",
+      signedToContactId: null,
+    });
+
+    expect(assignmentRepository.assignments[0]).toMatchObject({
+      status: "active",
+      documentId: "86f8e191-bb5c-48ca-9868-4f2b8e0480ea",
+    });
+    expect(assignmentItemLinkRepository.links).toMatchObject([
+      {
+        id: "3dbd4b63-4d13-4e91-b27c-3f2211cd8494",
+        status: "closed",
+      },
+      {
+        id: "941cbef0-b703-4327-8440-2ad719dcb098",
+        status: "active",
+      },
+    ]);
+    expect(itemRepository.items[1]).toMatchObject({
+      id: "53cc548f-1493-406b-ae47-7037dd1ca610",
+      status: "active",
+      signedToContactId: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+    });
+    expect(auditRepository.events.map((event) => event.action)).toEqual([
+      "item.archived",
+      "assignment_item_link.removed",
+    ]);
+    expect(auditRepository.events[1]?.metadata).toMatchObject({
+      reason: "item_archived",
+      documentId: "86f8e191-bb5c-48ca-9868-4f2b8e0480ea",
+      documentFilename: "signed-2062.pdf",
+    });
+  });
+
+  it("closes the 2062 assignment when archived item was the final active link", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+    const assignmentRepository = new InMemoryAssignmentRepository([
+      {
+        id: "26975a26-42c7-4307-b883-d676482f1545",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        contactId: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+        contactName: "SSG Rivera",
+        documentId: "86f8e191-bb5c-48ca-9868-4f2b8e0480ea",
+        documentFilename: "signed-2062.pdf",
+        status: "active",
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+    ]);
+    const assignmentItemLinkRepository =
+      new InMemoryAssignmentItemLinkRepository([
+        {
+          id: "3dbd4b63-4d13-4e91-b27c-3f2211cd8494",
+          accountId: "account-1",
+          assignmentId: "26975a26-42c7-4307-b883-d676482f1545",
+          itemId: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+          status: "active",
+          closedAt: null,
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ]);
+    const itemRepository = new InMemoryItemRepository([
+      {
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        nomenclature: "Final covered radio",
+        ecn: "ECN-706",
+        serialNumber: null,
+        generatedId: null,
+        notes: null,
+        status: "active",
+        signedToContactId: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+        createdAt: new Date("2026-04-29T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-29T12:00:00.000Z"),
+      },
+    ]);
+    const caller = createCaller({
+      assignmentItemLinkRepository,
+      assignmentRepository,
+      auditRepository,
+      itemRepository,
+    });
+
+    await expect(
+      caller.items.getActive2062CoverageInfo({
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+      }),
+    ).resolves.toEqual({
+      hasActiveCoverage: true,
+      assignmentId: "26975a26-42c7-4307-b883-d676482f1545",
+      isLastActiveLink: true,
+    });
+    await expect(
+      caller.items.archive({ id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c" }),
+    ).resolves.toMatchObject({
+      status: "archived",
+      signedToContactId: null,
+    });
+
+    expect(assignmentRepository.assignments[0]?.status).toBe("closed");
+    expect(auditRepository.events.map((event) => event.action)).toEqual([
+      "item.archived",
+      "assignment_item_link.removed",
+      "assignment.closed",
+    ]);
+    expect(auditRepository.events[2]?.metadata).toMatchObject({
+      reason: "last_item_archived",
+      documentId: "86f8e191-bb5c-48ca-9868-4f2b8e0480ea",
+    });
   });
 
   it("rejects cross-account item moves as not found", async () => {

--- a/tests/integration/trpc/items-router.test.ts
+++ b/tests/integration/trpc/items-router.test.ts
@@ -1023,6 +1023,81 @@ describe("itemsRouter", () => {
     });
   });
 
+  it("maps covered item archive link closure races to conflict", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+    const assignmentRepository = new InMemoryAssignmentRepository([
+      {
+        id: "26975a26-42c7-4307-b883-d676482f1545",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        contactId: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+        contactName: "SSG Rivera",
+        documentId: "86f8e191-bb5c-48ca-9868-4f2b8e0480ea",
+        documentFilename: "signed-2062.pdf",
+        status: "active",
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+    ]);
+    const assignmentItemLinkRepository =
+      new InMemoryAssignmentItemLinkRepository([
+        {
+          id: "3dbd4b63-4d13-4e91-b27c-3f2211cd8494",
+          accountId: "account-1",
+          assignmentId: "26975a26-42c7-4307-b883-d676482f1545",
+          itemId: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+          status: "active",
+          closedAt: null,
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+          updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ]);
+    const itemRepository = new InMemoryItemRepository([
+      {
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        nomenclature: "Race covered radio",
+        ecn: "ECN-707",
+        serialNumber: null,
+        generatedId: null,
+        notes: null,
+        status: "active",
+        signedToContactId: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+        createdAt: new Date("2026-04-29T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-29T12:00:00.000Z"),
+      },
+    ]);
+    const originalFindById =
+      assignmentItemLinkRepository.findById.bind(assignmentItemLinkRepository);
+    assignmentItemLinkRepository.findById = async (...args) => {
+      const link = await originalFindById(...args);
+
+      if (!link) {
+        return null;
+      }
+
+      return {
+        ...link,
+        status: "closed",
+        closedAt: new Date("2026-05-02T12:00:00.000Z"),
+      };
+    };
+    const caller = createCaller({
+      assignmentItemLinkRepository,
+      assignmentRepository,
+      auditRepository,
+      itemRepository,
+    });
+
+    await expect(
+      caller.items.archive({ id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c" }),
+    ).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Item link is already closed.",
+    });
+  });
+
   it("rejects cross-account item moves as not found", async () => {
     const itemRepository = new InMemoryItemRepository([
       {

--- a/tests/unit/items/archive-restore-item.test.ts
+++ b/tests/unit/items/archive-restore-item.test.ts
@@ -117,23 +117,47 @@ describe("archiveItem", () => {
     expect(auditRepository.events).toEqual([]);
   });
 
-  it("blocks archive while active 2062 coverage exists", async () => {
+  it("archives an item with active 2062 coverage and closes that item link", async () => {
     const auditRepository = new InMemoryAuditRepository();
+    const itemRepository = createRepository();
+    const closedLinks: string[] = [];
 
-    await expect(
-      archiveItem({
-        account: createAccount(),
-        actorId: "owner-1",
-        itemId: "active-item",
-        itemRepository: createRepository(),
-        auditRepository,
-        hasActive2062Coverage: ({ accountId, itemId }) =>
-          accountId === "account-1" && itemId === "active-item",
-      }),
-    ).rejects.toThrow(
-      "Cannot archive item with active 2062 coverage until the active link is closed.",
-    );
-    expect(auditRepository.events).toEqual([]);
+    const archived = await archiveItem({
+      account: createAccount(),
+      actorId: "owner-1",
+      itemId: "active-item",
+      itemRepository,
+      auditRepository,
+      getActive2062CoverageInfo: ({ accountId, itemId }) =>
+        accountId === "account-1" && itemId === "active-item"
+          ? {
+              hasActiveCoverage: true,
+              itemLinkId: "link-1",
+              assignmentId: "assignment-1",
+              isLastActiveLink: true,
+            }
+          : null,
+      closeActive2062ItemLink: async ({ itemLinkId }) => {
+        closedLinks.push(itemLinkId);
+        await itemRepository.update("account-1", "active-item", {
+          signedToContactId: null,
+        });
+      },
+    });
+
+    expect(archived).toMatchObject({
+      id: "active-item",
+      status: "archived",
+      signedToContactId: null,
+    });
+    expect(closedLinks).toEqual(["link-1"]);
+    expect(auditRepository.events).toMatchObject([
+      {
+        action: "item.archived",
+        targetType: "item",
+        targetId: "active-item",
+      },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Enforces active 2062 coverage in item workflows: covered items cannot move hand receipts, and confirmed archive closes the covered item link.
- Adds item preflight queries and item-detail UI warnings for move block and archive-with-2062 confirmation.
- Preserves document/history behavior, closes the assignment when archive removes the final active link, and updates docs/tests for the new rule.

## Review and audit

- Code review: no remaining findings after tightening failed preflight coverage checks so move/archive actions stay disabled until the warning state is known.
- Field Ledger architecture audit: no remaining findings. Business behavior stays in module services, tRPC composes services, provider boundaries are untouched, and audit events are emitted through the unit-of-work path.
- CodeRabbit plan was used as advisory input only; the implementation follows the issue, Phase 5 PRD, and existing module seams.

## Validation

- pnpm vitest run tests/unit/items/move-item.test.ts tests/unit/items/archive-restore-item.test.ts tests/integration/trpc/items-router.test.ts
- pnpm test -- --runInBand
- pnpm typecheck
- pnpm exec playwright test tests/e2e/items.spec.ts --project=chromium
- pnpm lint
- git diff --check

Closes #64.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Enforce Active 2062 Item Workflow Constraints

### Overview
This release implements constraints on item workflows when active 2062 coverage exists. Items can now be deliberately archived with coverage by warning the user and closing only that item's link, while moves to items with active coverage are blocked until the link is closed.

### Features & Improvements

**Archive with Active 2062 Coverage**
- Items with active 2062 coverage can now be archived as a deliberate action with user warning and confirmation
- Archiving closes only the specific item's active 2062 link, preserving the linked document and closed-link history
- If archiving removes the final active link on a 2062 assignment, the assignment is automatically closed
- Item activity history and audit events are preserved

**Move Blocking for Covered Items**
- Items with active 2062 coverage cannot be moved between hand receipts
- Move action is blocked at both the application-service and UI levels
- Clear UI messaging indicates the active 2062 link must be closed first
- Applies to covered items only; moves of uncovered items remain unaffected

**UI Enhancements**
- Move dialog now displays coverage-check results with messaging when items are blocked
- Archive dialog warns users before confirmation and reports when archiving closes the final active link
- Disabled state properly reflects loading/failure conditions for coverage checks

### Technical Changes

**Application Services**
- `getActive2062CoverageInfo` replaces boolean-only coverage checks and provides `isLastActiveLink` information
- `closeActive2062ItemLink` closes item-specific links during archive operations
- `removeAssignmentItemLink` now accepts optional `closeReason` parameter (`"item_archived"` | `"user_removed"`) for audit event classification

**TRPC Router**
- New procedures: `hasActive2062Coverage` and `getActive2062CoverageInfo` for client-side preflight checks
- Error mapping expanded for item-link-specific errors (`ItemLinkNotFoundError`, `ItemLinkAlreadyClosedError`)

**Documentation**
- Updated domain model rules for property items and active 2062 coverage
- Clarified 2062 boundary behavior during item workflows and hand receipt archiving
- Added UI specification for move/archive dialogs with covered items

### Testing
- Unit tests updated for archive/restore lifecycle with active coverage scenarios
- Integration tests cover move blocking, archive with coverage (single/multi-item), final-link handling, and race conditions
- E2E test validates move blocking UI state and archive confirmation flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->