### PR TITLE
[codex] Harden Field Ledger MVP baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ notes.
 - tRPC
 - TanStack Query
 - Drizzle
-- Supabase Auth, Postgres, and Storage
+- Better Auth
+- Supabase Postgres and Storage
 - Local Supabase for development
 - Vitest and Playwright
 
@@ -69,19 +70,26 @@ internal boundaries.
 
 ## Current Status
 
-The repo is in the foundation stage. The scaffold proves the real app stack is
-installed and wired, and the first auth/session slice is now in place:
+The MVP baseline is implemented and in hardening closeout. The app now has real
+authenticated product routes for dashboard, hand receipts, item search, item
+detail, Active 2062s, Activity, and upload 2062 workflows, with placeholder
+surfaces still reserved for billing, contacts, locations, and settings.
 
-- Next.js app shell
-- Tailwind v4 and shadcn/ui setup
-- tRPC plus TanStack Query foundation
-- Drizzle config and first scaffold migration
-- Local Supabase config on nondefault ports
-- Provider-boundary starting point, including Supabase Auth session access
-- Public `/auth/login` and protected `/app/...` route behavior
-- Unit, integration, RLS-placeholder, and browser test commands
+Implemented MVP behavior includes:
 
-Product workflows are intentionally added in small vertical slices.
+- Better Auth sign-in, account initialization, onboarding, and read-only access
+  behavior.
+- Hand receipt create, edit, archive, restore, list, and detail workflows.
+- Property item create, edit, archive, restore, move, global search, reusable
+  contact/location context, and manual signed-to state.
+- Item requirements with due windows, completion history, pause/resume, manual
+  next-due adjustment, and dashboard review behavior.
+- Private document upload for formal 2062 workflows, single-item and multi-item
+  2062 assignment creation, active 2062 review, close, and remove-item-link
+  behavior.
+- Audit/activity events with readable Activity surfaces.
+- Supabase RLS coverage for account-owned MVP data and focused browser coverage
+  for core mobile/desktop workflows.
 
 ## Quick Start
 
@@ -103,13 +111,15 @@ Start local Supabase:
 pnpm supabase:start
 ```
 
-Copy the local publishable key from:
+Copy the local service-role key from:
 
 ```sh
 pnpm supabase:status
 ```
 
-Then paste it into `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` in `.env.local`.
+Then paste it into `SUPABASE_SERVICE_ROLE_KEY` in `.env.local`. Local
+email/password auth uses Better Auth and does not require Supabase Auth
+publishable keys.
 
 Apply local migrations:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,7 @@ Use a domain-first structure:
 
 ```text
 src/modules/accounts/
+src/modules/app-foundation/
 src/modules/audit/
 src/modules/billing/
 src/modules/contacts/
@@ -17,10 +18,12 @@ src/modules/items/
 src/modules/locations/
 src/modules/requirements/
 src/modules/assignments-2062/
-src/modules/import-export/
+src/modules/provider-boundaries/
 ```
 
-The exact folder names can evolve during scaffold, but the dependency rule should not.
+`import-export` remains a documented post-MVP boundary, but it does not have an
+MVP implementation module yet. The exact folder names can evolve during
+scaffold, but the dependency rule should not.
 
 ## Dependency Rule
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,6 +140,24 @@ belongs in domain modules; shell pages are only composition surfaces.
   should include a repository-level RLS regression test proving they cannot read
   or write another account's rows through the app adapter.
 
+## Cross-Account Relationship Protection
+
+Account-owned relationship columns must prevent records from pointing at another
+owner account's records. Field Ledger uses two database patterns for this:
+
+- RESTRICTIVE RLS policies add extra insert/update checks to the writing table.
+  `items` uses this pattern for `signed_to_contact_id` in migration `0014` and
+  `location_id` in migration `0015`; item hand receipt ownership is also
+  checked in the item owner insert/update policies from migration `0013`.
+- Composite foreign keys include `account_id` on both sides of the relationship.
+  `assignments` and `assignment_item_links` use this pattern in migration `0023`
+  for hand receipt, contact, document, assignment, and item links.
+
+Both patterns are valid for MVP account isolation. RESTRICTIVE policies reject
+the write through RLS, while composite foreign keys reject it through schema
+constraints. RLS tests should prove the relationship cannot cross accounts
+regardless of which enforcement pattern a table uses.
+
 ## RLS Session Context
 
 RLS remains mandatory for account-owned data even though Supabase Auth is no

--- a/docs/billing-capabilities.md
+++ b/docs/billing-capabilities.md
@@ -39,6 +39,44 @@ UI workflows should use the typed tRPC boundary, currently
 `billing.capabilities`, so client code does not need to know how access state or
 tier data is stored.
 
+## Read-Only Enforcement Pattern
+
+Read-only behavior is enforced in three layers:
+
+1. Application services derive capabilities and block writes when
+   `isReadOnly` is true.
+2. tRPC routers translate read-only write attempts to `FORBIDDEN` responses
+   with the canonical message `This account is read-only.`
+3. Module UI queries `billing.capabilities` and disables, hides, or explains
+   write actions while preserving record review.
+
+Core property reads remain available for paused/read-only accounts. This
+includes hand receipts, items, contacts, locations, search results, and
+activity. Expired trials with no active plan resolve to the same read-only
+capability behavior dynamically.
+
+## Capability Helpers
+
+- `isAccountReadOnly`: checks whether an account is in read-only capability
+  mode.
+- `getActiveHandReceiptLimit`: returns the current active hand receipt limit, or
+  unlimited when the value is `null`.
+- `canCreateHandReceipt`: allows creation only when the account is writable and
+  the active hand receipt limit has room.
+- `canRestoreHandReceipt`: uses the same writable account and active limit rule
+  as hand receipt creation.
+- `canArchiveHandReceipt`: blocks lifecycle archive actions for read-only
+  accounts.
+- `canMoveItem`: blocks item moves for read-only accounts.
+- `canCreateRequirement`: blocks requirement creation for read-only accounts.
+- `canEditRequirement`: blocks requirement edit and lifecycle actions for
+  read-only accounts.
+- `canUploadDocument`: blocks private document upload for read-only accounts.
+- `canClose2062Assignment`: blocks whole-assignment close actions for read-only
+  accounts.
+- `canRemove2062ItemLink`: blocks individual 2062 item-link removal for
+  read-only accounts.
+
 ## Provider Boundary
 
 This slice does not add Stripe checkout, invoices, webhooks, a customer portal,

--- a/docs/billing-capabilities.md
+++ b/docs/billing-capabilities.md
@@ -50,10 +50,22 @@ Read-only behavior is enforced in three layers:
 3. Module UI queries `billing.capabilities` and disables, hides, or explains
    write actions while preserving record review.
 
-Core property reads remain available for paused/read-only accounts. This
-includes hand receipts, items, contacts, locations, search results, and
-activity. Expired trials with no active plan resolve to the same read-only
-capability behavior dynamically.
+Core operational reads remain available for paused/read-only accounts. This
+includes hand receipts, items, contacts, locations, search results,
+requirements and completion history, document metadata and downloads, active
+2062 assignments, closed 2062 coverage history, and activity. Expired trials
+with no active plan resolve to the same read-only capability behavior
+dynamically.
+
+Read-only write blocking applies to the remaining MVP operational workflows:
+
+- Requirements: create, edit, complete, pause, resume, and next-due adjustment
+  actions are blocked while list and completion-history reads remain available.
+- Documents: upload initiation and upload completion are blocked while existing
+  document list, metadata, and download reads remain available.
+- Formal 2062s: assignment creation, whole-assignment close, and individual
+  item-link removal are blocked while active assignment and item coverage reads
+  remain available.
 
 ## Capability Helpers
 

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -41,7 +41,8 @@ notice states that Field Ledger is for property accountability assistance, is
 not an official Army system of record, and must not store classified
 information, PHI, or sensitive operational details. Paused/read-only accounts
 can acknowledge the notice, but the copy must make clear that new hand receipt
-work waits until access is restored.
+work waits until access is restored. Completing onboarding emits
+`account.onboarding_completed` with boundary-notice acknowledgment metadata.
 
 ## Hand Receipts
 
@@ -68,8 +69,8 @@ Status:
 Archived hand receipts are hidden from day-to-day workflows.
 Creation of a hand receipt emits `hand_receipt.created` through the audit
 logger boundary. Editing a hand receipt emits `hand_receipt.updated` with the
-changed field names in metadata. Archiving and restoring a hand receipt emit
-`hand_receipt.archived` and `hand_receipt.restored`.
+hand receipt name and changed field names in metadata. Archiving and restoring
+a hand receipt emit `hand_receipt.archived` and `hand_receipt.restored`.
 
 Activity is the user-readable surface over audit events. Hand receipt activity
 labels are:
@@ -82,8 +83,8 @@ labels are:
 Activity reads are account-scoped. The general Activity route can show recent
 account history, the dashboard shows a lower-priority recent activity section,
 and hand receipt detail shows only recent events for that receipt. Activity UI
-should show readable labels and receipt names when available, not raw action
-strings, target type names, or database ids.
+should show readable labels and entity names when available, not raw action
+strings, raw target type names, or database ids.
 
 When item requirements exist, archived hand receipts should suppress contained
 item reminders so inactive buckets do not create day-to-day requirement noise.

--- a/docs/mvp-scope.md
+++ b/docs/mvp-scope.md
@@ -24,16 +24,20 @@ MVP means the app is personally useful for managing real hand receipt data. It d
 ## Out of Scope
 
 - Real Stripe checkout/webhooks.
+- Real billing automation such as invoices, customer portal, or subscription
+  lifecycle webhooks.
 - Public marketing site.
 - Organization/team collaboration.
 - CSV/XLSX import/export implementation.
 - Offline read cache.
+- Offline editing.
 - Push/email reminders.
 - OCR.
 - Item photos.
 - Dedicated Reports area.
 - Requirement templates.
 - Tags/categories.
+- Advanced activity filtering, audit export, or admin audit tooling.
 
 ## MVP UI Standard
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -78,8 +78,14 @@
 - CSV/XLSX import/export
 - report exports
 - read-only offline cache
+- offline editing, if later justified
 - Stripe checkout/webhooks
+- customer portal and subscription automation
 - email reminders
+- push reminders
 - OCR exploration
 - item photos
+- tags/categories
+- organization/team collaboration
 - requirement templates
+- advanced activity filtering/export

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -80,13 +80,14 @@ database rules that restrict which rows a user can access.
 Every account-owned table should have tests proving one account cannot read or
 write another account's rows.
 
-Hand receipt and item RLS tests cover owner-scoped select, insert, and update
-behavior. Item RLS also proves a row cannot be linked to another account's hand
-receipt. Archive and restore are update behaviors, so RLS coverage must prove
-status changes cannot cross account boundaries while application tests prove
-lifecycle rules and read-only blocking.
-Application-service tests still cover read-only capability blocking because RLS
-protects row ownership, not product access state.
+RLS tests cover owner-scoped select, insert, and update behavior for the
+account-owned MVP tables that support those operations. Relationship tests also
+prove rows cannot point at records from another account. Archive, restore,
+pause, and close are update behaviors, so RLS coverage proves status changes
+cannot cross account boundaries while application tests prove lifecycle rules
+and read-only blocking. Application-service tests still cover read-only
+capability blocking because RLS protects row ownership, not product access
+state.
 
 Command:
 
@@ -98,11 +99,26 @@ The account foundation includes the first RLS-protected production table, so
 `pnpm test:rls` now runs real tests instead of using scaffold
 `--passWithNoTests` behavior.
 
-Current account RLS proof:
+Current table-level RLS proof:
 
 - `tests/rls/accounts/accounts-rls.test.ts`
+- `tests/rls/audit/audit-events-rls.test.ts`
 - `tests/rls/hand-receipts/hand-receipts-rls.test.ts`
 - `tests/rls/items/items-rls.test.ts`
+- `tests/rls/contacts/contacts-rls.test.ts`
+- `tests/rls/locations/locations-rls.test.ts`
+- `tests/rls/requirements/requirements-rls.test.ts`
+- `tests/rls/requirements/requirement-completions-rls.test.ts`
+- `tests/rls/documents/documents-rls.test.ts`
+- `tests/rls/assignments-2062/assignments-2062-rls.test.ts`
+
+Current repository-level RLS proof:
+
+- `tests/rls/audit/audit-repository-rls.test.ts`
+- `tests/rls/hand-receipts/hand-receipt-repository-rls.test.ts`
+- `tests/rls/requirements/requirements-repository-rls.test.ts`
+- `tests/rls/requirements/requirement-completion-repository-rls.test.ts`
+- `tests/rls/documents/document-repository-rls.test.ts`
 
 ## Browser/UI Tests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -23,20 +23,15 @@ Command:
 pnpm test:unit
 ```
 
-Current scaffold proof:
+Current unit coverage includes 37 test files across accounts, app foundation,
+assignments-2062, audit, billing, contacts, documents, hand receipts, items,
+locations, and requirements. These tests cover capability decisions,
+application-service lifecycle rules, validation, audit emission, date handling,
+and read-only blocking.
 
-- `tests/unit/accounts/ensure-account.test.ts`
-- `tests/unit/app-foundation/get-scaffold-health.test.ts`
-
-Requirement proof:
-
-- `tests/unit/requirements/requirement-due-date.test.ts` covers recurring due
-  date calculation.
-- `tests/unit/requirements/requirement-completion.test.ts` covers completion
-  behavior, past completion dates, future-date blocking, next-due recalculation,
-  and audit emission.
-- `tests/unit/requirements/requirement-lifecycle.test.ts` covers manual next
-  due adjustment plus pause/resume behavior.
+`tests/support/` contains in-memory repositories and test helpers used by unit
+and integration tests to keep application-service coverage fast and focused
+without depending on browser flows.
 
 ## Integration Tests
 
@@ -60,17 +55,10 @@ Command:
 pnpm test:integration
 ```
 
-Current scaffold proof:
-
-- `tests/integration/trpc/foundation-router.test.ts`
-- `tests/integration/auth/protected-procedure.test.ts`
-
-Requirement proof:
-
-- `tests/integration/trpc/requirements-router.test.ts` covers the typed
-  requirement workflow, including completion history.
-- `tests/integration/trpc/audit-router.test.ts` covers readable requirement
-  activity labels and requirement target-scoped activity reads.
+Current integration coverage includes 12 test files across auth and tRPC
+routers. The suite covers protected procedures and typed router behavior for
+accounts, assignments-2062, audit, billing, contacts, documents, hand receipts,
+items, locations, onboarding, requirements, and app foundation.
 
 ## RLS Tests
 
@@ -99,7 +87,7 @@ The account foundation includes the first RLS-protected production table, so
 `pnpm test:rls` now runs real tests instead of using scaffold
 `--passWithNoTests` behavior.
 
-Current table-level RLS proof:
+Current RLS coverage includes 15 test files. Table-level RLS proof:
 
 - `tests/rls/accounts/accounts-rls.test.ts`
 - `tests/rls/audit/audit-events-rls.test.ts`
@@ -112,7 +100,7 @@ Current table-level RLS proof:
 - `tests/rls/documents/documents-rls.test.ts`
 - `tests/rls/assignments-2062/assignments-2062-rls.test.ts`
 
-Current repository-level RLS proof:
+Repository-level RLS proof:
 
 - `tests/rls/audit/audit-repository-rls.test.ts`
 - `tests/rls/hand-receipts/hand-receipt-repository-rls.test.ts`
@@ -136,16 +124,22 @@ Command:
 pnpm test:e2e
 ```
 
-Current scaffold proof:
+Current browser coverage includes 9 specs:
 
-- `tests/e2e/scaffold.spec.ts`
+- `tests/e2e/app-shell.spec.ts`
 - `tests/e2e/auth.spec.ts`
+- `tests/e2e/blocked-states.spec.ts`
+- `tests/e2e/dashboard-requirements.spec.ts`
+- `tests/e2e/hand-receipts.spec.ts`
+- `tests/e2e/items.spec.ts`
+- `tests/e2e/onboarding.spec.ts`
+- `tests/e2e/responsive-smoke.spec.ts`
+- `tests/e2e/scaffold.spec.ts`
 
-Requirement proof:
-
-- `tests/e2e/dashboard-requirements.spec.ts` covers dashboard overdue, due
-  soon, and upcoming sections plus mobile priority ordering and desktop
-  overflow.
+Together they cover app shell navigation, auth, onboarding, dashboard
+requirements, read-only blocked states, validation and empty states, hand
+receipt and item workflows, 2062 flows, archived records, activity surfacing,
+and focused responsive smoke checks.
 
 Auth-related browser tests should verify the app-owned auth/session boundary
 and Better Auth flow, not route or UI calls to provider internals.

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -109,6 +109,12 @@ enforcement.
   and activity remain reviewable.
 - `DashboardReadOnlyNotice` suppresses active requirement work tiles for
   read-only accounts.
+- Requirement UI remains visible as review context, but create, edit, complete,
+  pause, resume, and due-date adjustment controls are unavailable.
+- Document UI keeps existing document review/download paths available, but
+  upload entry points are unavailable.
+- 2062 UI keeps active assignments and coverage history visible, but create,
+  close, and remove-item-link controls are unavailable.
 
 ## Key Workflows
 

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -130,6 +130,17 @@ Step-based workflows should avoid tall stacked progress rails on phone. Use
 compact horizontal rails or equivalent compressed progress indicators, with
 full-width primary buttons where thumb reach matters.
 
+## Error, Blocked, and Empty States
+
+Error blocks should state what could not be loaded or saved, show the plain
+service error when available, provide a non-empty fallback, and offer Retry when
+the user can safely try the same read again.
+
+Blocked-state copy should name the actual product state: read-only account,
+archived item or receipt, active 2062 coverage, or missing data. Empty states
+should describe what is absent and offer only navigation or actions available to
+the current account.
+
 ## Key Workflows
 
 ### Upload 2062 From Hand Receipt

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -91,6 +91,25 @@ Due windows:
 - upcoming: 15 through 30 days
 - beyond 30 days: hidden by default
 
+Paused/read-only accounts keep dashboard review access, but operational
+requirement sections should not ask the user to complete active work. Use a
+plain read-only notice instead of due-work calls to action.
+
+## Read-Only UI Pattern
+
+Use `billing.capabilities` as the UI source of truth for access gating. UI
+gating explains the application-service rule; it does not replace server-side
+enforcement.
+
+- Detail pages should show an inline read-only banner near the page heading.
+- Write buttons should be disabled or hidden where the action cannot start.
+- Disabled controls should keep plain reasons near the control or in the
+  native `title` where the existing component pattern uses titles.
+- Existing records, archived history, search results, documents, 2062 context,
+  and activity remain reviewable.
+- `DashboardReadOnlyNotice` suppresses active requirement work tiles for
+  read-only accounts.
+
 ## Key Workflows
 
 ### Upload 2062 From Hand Receipt

--- a/docs/ui-spec.md
+++ b/docs/ui-spec.md
@@ -29,6 +29,9 @@ Phone:
 - Items/Search
 - Hand Receipts
 - More
+- More sheet groups secondary record surfaces separately from account surfaces,
+  keeps Active 2062s visible in the Records group, and scrolls within the
+  viewport when content grows.
 
 Tablet/desktop:
 
@@ -115,6 +118,17 @@ enforcement.
   upload entry points are unavailable.
 - 2062 UI keeps active assignments and coverage history visible, but create,
   close, and remove-item-link controls are unavailable.
+
+## Responsive Form Pattern
+
+Form-heavy dialogs should stay within the phone viewport and scroll internally
+when their fields exceed available height. Primary form actions must remain
+reachable by scrolling the dialog, not by scrolling hidden page content behind
+the overlay.
+
+Step-based workflows should avoid tall stacked progress rails on phone. Use
+compact horizontal rails or equivalent compressed progress indicators, with
+full-width primary buttons where thumb reach matters.
 
 ## Key Workflows
 

--- a/plans/01-scaffold-foundation.md
+++ b/plans/01-scaffold-foundation.md
@@ -29,11 +29,11 @@ Create the initial Next.js app scaffold with TypeScript, pnpm, Tailwind v4, shad
 
 ### Acceptance Criteria
 
-- [ ] The project runs locally with `pnpm dev`.
-- [ ] TypeScript, linting, and formatting conventions are established.
-- [ ] Tailwind v4 is configured and ready for shadcn/ui.
-- [ ] The docs and repo-local skills remain intact.
-- [ ] No product workflow is implemented beyond scaffold proof.
+- [x] The project runs locally with `pnpm dev`.
+- [x] TypeScript, linting, and formatting conventions are established.
+- [x] Tailwind v4 is configured and ready for shadcn/ui.
+- [x] The docs and repo-local skills remain intact.
+- [x] No product workflow is implemented beyond scaffold proof.
 
 ---
 
@@ -47,11 +47,11 @@ Add local Supabase development setup, environment example documentation, and the
 
 ### Acceptance Criteria
 
-- [ ] Local Supabase startup is documented.
-- [ ] `.env.example` lists required local values without secrets.
-- [ ] The app can connect to the local database in development.
-- [ ] The setup does not require hosted Supabase for local development.
-- [ ] Provider boundaries remain documented as the required integration path.
+- [x] Local Supabase startup is documented.
+- [x] `.env.example` lists required local values without secrets.
+- [x] The app can connect to the local database in development.
+- [x] The setup does not require hosted Supabase for local development.
+- [x] Provider boundaries remain documented as the required integration path.
 
 ---
 
@@ -65,10 +65,10 @@ Add Drizzle configuration and a first harmless migration path that proves app-ow
 
 ### Acceptance Criteria
 
-- [ ] Drizzle can generate/apply migrations against local Supabase.
-- [ ] Migration commands are documented.
-- [ ] RLS policy handling is documented for future user-owned tables.
-- [ ] The scaffold does not add real domain tables unless needed to prove the migration path.
+- [x] Drizzle can generate/apply migrations against local Supabase.
+- [x] Migration commands are documented.
+- [x] RLS policy handling is documented for future user-owned tables.
+- [x] The scaffold does not add real domain tables unless needed to prove the migration path.
 
 ---
 
@@ -82,10 +82,10 @@ Add the tRPC/TanStack Query foundation and a minimal health-style procedure that
 
 ### Acceptance Criteria
 
-- [ ] The app has a working typed server/client API path.
-- [ ] The API foundation is documented as calling module services for real workflows.
-- [ ] No domain behavior is embedded directly in route components.
-- [ ] Verification commands cover the API foundation.
+- [x] The app has a working typed server/client API path.
+- [x] The API foundation is documented as calling module services for real workflows.
+- [x] No domain behavior is embedded directly in route components.
+- [x] Verification commands cover the API foundation.
 
 ---
 
@@ -99,9 +99,9 @@ Add the testing harness that future slices will use for domain rules, module wor
 
 ### Acceptance Criteria
 
-- [ ] Unit tests can run.
-- [ ] Integration-style tests have a documented path.
-- [ ] Browser/UI test tooling is ready or explicitly staged for the first UI slice.
-- [ ] `docs/testing.md` matches the actual command names.
-- [ ] CI-ready command set is documented, even if CI is added later.
+- [x] Unit tests can run.
+- [x] Integration-style tests have a documented path.
+- [x] Browser/UI test tooling is ready or explicitly staged for the first UI slice.
+- [x] `docs/testing.md` matches the actual command names.
+- [x] CI-ready command set is documented, even if CI is added later.
 

--- a/plans/02-auth-shell-access.md
+++ b/plans/02-auth-shell-access.md
@@ -28,11 +28,11 @@ Add Better Auth sign-in using email/password support for the scaffold stage. Cre
 
 ### Acceptance Criteria
 
-- [ ] A user can sign in and sign out locally.
-- [ ] Authenticated `/app/...` routes require a session.
-- [ ] Public/auth routes remain outside the app shell.
-- [ ] App code uses an internal session boundary rather than raw provider calls everywhere.
-- [ ] Tests or verification steps prove protected route behavior.
+- [x] A user can sign in and sign out locally.
+- [x] Authenticated `/app/...` routes require a session.
+- [x] Public/auth routes remain outside the app shell.
+- [x] App code uses an internal session boundary rather than raw provider calls everywhere.
+- [x] Tests or verification steps prove protected route behavior.
 
 ---
 
@@ -46,11 +46,11 @@ Create the account model and first-run account initialization behavior, includin
 
 ### Acceptance Criteria
 
-- [ ] New signed-in users get an account record.
-- [ ] Trial state is initialized consistently.
-- [ ] Access state can distinguish trialing, active, and paused/read-only.
-- [ ] User-owned account data is protected by RLS.
-- [ ] Account initialization is idempotent (safe to run more than once).
+- [x] New signed-in users get an account record.
+- [x] Trial state is initialized consistently.
+- [x] Access state can distinguish trialing, active, and paused/read-only.
+- [x] User-owned account data is protected by RLS.
+- [x] Account initialization is idempotent (safe to run more than once).
 
 ---
 
@@ -64,12 +64,12 @@ Add the access/capability layer that answers questions such as whether the accou
 
 ### Acceptance Criteria
 
-- [ ] Trial accounts receive Pro-like capabilities.
-- [ ] Base tier capability limit is 3 active hand receipts.
-- [ ] Pro tier capability allows unlimited hand receipts.
-- [ ] Expired trial with no active plan becomes read-only.
-- [ ] UI/server workflows can ask capabilities without knowing billing-provider details.
-- [ ] No fake checkout, fake invoice, or fake webhook system is introduced.
+- [x] Trial accounts receive Pro-like capabilities.
+- [x] Base tier capability limit is 3 active hand receipts.
+- [x] Pro tier capability allows unlimited hand receipts.
+- [x] Expired trial with no active plan becomes read-only.
+- [x] UI/server workflows can ask capabilities without knowing billing-provider details.
+- [x] No fake checkout, fake invoice, or fake webhook system is introduced.
 
 ---
 
@@ -83,12 +83,12 @@ Implement the mock-derived app shell with authenticated `/app/...` routing, phon
 
 ### Acceptance Criteria
 
-- [ ] Phone layout uses bottom navigation: Dashboard, Items, Hand Receipts, More.
-- [ ] Tablet/desktop layout uses a collapsible left sidebar.
-- [ ] Dashboard is the default authenticated home.
-- [ ] The initial route map exists with appropriate placeholder states.
-- [ ] Placeholder content does not implement fake product workflows.
-- [ ] Browser/UI verification covers mobile and desktop shell behavior.
+- [x] Phone layout uses bottom navigation: Dashboard, Items, Hand Receipts, More.
+- [x] Tablet/desktop layout uses a collapsible left sidebar.
+- [x] Dashboard is the default authenticated home.
+- [x] The initial route map exists with appropriate placeholder states.
+- [x] Placeholder content does not implement fake product workflows.
+- [x] Browser/UI verification covers mobile and desktop shell behavior.
 
 ---
 
@@ -106,7 +106,7 @@ Add lightweight first-run onboarding that communicates the product boundary and 
 
 ### Acceptance Criteria
 
-- [ ] The app states the lightweight compliance boundary: property accountability only, no classified/PHI/sensitive operational data.
-- [ ] The onboarding flow is minimal and does not become a long tour.
-- [ ] Onboarding routes build into the real shell/auth flow.
-- [ ] The flow respects paused/read-only access state.
+- [x] The app states the lightweight compliance boundary: property accountability only, no classified/PHI/sensitive operational data.
+- [x] The onboarding flow is minimal and does not become a long tour.
+- [x] Onboarding routes build into the real shell/auth flow.
+- [x] The flow respects paused/read-only access state.

--- a/plans/03-audit-hand-receipts.md
+++ b/plans/03-audit-hand-receipts.md
@@ -25,11 +25,11 @@ Create the audit event foundation and an app-owned audit logger boundary that fu
 
 ### Acceptance Criteria
 
-- [ ] Audit events are account-owned and protected by RLS.
-- [ ] The audit logger can record actor, action, target, timestamp, and useful metadata.
-- [ ] The logger is available to application services without coupling them to UI routes.
-- [ ] Tests prove audit events can be written and isolated by account.
-- [ ] Docs explain which workflows must emit audit events.
+- [x] Audit events are account-owned and protected by RLS.
+- [x] The audit logger can record actor, action, target, timestamp, and useful metadata.
+- [x] The logger is available to application services without coupling them to UI routes.
+- [x] Tests prove audit events can be written and isolated by account.
+- [x] Docs explain which workflows must emit audit events.
 
 ---
 
@@ -43,10 +43,10 @@ Add simple activity UI surfaces in the app shell, starting with dashboard/recent
 
 ### Acceptance Criteria
 
-- [ ] Recent activity is visible in a low-priority dashboard area.
-- [ ] A broader activity surface exists or is clearly staged in the app shell.
-- [ ] Activity labels are user-readable and do not expose raw implementation details.
-- [ ] Activity remains secondary to dashboard requirements and quick actions.
+- [x] Recent activity is visible in a low-priority dashboard area.
+- [x] A broader activity surface exists or is clearly staged in the app shell.
+- [x] Activity labels are user-readable and do not expose raw implementation details.
+- [x] Activity remains secondary to dashboard requirements and quick actions.
 
 ---
 
@@ -60,12 +60,12 @@ Implement hand receipt creation and listing, including optional metadata support
 
 ### Acceptance Criteria
 
-- [ ] User can create a hand receipt with required name.
-- [ ] Optional metadata can be stored without being required.
-- [ ] Base/Pro/trial hand receipt creation rules are enforced through the capability layer.
-- [ ] Read-only/paused accounts cannot create hand receipts.
-- [ ] Hand receipt creation emits an audit event.
-- [ ] The list builds into `/app/hand-receipts`.
+- [x] User can create a hand receipt with required name.
+- [x] Optional metadata can be stored without being required.
+- [x] Base/Pro/trial hand receipt creation rules are enforced through the capability layer.
+- [x] Read-only/paused accounts cannot create hand receipts.
+- [x] Hand receipt creation emits an audit event.
+- [x] The list builds into `/app/hand-receipts`.
 
 ---
 
@@ -79,11 +79,11 @@ Add hand receipt detail and edit behavior, including the mock-derived detail rou
 
 ### Acceptance Criteria
 
-- [ ] User can view a hand receipt detail page.
-- [ ] User can edit required and optional metadata.
-- [ ] Updates emit audit events.
-- [ ] Detail UI leaves room for item list, upload 2062 action, and activity without implementing those workflows prematurely.
-- [ ] Paused/read-only accounts cannot edit.
+- [x] User can view a hand receipt detail page.
+- [x] User can edit required and optional metadata.
+- [x] Updates emit audit events.
+- [x] Detail UI leaves room for item list, upload 2062 action, and activity without implementing those workflows prematurely.
+- [x] Paused/read-only accounts cannot edit.
 
 ---
 
@@ -97,10 +97,10 @@ Implement hand receipt archive and restore, including warnings and default filte
 
 ### Acceptance Criteria
 
-- [ ] Active hand receipts can be archived.
-- [ ] Archived hand receipts are hidden from normal lists/search surfaces by default.
-- [ ] Archived hand receipts can be restored.
-- [ ] Archive and restore emit audit events.
-- [ ] Read-only/paused accounts cannot archive or restore.
-- [ ] Docs capture any unresolved future behavior around active 2062s/reminders at hand receipt archive time.
+- [x] Active hand receipts can be archived.
+- [x] Archived hand receipts are hidden from normal lists/search surfaces by default.
+- [x] Archived hand receipts can be restored.
+- [x] Archive and restore emit audit events.
+- [x] Read-only/paused accounts cannot archive or restore.
+- [x] Docs capture any unresolved future behavior around active 2062s/reminders at hand receipt archive time.
 

--- a/plans/04-items-search-shared-records.md
+++ b/plans/04-items-search-shared-records.md
@@ -26,12 +26,12 @@ Implement item creation inside a selected hand receipt, including identifier val
 
 ### Acceptance Criteria
 
-- [ ] Item requires nomenclature and a hand receipt.
-- [ ] Item requires ECN, serial number, or generated ID.
-- [ ] User can generate an app ID when ECN/serial is unknown.
-- [ ] Generated ID remains stable and searchable.
-- [ ] Duplicate ECN/serial warnings are shown and can be confirmed.
-- [ ] Creation emits an audit event.
+- [x] Item requires nomenclature and a hand receipt.
+- [x] Item requires ECN, serial number, or generated ID.
+- [x] User can generate an app ID when ECN/serial is unknown.
+- [x] Generated ID remains stable and searchable.
+- [x] Duplicate ECN/serial warnings are shown and can be confirmed.
+- [x] Creation emits an audit event.
 
 ---
 
@@ -45,12 +45,12 @@ Add item detail and editing, including ECN/serial edits with audit history and p
 
 ### Acceptance Criteria
 
-- [ ] User can view item detail from hand receipt and search contexts.
-- [ ] User can edit nomenclature, ECN, serial number, generated ID presence rules, and notes if present.
-- [ ] Identifier edits keep the item valid.
-- [ ] Identifier changes emit audit events.
-- [ ] Item UI works well without photos.
-- [ ] Read-only/paused accounts cannot edit.
+- [x] User can view item detail from hand receipt and search contexts.
+- [x] User can edit nomenclature, ECN, serial number, generated ID presence rules, and notes if present.
+- [x] Identifier edits keep the item valid.
+- [x] Identifier changes emit audit events.
+- [x] Item UI works well without photos.
+- [x] Read-only/paused accounts cannot edit.
 
 ---
 
@@ -64,12 +64,12 @@ Implement item archive/restore and moving items between hand receipts, with acti
 
 ### Acceptance Criteria
 
-- [ ] User can archive an item with optional reason/notes.
-- [ ] Archived items are hidden from normal lists/search by default.
-- [ ] User can restore archived items.
-- [ ] User can move an item between hand receipts.
-- [ ] Movement behavior leaves a clear constraint hook for active 2062 coverage.
-- [ ] Archive, restore, and move emit audit events.
+- [x] User can archive an item with optional reason/notes.
+- [x] Archived items are hidden from normal lists/search by default.
+- [x] User can restore archived items.
+- [x] User can move an item between hand receipts.
+- [x] Movement behavior leaves a clear constraint hook for active 2062 coverage.
+- [x] Archive, restore, and move emit audit events.
 
 ---
 
@@ -108,12 +108,12 @@ Implement account-wide contacts and manual signed-to fallback through contact se
 
 ### Acceptance Criteria
 
-- [ ] User can create contacts with display name only.
-- [ ] Contacts are account-wide.
-- [ ] Manual signed-to always references a contact.
-- [ ] Typing a new signed-to name creates a contact.
-- [ ] Existing contacts are suggested to reduce duplicates.
-- [ ] Manual signed-to items appear in signed-out surfaces with a no-2062 indicator.
+- [x] User can create contacts with display name only.
+- [x] Contacts are account-wide.
+- [x] Manual signed-to always references a contact.
+- [x] Typing a new signed-to name creates a contact.
+- [x] Existing contacts are suggested to reduce duplicates.
+- [x] Manual signed-to items appear in signed-out surfaces with a no-2062 indicator.
 
 ---
 
@@ -127,9 +127,9 @@ Implement account-wide reusable locations and item location assignment.
 
 ### Acceptance Criteria
 
-- [ ] User can create locations with name only.
-- [ ] Locations are account-wide and optional.
-- [ ] Items can have no location or one current location.
-- [ ] Location changes emit audit events.
-- [ ] Search/filtering can use location context.
-- [ ] Read-only/paused accounts cannot change locations.
+- [x] User can create locations with name only.
+- [x] Locations are account-wide and optional.
+- [x] Items can have no location or one current location.
+- [x] Location changes emit audit events.
+- [x] Search/filtering can use location context.
+- [x] Read-only/paused accounts cannot change locations.

--- a/plans/06-documents-2062.md
+++ b/plans/06-documents-2062.md
@@ -27,12 +27,12 @@ Implement the document module, private file storage boundary, and metadata persi
 
 ### Acceptance Criteria
 
-- [ ] User can upload an accepted document type for future 2062 use.
-- [ ] Document metadata is stored account-owned.
-- [ ] Files are private.
-- [ ] Closing/archive workflows do not delete documents.
-- [ ] Upload emits an audit event.
-- [ ] Read-only/paused accounts cannot upload.
+- [x] User can upload an accepted document type for future 2062 use.
+- [x] Document metadata is stored account-owned.
+- [x] Files are private.
+- [x] Closing/archive workflows do not delete documents.
+- [x] Upload emits an audit event.
+- [x] Read-only/paused accounts cannot upload.
 
 ---
 
@@ -46,13 +46,13 @@ Implement `/app/items/[itemId]/upload-2062` as a focused one-item assignment flo
 
 ### Acceptance Criteria
 
-- [ ] Flow starts from item detail.
-- [ ] The item is preselected.
-- [ ] User selects or creates a required contact.
-- [ ] User uploads a required document.
-- [ ] If item has manual signed-to contact, contact defaults to that person.
-- [ ] Creating the 2062 clears/replaces manual signed-to state.
-- [ ] Assignment and item-link creation emit audit events.
+- [x] Flow starts from item detail.
+- [x] The item is preselected.
+- [x] User selects or creates a required contact.
+- [x] User uploads a required document.
+- [x] If item has manual signed-to contact, contact defaults to that person.
+- [x] Creating the 2062 clears/replaces manual signed-to state.
+- [x] Assignment and item-link creation emit audit events.
 
 ---
 
@@ -88,11 +88,11 @@ Add a simple Active 2062s list accessible from mobile More/dashboard context and
 
 ### Acceptance Criteria
 
-- [ ] Active 2062s list includes formal 2062 assignments only.
-- [ ] Manual signed-to records do not appear as Active 2062s.
-- [ ] Each row/card shows contact, item count, hand receipt context, date/status, and a way to open the assignment context.
-- [ ] Mobile access is discoverable without making it a primary bottom nav item.
-- [ ] Desktop access fits the sidebar/navigation model.
+- [x] Active 2062s list includes formal 2062 assignments only.
+- [x] Manual signed-to records do not appear as Active 2062s.
+- [x] Each row/card shows contact, item count, hand receipt context, date/status, and a way to open the assignment context.
+- [x] Mobile access is discoverable without making it a primary bottom nav item.
+- [x] Desktop access fits the sidebar/navigation model.
 
 ---
 
@@ -128,7 +128,7 @@ Tie active 2062 constraints into item move/archive behavior.
 
 ### Acceptance Criteria
 
-- [ ] Item with active 2062 cannot move to another hand receipt until the active 2062 item link is closed.
-- [ ] Archiving an item with active 2062 is allowed with warning and closes that item link.
-- [ ] If archiving closes the last active link on a 2062, the user is prompted to close the assignment.
-- [ ] All state changes emit audit events.
+- [x] Item with active 2062 cannot move to another hand receipt until the active 2062 item link is closed.
+- [x] Archiving an item with active 2062 is allowed with warning and closes that item link.
+- [x] If archiving closes the last active link on a 2062, the user is prompted to close the assignment.
+- [x] All state changes emit audit events.

--- a/plans/07-mvp-hardening.md
+++ b/plans/07-mvp-hardening.md
@@ -25,11 +25,11 @@ Audit and enforce paused/read-only account behavior across all MVP workflows.
 
 ### Acceptance Criteria
 
-- [ ] Paused accounts can view their existing data.
-- [ ] Paused accounts cannot create, edit, archive, restore, complete, upload, link, close, or move records.
-- [ ] Dashboard does not present reminders as active operational work for paused accounts.
-- [ ] UI messaging explains account paused/read-only state simply.
-- [ ] Tests cover representative blocked workflows.
+- [x] Paused accounts can view their existing data.
+- [x] Paused accounts cannot create, edit, archive, restore, complete, upload, link, close, or move records.
+- [x] Dashboard does not present reminders as active operational work for paused accounts.
+- [x] UI messaging explains account paused/read-only state simply.
+- [x] Tests cover representative blocked workflows.
 
 ---
 
@@ -43,11 +43,11 @@ Verify RLS coverage and account isolation for all MVP user-owned tables and work
 
 ### Acceptance Criteria
 
-- [ ] Every account-owned table has RLS enabled.
-- [ ] Policies prevent cross-account reads.
-- [ ] Policies prevent cross-account writes.
-- [ ] Service-role or privileged access, if any, is documented and isolated.
-- [ ] RLS tests cover core domain tables.
+- [x] Every account-owned table has RLS enabled.
+- [x] Policies prevent cross-account reads.
+- [x] Policies prevent cross-account writes.
+- [x] Service-role or privileged access, if any, is documented and isolated.
+- [x] RLS tests cover core domain tables.
 
 ---
 
@@ -61,12 +61,12 @@ Audit MVP workflows for missing audit events and make activity surfaces coherent
 
 ### Acceptance Criteria
 
-- [ ] Hand receipt workflows emit expected events.
-- [ ] Item workflows emit expected events.
-- [ ] Contact/location changes emit expected events where meaningful.
-- [ ] Requirement workflows emit expected events.
-- [ ] 2062/document workflows emit expected events.
-- [ ] Activity UI shows useful labels and context.
+- [x] Hand receipt workflows emit expected events.
+- [x] Item workflows emit expected events.
+- [x] Contact/location changes emit expected events where meaningful.
+- [x] Requirement workflows emit expected events.
+- [x] 2062/document workflows emit expected events.
+- [x] Activity UI shows useful labels and context.
 
 ---
 
@@ -80,12 +80,12 @@ Review and refine MVP screens against the mock-derived UI spec and responsive re
 
 ### Acceptance Criteria
 
-- [ ] Phone navigation and core workflows are thumb-friendly.
-- [ ] Tablet/desktop sidebar collapse works reliably.
-- [ ] Desktop/tablet layouts use space intelligently instead of stretching phone views.
-- [ ] Dashboard priority is preserved.
-- [ ] Text does not overflow or overlap in core screens.
-- [ ] Active 2062 access is discoverable on mobile and desktop.
+- [x] Phone navigation and core workflows are thumb-friendly.
+- [x] Tablet/desktop sidebar collapse works reliably.
+- [x] Desktop/tablet layouts use space intelligently instead of stretching phone views.
+- [x] Dashboard priority is preserved.
+- [x] Text does not overflow or overlap in core screens.
+- [x] Active 2062 access is discoverable on mobile and desktop.
 
 ---
 
@@ -99,9 +99,9 @@ Run the full verification pass and reconcile docs/ADRs with the implemented MVP.
 
 ### Acceptance Criteria
 
-- [ ] Lint, typecheck, unit tests, integration tests, and focused browser tests pass.
-- [ ] `AGENTS.md` reflects actual commands and workflow.
-- [ ] Domain, architecture, UI, testing, and roadmap docs match MVP behavior.
-- [ ] ADRs capture any major decisions made during implementation.
-- [ ] Deferred post-MVP ideas remain explicitly documented and out of MVP.
+- [x] Lint, typecheck, unit tests, integration tests, and focused browser tests pass.
+- [x] `AGENTS.md` reflects actual commands and workflow.
+- [x] Domain, architecture, UI, testing, and roadmap docs match MVP behavior.
+- [x] ADRs capture any major decisions made during implementation.
+- [x] Deferred post-MVP ideas remain explicitly documented and out of MVP.
 

--- a/src/app/(protected)/app/items/[id]/upload-2062/page.tsx
+++ b/src/app/(protected)/app/items/[id]/upload-2062/page.tsx
@@ -6,7 +6,33 @@ import { Upload2062Form } from "@/modules/assignments-2062/ui/upload-2062-form";
 import { getItem } from "@/modules/items";
 import { createTRPCContext } from "@/server/trpc/context";
 
-function ItemUnavailable() {
+type ItemUnavailableReason = "not_found" | "archived" | "active_coverage";
+
+function itemUnavailableCopy(reason: ItemUnavailableReason) {
+  if (reason === "archived") {
+    return {
+      title: "This item is archived",
+      description:
+        "Archived items cannot receive new 2062 assignments. Restore the item before creating new formal coverage.",
+    };
+  }
+
+  if (reason === "active_coverage") {
+    return {
+      title: "This item already has active 2062 coverage",
+      description: "Close the existing assignment before creating a new one.",
+    };
+  }
+
+  return {
+    title: "Item not found",
+    description: "This item is unavailable or outside the current account.",
+  };
+}
+
+function ItemUnavailable({ reason }: { reason: ItemUnavailableReason }) {
+  const copy = itemUnavailableCopy(reason);
+
   return (
     <section className="space-y-4">
       <Button asChild variant="outline">
@@ -16,11 +42,9 @@ function ItemUnavailable() {
         </Link>
       </Button>
       <div className="rounded-lg border bg-card p-4">
-        <h1 className="text-xl font-semibold tracking-normal">
-          Item not found
-        </h1>
+        <h1 className="text-xl font-semibold tracking-normal">{copy.title}</h1>
         <p className="mt-2 text-sm leading-6 text-muted-foreground">
-          This item is unavailable or outside the current account.
+          {copy.description}
         </p>
       </div>
     </section>
@@ -46,13 +70,17 @@ export default async function Upload2062Page({
   });
 
   if (!item) {
-    return <ItemUnavailable />;
+    return <ItemUnavailable reason="not_found" />;
   }
 
   const isReadOnly = ctx.account.accessState === "paused_read_only";
 
-  if (item.status !== "active" || item.active2062Coverage) {
-    return <ItemUnavailable />;
+  if (item.status !== "active") {
+    return <ItemUnavailable reason="archived" />;
+  }
+
+  if (item.active2062Coverage) {
+    return <ItemUnavailable reason="active_coverage" />;
   }
 
   return (

--- a/src/components/shell/bottom-nav.tsx
+++ b/src/components/shell/bottom-nav.tsx
@@ -64,6 +64,27 @@ function MoreSheetLink({ item }: { item: ShellNavItem }) {
   );
 }
 
+function MoreSheetSection({
+  items,
+  title,
+}: {
+  items: ShellNavItem[];
+  title: string;
+}) {
+  return (
+    <section className="space-y-2">
+      <h3 className="px-1 font-mono text-[0.68rem] font-semibold uppercase text-muted-foreground">
+        {title}
+      </h3>
+      <div className="grid gap-2">
+        {items.map((item) => (
+          <MoreSheetLink item={item} key={item.href} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function BottomNav() {
   const pathname = usePathname();
   const moreItems = [...secondaryNavItems, ...footerNavItems];
@@ -101,11 +122,14 @@ export function BottomNav() {
                 Additional Field Ledger surfaces.
               </SheetDescription>
             </SheetHeader>
-            <div className="grid gap-2">
-              {moreItems.map((item) => (
-                <MoreSheetLink item={item} key={item.href} />
-              ))}
-              <form action="/auth/signout" method="post">
+            <div className="grid max-h-[70vh] gap-4 overflow-y-auto pr-1">
+              <MoreSheetSection items={secondaryNavItems} title="Records" />
+              <MoreSheetSection items={footerNavItems} title="Account" />
+              <form
+                action="/auth/signout"
+                className="border-t pt-2"
+                method="post"
+              >
                 <Button
                   className="w-full justify-start"
                   type="submit"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -50,9 +50,11 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
+  scrollable = false,
   showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  scrollable?: boolean;
   showCloseButton?: boolean;
 }) {
   return (
@@ -62,6 +64,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg border bg-popover p-5 text-popover-foreground shadow-lg duration-200 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95",
+          scrollable && "max-h-[min(85dvh,calc(100vh-2rem))] overflow-y-auto",
           className,
         )}
         {...props}

--- a/src/modules/accounts/application/ensure-account.ts
+++ b/src/modules/accounts/application/ensure-account.ts
@@ -16,13 +16,18 @@ export type AccountRecord = {
   updatedAt?: Date;
 };
 
+export type MarkOnboardingCompletedResult = {
+  account: AccountRecord;
+  completedNow: boolean;
+};
+
 export type AccountRepository = {
   findByUserId(userId: string): Promise<AccountRecord | null>;
   create(account: AccountRecord): Promise<AccountRecord | null>;
   markOnboardingCompleted(
     accountId: string,
     completedAt: Date,
-  ): Promise<AccountRecord | null>;
+  ): Promise<MarkOnboardingCompletedResult | null>;
   incrementAndGetNextItemSequence(accountId: string): Promise<number>;
 };
 
@@ -114,29 +119,31 @@ export async function completeOnboarding({
     return getOnboardingStatus({ account, now });
   }
 
-  const updatedAccount = await repository.markOnboardingCompleted(
+  const completion = await repository.markOnboardingCompleted(
     account.id,
     completedAt,
   );
 
-  if (!updatedAccount) {
+  if (!completion) {
     throw new Error("Unable to complete owner account onboarding.");
   }
 
-  await recordAuditEvent({
-    accountId: account.id,
-    actorId: account.userId,
-    action: "account.onboarding_completed",
-    target: {
-      type: "account",
-      id: account.id,
-    },
-    metadata: {
-      acknowledgedBoundaryNotice: true,
-    },
-    occurredAt: completedAt,
-    repository: auditRepository,
-  });
+  if (completion.completedNow) {
+    await recordAuditEvent({
+      accountId: account.id,
+      actorId: account.userId,
+      action: "account.onboarding_completed",
+      target: {
+        type: "account",
+        id: account.id,
+      },
+      metadata: {
+        acknowledgedBoundaryNotice: true,
+      },
+      occurredAt: completedAt,
+      repository: auditRepository,
+    });
+  }
 
-  return getOnboardingStatus({ account: updatedAccount, now });
+  return getOnboardingStatus({ account: completion.account, now });
 }

--- a/src/modules/accounts/application/ensure-account.ts
+++ b/src/modules/accounts/application/ensure-account.ts
@@ -1,4 +1,5 @@
 import { deriveAccountCapabilities } from "@/modules/billing";
+import { recordAuditEvent, type AuditRepository } from "@/modules/audit";
 
 export type AccessState = "trialing" | "active" | "paused_read_only";
 export type SubscriptionTier = "base" | "pro";
@@ -82,6 +83,7 @@ type GetOnboardingStatusInput = {
 type CompleteOnboardingInput = {
   account: AccountRecord;
   repository: AccountRepository;
+  auditRepository: AuditRepository;
   completedAt?: Date;
   now?: Date;
 };
@@ -104,6 +106,7 @@ export function getOnboardingStatus({
 export async function completeOnboarding({
   account,
   repository,
+  auditRepository,
   completedAt = new Date(),
   now,
 }: CompleteOnboardingInput) {
@@ -119,6 +122,21 @@ export async function completeOnboarding({
   if (!updatedAccount) {
     throw new Error("Unable to complete owner account onboarding.");
   }
+
+  await recordAuditEvent({
+    accountId: account.id,
+    actorId: account.userId,
+    action: "account.onboarding_completed",
+    target: {
+      type: "account",
+      id: account.id,
+    },
+    metadata: {
+      acknowledgedBoundaryNotice: true,
+    },
+    occurredAt: completedAt,
+    repository: auditRepository,
+  });
 
   return getOnboardingStatus({ account: updatedAccount, now });
 }

--- a/src/modules/accounts/infrastructure/drizzle-account-repository.ts
+++ b/src/modules/accounts/infrastructure/drizzle-account-repository.ts
@@ -44,7 +44,10 @@ function createAccountRepository(db: AccountExecutor): AccountRepository {
         .returning();
 
       if (updatedAccount) {
-        return updatedAccount;
+        return {
+          account: updatedAccount,
+          completedNow: true,
+        };
       }
 
       const [existingAccount] = await db
@@ -53,7 +56,14 @@ function createAccountRepository(db: AccountExecutor): AccountRepository {
         .where(eq(accounts.id, accountId))
         .limit(1);
 
-      return existingAccount ?? null;
+      if (!existingAccount) {
+        return null;
+      }
+
+      return {
+        account: existingAccount,
+        completedNow: false,
+      };
     },
     async incrementAndGetNextItemSequence(accountId) {
       const [updatedAccount] = await db

--- a/src/modules/assignments-2062/ui/assignment-list-item.tsx
+++ b/src/modules/assignments-2062/ui/assignment-list-item.tsx
@@ -29,8 +29,8 @@ export function AssignmentList({
               <ReceiptText aria-hidden="true" className="size-4" />
             </span>
             <div className="min-w-0 space-y-2">
-              <div className="flex flex-wrap items-center gap-2">
-                <h2 className="text-sm font-semibold tracking-normal">
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <h2 className="min-w-0 max-w-full truncate text-sm font-semibold tracking-normal">
                   {assignment.contactName}
                 </h2>
                 <span className="rounded-sm border bg-secondary px-2 py-1 font-mono text-[0.68rem] uppercase text-muted-foreground">

--- a/src/modules/assignments-2062/ui/upload-2062-flow.tsx
+++ b/src/modules/assignments-2062/ui/upload-2062-flow.tsx
@@ -63,14 +63,14 @@ function StepRail({ currentStep }: { currentStep: Step }) {
   const currentIndex = steps.findIndex((step) => step.id === currentStep);
 
   return (
-    <ol className="grid gap-2 sm:grid-cols-4">
+    <ol className="grid auto-cols-[minmax(7rem,1fr)] grid-flow-col gap-2 overflow-x-auto pb-1 sm:grid-flow-row sm:grid-cols-4 sm:overflow-visible sm:pb-0">
       {steps.map((step, index) => {
         const isCurrent = step.id === currentStep;
         const isComplete = index < currentIndex;
 
         return (
           <li
-            className="flex items-center gap-2 rounded-md border bg-card px-3 py-2 text-xs"
+            className="flex min-w-0 items-center gap-2 rounded-md border bg-card px-3 py-2 text-xs"
             key={step.id}
           >
             <span
@@ -89,8 +89,8 @@ function StepRail({ currentStep }: { currentStep: Step }) {
             <span
               className={
                 isCurrent
-                  ? "font-semibold text-foreground"
-                  : "text-muted-foreground"
+                  ? "truncate font-semibold text-foreground"
+                  : "truncate text-muted-foreground"
               }
             >
               {step.label}
@@ -430,8 +430,9 @@ export function Upload2062Flow({ handReceiptId }: { handReceiptId: string }) {
               setNewContactDisplayName("");
             }}
           />
-          <div className="flex justify-end">
+          <div className="flex">
             <Button
+              className="w-full sm:w-auto"
               disabled={
                 isDisabled ||
                 (!selectedContactId && !newContactDisplayName.trim())
@@ -484,8 +485,9 @@ export function Upload2062Flow({ handReceiptId }: { handReceiptId: string }) {
                 Upload a document, then select it here.
               </p>
             ) : null}
-            <div className="flex justify-between gap-2">
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
               <Button
+                className="w-full sm:w-auto"
                 onClick={() => goNext("contact")}
                 type="button"
                 variant="outline"
@@ -493,6 +495,7 @@ export function Upload2062Flow({ handReceiptId }: { handReceiptId: string }) {
                 Back
               </Button>
               <Button
+                className="w-full sm:w-auto"
                 disabled={isDisabled || !selectedDocumentId}
                 onClick={() => goNext("items")}
                 type="button"
@@ -519,8 +522,9 @@ export function Upload2062Flow({ handReceiptId }: { handReceiptId: string }) {
             selectedItemIds={validSelectedItemIds}
             setSelectedItemIds={setSelectedItemIds}
           />
-          <div className="flex justify-between gap-2">
+          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
             <Button
+              className="w-full sm:w-auto"
               onClick={() => goNext("document")}
               type="button"
               variant="outline"
@@ -528,6 +532,7 @@ export function Upload2062Flow({ handReceiptId }: { handReceiptId: string }) {
               Back
             </Button>
             <Button
+              className="w-full sm:w-auto"
               disabled={isDisabled || validSelectedItemIds.length === 0}
               onClick={() => goNext("summary")}
               type="button"
@@ -602,6 +607,7 @@ export function Upload2062Flow({ handReceiptId }: { handReceiptId: string }) {
           </div>
           <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
             <Button
+              className="w-full sm:w-auto"
               onClick={() => goNext("items")}
               type="button"
               variant="outline"
@@ -609,6 +615,7 @@ export function Upload2062Flow({ handReceiptId }: { handReceiptId: string }) {
               Back
             </Button>
             <Button
+              className="w-full sm:w-auto"
               disabled={isDisabled || createAssignment.isPending}
               onClick={submit}
               type="button"

--- a/src/modules/assignments-2062/ui/upload-2062-form.tsx
+++ b/src/modules/assignments-2062/ui/upload-2062-form.tsx
@@ -11,6 +11,41 @@ import { DocumentUpload } from "@/modules/documents/ui/document-upload";
 import type { ItemRecord } from "@/modules/items";
 import { trpc } from "@/trpc/react";
 
+function Upload2062Actions({
+  canSubmit,
+  hasActiveCoverage,
+  isPending,
+  itemId,
+  onSubmit,
+}: {
+  canSubmit: boolean;
+  hasActiveCoverage: boolean;
+  isPending: boolean;
+  itemId: string;
+  onSubmit: () => void;
+}) {
+  return (
+    <section className="space-y-3 rounded-lg border bg-card p-4">
+      <Button
+        className="w-full"
+        disabled={!canSubmit || hasActiveCoverage}
+        onClick={onSubmit}
+        type="button"
+      >
+        {isPending ? (
+          <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+        ) : (
+          <CheckCircle2 aria-hidden="true" className="size-4" />
+        )}
+        {isPending ? "Creating 2062" : "Create 2062"}
+      </Button>
+      <Button asChild className="w-full" type="button" variant="outline">
+        <Link href={`/app/items/${itemId}`}>Cancel</Link>
+      </Button>
+    </section>
+  );
+}
+
 export function Upload2062Form({
   isReadOnly,
   item,
@@ -203,6 +238,24 @@ export function Upload2062Form({
               </p>
             ) : null}
           </section>
+
+          <div className="space-y-3 lg:hidden">
+            {formError ? (
+              <p
+                className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+                role="alert"
+              >
+                {formError}
+              </p>
+            ) : null}
+            <Upload2062Actions
+              canSubmit={Boolean(canSubmit)}
+              hasActiveCoverage={Boolean(item.active2062Coverage)}
+              isPending={createAssignment.isPending}
+              itemId={item.id}
+              onSubmit={submit}
+            />
+          </div>
         </div>
 
         <div className="space-y-4">
@@ -215,7 +268,7 @@ export function Upload2062Form({
               })
             }
           />
-          <section className="space-y-3 rounded-lg border bg-card p-4">
+          <div className="hidden space-y-3 lg:block">
             {formError ? (
               <p
                 className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
@@ -224,23 +277,14 @@ export function Upload2062Form({
                 {formError}
               </p>
             ) : null}
-            <Button
-              className="w-full"
-              disabled={!canSubmit || Boolean(item.active2062Coverage)}
-              onClick={submit}
-              type="button"
-            >
-              {createAssignment.isPending ? (
-                <Loader2 aria-hidden="true" className="size-4 animate-spin" />
-              ) : (
-                <CheckCircle2 aria-hidden="true" className="size-4" />
-              )}
-              {createAssignment.isPending ? "Creating 2062" : "Create 2062"}
-            </Button>
-            <Button asChild className="w-full" type="button" variant="outline">
-              <Link href={`/app/items/${item.id}`}>Cancel</Link>
-            </Button>
-          </section>
+            <Upload2062Actions
+              canSubmit={Boolean(canSubmit)}
+              hasActiveCoverage={Boolean(item.active2062Coverage)}
+              isPending={createAssignment.isPending}
+              itemId={item.id}
+              onSubmit={submit}
+            />
+          </div>
         </div>
       </div>
     </section>

--- a/src/modules/audit/application/list-activity.ts
+++ b/src/modules/audit/application/list-activity.ts
@@ -51,6 +51,18 @@ function formatTargetLabel(event: AuditEventRecord) {
     return metadataName(event.metadata) ?? "Requirement";
   }
 
+  if (event.targetType === "contact") {
+    return metadataString(event.metadata, "displayName") ?? "Contact";
+  }
+
+  if (event.targetType === "document") {
+    return metadataString(event.metadata, "filename") ?? "Document";
+  }
+
+  if (event.targetType === "location") {
+    return metadataName(event.metadata) ?? "Location";
+  }
+
   if (event.targetType === "assignment") {
     const contactName = metadataString(event.metadata, "contactName");
     const documentFilename = metadataString(event.metadata, "documentFilename");

--- a/src/modules/audit/ui/activity-list.tsx
+++ b/src/modules/audit/ui/activity-list.tsx
@@ -53,7 +53,10 @@ export function ActivityList({
   }
 
   return (
-    <ol className="overflow-hidden rounded-lg border bg-card text-card-foreground">
+    <ol
+      aria-label="Activity events"
+      className="overflow-hidden rounded-lg border bg-card text-card-foreground"
+    >
       {activity.map((event) => (
         <li
           className={

--- a/src/modules/hand-receipts/application/update-hand-receipt.ts
+++ b/src/modules/hand-receipts/application/update-hand-receipt.ts
@@ -113,6 +113,7 @@ export async function updateHandReceipt({
       id: handReceiptId,
     },
     metadata: {
+      name: updated.name,
       changedFields: changedFieldNames,
     },
     occurredAt: now,

--- a/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
+++ b/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
@@ -165,6 +165,7 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
   const [itemLifecycleError, setItemLifecycleError] = useState<string | null>(
     null,
   );
+  const [createItemError, setCreateItemError] = useState<string | null>(null);
   const utilities = trpc.useUtils();
   const handReceiptQuery = trpc.handReceipts.getById.useQuery({
     id: handReceiptId,
@@ -255,6 +256,8 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
   });
   const createItemMutation = trpc.items.create.useMutation({
     onSuccess: async (result) => {
+      setCreateItemError(null);
+
       if (result.item) {
         await Promise.all([
           utilities.items.listByHandReceipt.invalidate({
@@ -269,6 +272,9 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
           }),
         ]);
       }
+    },
+    onError: (error) => {
+      setCreateItemError(error.message || "Item could not be created.");
     },
   });
   const restoreItemMutation = trpc.items.restore.useMutation({
@@ -353,8 +359,8 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
 
       {isReadOnly ? (
         <p className="rounded-lg border bg-secondary px-4 py-3 text-sm text-muted-foreground">
-          This account is read-only. Detail records remain available, but edits
-          and lifecycle changes are paused until access is restored.
+          Detail records remain available, but edits and lifecycle changes are
+          paused until access is restored.
         </p>
       ) : null}
 
@@ -431,17 +437,27 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
                     <CreateItemForm
                       canCreate={!isReadOnly && handReceipt.status === "active"}
                       disabledReason={createItemDisabledReason}
-                      onSubmit={(input) =>
-                        createItemMutation.mutateAsync({
+                      onSubmit={(input) => {
+                        setCreateItemError(null);
+
+                        return createItemMutation.mutateAsync({
                           handReceiptId,
                           ...input,
-                        })
-                      }
+                        });
+                      }}
                     />
                   </>
                 ) : null}
               </div>
             </div>
+            {createItemError ? (
+              <p
+                className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
+                role="alert"
+              >
+                {createItemError}
+              </p>
+            ) : null}
             <div className="flex w-fit rounded-lg border bg-background p-1">
               <button
                 aria-pressed={itemView === "active"}

--- a/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
+++ b/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
@@ -354,7 +354,7 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
       {isReadOnly ? (
         <p className="rounded-lg border bg-secondary px-4 py-3 text-sm text-muted-foreground">
           This account is read-only. Detail records remain available, but edits
-          are paused until access is restored.
+          and lifecycle changes are paused until access is restored.
         </p>
       ) : null}
 

--- a/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
+++ b/src/modules/hand-receipts/ui/hand-receipt-detail.tsx
@@ -165,7 +165,6 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
   const [itemLifecycleError, setItemLifecycleError] = useState<string | null>(
     null,
   );
-  const [createItemError, setCreateItemError] = useState<string | null>(null);
   const utilities = trpc.useUtils();
   const handReceiptQuery = trpc.handReceipts.getById.useQuery({
     id: handReceiptId,
@@ -256,8 +255,6 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
   });
   const createItemMutation = trpc.items.create.useMutation({
     onSuccess: async (result) => {
-      setCreateItemError(null);
-
       if (result.item) {
         await Promise.all([
           utilities.items.listByHandReceipt.invalidate({
@@ -272,9 +269,6 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
           }),
         ]);
       }
-    },
-    onError: (error) => {
-      setCreateItemError(error.message || "Item could not be created.");
     },
   });
   const restoreItemMutation = trpc.items.restore.useMutation({
@@ -438,8 +432,6 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
                       canCreate={!isReadOnly && handReceipt.status === "active"}
                       disabledReason={createItemDisabledReason}
                       onSubmit={(input) => {
-                        setCreateItemError(null);
-
                         return createItemMutation.mutateAsync({
                           handReceiptId,
                           ...input,
@@ -450,14 +442,6 @@ export function HandReceiptDetail({ handReceiptId }: HandReceiptDetailProps) {
                 ) : null}
               </div>
             </div>
-            {createItemError ? (
-              <p
-                className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
-                role="alert"
-              >
-                {createItemError}
-              </p>
-            ) : null}
             <div className="flex w-fit rounded-lg border bg-background p-1">
               <button
                 aria-pressed={itemView === "active"}

--- a/src/modules/items/ui/create-item-form.tsx
+++ b/src/modules/items/ui/create-item-form.tsx
@@ -174,7 +174,7 @@ export function CreateItemForm({
           Add item
         </Button>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent scrollable>
         <form className="space-y-4" onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>Add property item</DialogTitle>

--- a/src/modules/items/ui/item-detail.tsx
+++ b/src/modules/items/ui/item-detail.tsx
@@ -190,7 +190,7 @@ function MoveItemDialog({
 }) {
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent scrollable>
         <DialogHeader>
           <DialogTitle>Move item</DialogTitle>
           <DialogDescription>

--- a/src/modules/items/ui/item-detail.tsx
+++ b/src/modules/items/ui/item-detail.tsx
@@ -39,6 +39,9 @@ type ItemDetailProps = {
   itemId: string;
 };
 
+const coverageCheckFallback =
+  "Unable to verify 2062 coverage status. Try again or check your connection.";
+
 function formatDate(value: Date | string | null) {
   if (!value) {
     return "Not set";
@@ -211,7 +214,9 @@ function MoveItemDialog({
               />
               <div className="space-y-1">
                 <p className="font-medium">Coverage check failed</p>
-                <p className="leading-6">{moveCoverageError}</p>
+                <p className="leading-6">
+                  {moveCoverageError || coverageCheckFallback}
+                </p>
               </div>
             </div>
           </div>
@@ -551,7 +556,9 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
                 />
                 <div className="space-y-1">
                   <p className="font-medium">Coverage check failed</p>
-                  <p className="leading-6">{archiveCoverageError}</p>
+                  <p className="leading-6">
+                    {archiveCoverageError || coverageCheckFallback}
+                  </p>
                 </div>
               </div>
             </div>

--- a/src/modules/items/ui/item-detail.tsx
+++ b/src/modules/items/ui/item-detail.tsx
@@ -322,8 +322,7 @@ export function ItemDetail({ handReceiptId, itemId }: ItemDetailProps) {
     ) ?? [];
   const isReadOnly = capabilitiesQuery.data?.isReadOnly ?? false;
   const archiveCoverage = archiveCoverageQuery.data;
-  const archiveHasActive2062 =
-    archiveCoverage?.hasActiveCoverage === true;
+  const archiveHasActive2062 = archiveCoverage?.hasActiveCoverage === true;
   const archiveCoverageError = archiveCoverageQuery.error?.message ?? null;
   const archiveMutation = trpc.items.archive.useMutation({
     onSuccess: async (archived) => {

--- a/src/modules/requirements/ui/create-requirement-form.tsx
+++ b/src/modules/requirements/ui/create-requirement-form.tsx
@@ -161,7 +161,7 @@ export function CreateRequirementForm({
           Add requirement
         </Button>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent scrollable>
         <DialogHeader>
           <DialogTitle>Add requirement</DialogTitle>
           <DialogDescription>

--- a/src/modules/requirements/ui/requirements-list.tsx
+++ b/src/modules/requirements/ui/requirements-list.tsx
@@ -129,6 +129,24 @@ function dueTone(nextDueDate: string) {
   };
 }
 
+function emptyRequirementsDescription({
+  isReadOnly,
+  isItemActive,
+}: {
+  isReadOnly: boolean;
+  isItemActive: boolean;
+}) {
+  if (isReadOnly) {
+    return "Requirement work is paused while this account is read-only.";
+  }
+
+  if (!isItemActive) {
+    return "This item is archived. Requirements were cleared when the item was archived.";
+  }
+
+  return "Add the first recurring obligation for this item when there is a maintenance, inspection, calibration, or replacement cadence to track.";
+}
+
 export function RequirementsList({
   itemId,
   isReadOnly,
@@ -147,9 +165,26 @@ export function RequirementsList({
 
   if (requirementsQuery.error) {
     return (
-      <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm font-medium text-destructive">
-        {requirementsQuery.error.message}
-      </p>
+      <div
+        className="space-y-3 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive"
+        role="alert"
+      >
+        <div className="space-y-1">
+          <p className="font-medium">Requirements could not be loaded</p>
+          <p className="leading-6">
+            {requirementsQuery.error.message ||
+              "Refresh this requirement list before making changes."}
+          </p>
+        </div>
+        <Button
+          onClick={() => void requirementsQuery.refetch()}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          Retry
+        </Button>
+      </div>
     );
   }
 
@@ -164,13 +199,11 @@ export function RequirementsList({
             className="mt-0.5 size-4 text-muted-foreground"
           />
           <div className="space-y-1">
-            <p className="text-sm font-semibold tracking-normal">
+            <h3 className="text-sm font-semibold tracking-normal">
               No active requirements
-            </p>
+            </h3>
             <p className="text-sm leading-6 text-muted-foreground">
-              {isReadOnly || !isItemActive
-                ? "No active requirement work is tied to this item."
-                : "Add the first recurring obligation for this item when there is a maintenance, inspection, calibration, or replacement cadence to track."}
+              {emptyRequirementsDescription({ isReadOnly, isItemActive })}
             </p>
           </div>
         </div>
@@ -445,7 +478,7 @@ function RequirementPauseResumeButton({
         {isPaused ? "Resume" : "Pause"}
       </Button>
       {error ? (
-        <p className="max-w-56 text-xs font-medium text-destructive">{error}</p>
+        <p className="text-sm font-medium text-destructive">{error}</p>
       ) : null}
     </div>
   );
@@ -893,9 +926,16 @@ function RequirementCompletionHistory({
 
   if (historyQuery.error) {
     return (
-      <p className="mt-1 text-xs font-medium text-destructive">
-        {historyQuery.error.message}
-      </p>
+      <div
+        className="mt-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        role="alert"
+      >
+        <p className="font-medium">Completion history could not be loaded</p>
+        <p className="mt-1 leading-6">
+          {historyQuery.error.message ||
+            "Refresh this completion history before making changes."}
+        </p>
+      </div>
     );
   }
 

--- a/src/modules/requirements/ui/requirements-list.tsx
+++ b/src/modules/requirements/ui/requirements-list.tsx
@@ -323,7 +323,7 @@ function AdjustRequirementNextDueDialog({
         <CalendarClock aria-hidden="true" className="size-4" />
       </Button>
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent>
+        <DialogContent scrollable>
           <DialogHeader>
             <DialogTitle>Adjust next due</DialogTitle>
             <DialogDescription>
@@ -558,7 +558,7 @@ function EditRequirementDialog({
           }
         }}
       >
-        <DialogContent>
+        <DialogContent scrollable>
           <DialogHeader>
             <DialogTitle>Edit requirement</DialogTitle>
             <DialogDescription>
@@ -805,7 +805,7 @@ function CompleteRequirementDialog({
         Complete
       </Button>
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent>
+        <DialogContent scrollable>
           <DialogHeader>
             <DialogTitle>Complete requirement</DialogTitle>
             <DialogDescription>

--- a/src/server/trpc/routers/accounts.ts
+++ b/src/server/trpc/routers/accounts.ts
@@ -12,6 +12,7 @@ export const accountsRouter = createTRPCRouter({
     completeOnboarding({
       account: ctx.account,
       repository: ctx.accountRepository,
+      auditRepository: ctx.auditRepository,
     }),
   ),
 });

--- a/src/server/trpc/routers/accounts.ts
+++ b/src/server/trpc/routers/accounts.ts
@@ -9,10 +9,12 @@ export const accountsRouter = createTRPCRouter({
     getOnboardingStatus({ account: ctx.account }),
   ),
   completeOnboarding: protectedProcedure.mutation(({ ctx }) =>
-    completeOnboarding({
-      account: ctx.account,
-      repository: ctx.accountRepository,
-      auditRepository: ctx.auditRepository,
-    }),
+    ctx.unitOfWork.run((repositories) =>
+      completeOnboarding({
+        account: ctx.account,
+        repository: repositories.accountRepository,
+        auditRepository: repositories.auditRepository,
+      }),
+    ),
   ),
 });

--- a/testing.md
+++ b/testing.md
@@ -1,1 +1,9 @@
-SANDCASTLE WORKS
+# Testing
+
+The maintained testing strategy lives in [docs/testing.md](docs/testing.md).
+
+Use the repo verification command for release-readiness checks:
+
+```sh
+pnpm verify
+```

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -93,7 +93,7 @@ test("desktop shell uses a collapsible sidebar for app navigation", async ({
     .toBeLessThanOrEqual(48);
 });
 
-test("signed-in users can open the Activity route empty state", async ({
+test("signed-in users can open the Activity route with onboarding activity", async ({
   page,
 }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
@@ -105,10 +105,6 @@ test("signed-in users can open the Activity route empty state", async ({
   await expect(
     page.getByRole("heading", { name: "Activity", exact: true }),
   ).toBeVisible();
-  await expect(
-    page.getByRole("heading", { name: "No activity yet" }),
-  ).toBeVisible();
-  await expect(
-    page.getByText("Events will appear here as you use Field Ledger."),
-  ).toBeVisible();
+  await expect(page.getByText("Onboarding completed")).toBeVisible();
+  await expect(page.getByText("Account", { exact: true })).toBeVisible();
 });

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -50,6 +50,8 @@ test("mobile shell uses bottom navigation and exposes More surfaces", async ({
 
   await page.getByRole("button", { name: "More" }).click();
   await expect(page.getByRole("dialog", { name: "More" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Records" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Account" })).toBeVisible();
   await page.getByRole("link", { name: "Active 2062s" }).click();
   await expect(page).toHaveURL(/\/app\/active-2062s$/);
   await expect(

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -108,5 +108,9 @@ test("signed-in users can open the Activity route with onboarding activity", asy
     page.getByRole("heading", { name: "Activity", exact: true }),
   ).toBeVisible();
   await expect(page.getByText("Onboarding completed")).toBeVisible();
-  await expect(page.getByText("Account", { exact: true })).toBeVisible();
+  await expect(
+    page.getByRole("list", { name: "Activity events" }).getByText("Account", {
+      exact: true,
+    }),
+  ).toBeVisible();
 });

--- a/tests/e2e/blocked-states.spec.ts
+++ b/tests/e2e/blocked-states.spec.ts
@@ -1,0 +1,147 @@
+import { expect, type Page, test } from "@playwright/test";
+import { eq } from "drizzle-orm";
+
+import { accounts, authUser } from "@/db/schema";
+import { getDrizzleClient } from "@/modules/provider-boundaries/database/drizzle";
+
+async function signInLocalUser(page: Page) {
+  const suffix = `${Date.now()}-${test.info().workerIndex}-${Math.random().toString(36).slice(2)}`;
+  const email = `blocked-${suffix}@example.test`;
+
+  await page.goto("/auth/login?next=/app/hand-receipts");
+  await page.getByRole("tab", { name: "Register" }).click();
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill("password123");
+  await expect(
+    page.getByRole("button", { name: "Create account" }),
+  ).toBeEnabled();
+  await page.getByRole("button", { name: "Create account" }).click();
+  await expect(page).toHaveURL(/\/app\/hand-receipts$/);
+  const notice = page.getByRole("dialog", {
+    name: "Property accountability only",
+  });
+  await notice.getByRole("button", { name: "I understand" }).click();
+  await expect(notice).toBeHidden();
+
+  return { email };
+}
+
+async function markAccountReadOnly(email: string) {
+  const db = getDrizzleClient();
+  const [user] = await db
+    .select({ id: authUser.id })
+    .from(authUser)
+    .where(eq(authUser.email, email));
+
+  if (!user) {
+    throw new Error(`Test user ${email} was not created.`);
+  }
+
+  await db
+    .update(accounts)
+    .set({
+      accessState: "paused_read_only",
+      updatedAt: new Date(),
+    })
+    .where(eq(accounts.userId, user.id));
+}
+
+test("read-only hand receipt detail explains blocked writes", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  const { email } = await signInLocalUser(page);
+
+  await page.getByRole("button", { name: "New hand receipt" }).click();
+  await page.getByLabel("Name").fill("Read-only receipt");
+  await page.getByRole("button", { name: "Create" }).click();
+  await page.getByRole("link", { name: "Open Read-only receipt" }).click();
+  await expect(page).toHaveURL(/\/app\/hand-receipts\/[0-9a-f-]+$/);
+  await expect(
+    page.getByRole("heading", { name: "Read-only receipt" }),
+  ).toBeVisible();
+
+  await markAccountReadOnly(email);
+  await page.reload();
+
+  await expect(
+    page.getByText(
+      "Detail records remain available, but edits and lifecycle changes are paused until access is restored.",
+    ),
+  ).toBeVisible();
+  const addItemButton = page.getByRole("button", { name: "Add item" });
+  await expect(addItemButton).toBeDisabled();
+  await expect(addItemButton).toHaveAttribute(
+    "title",
+    "This account is read-only. Existing records remain available.",
+  );
+});
+
+test("item create validation errors render inline and clear after resubmission", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signInLocalUser(page);
+
+  await page.getByRole("button", { name: "New hand receipt" }).click();
+  await page.getByLabel("Name").fill("Validation receipt");
+  await page.getByRole("button", { name: "Create" }).click();
+  await page.getByRole("link", { name: "Open Validation receipt" }).click();
+  await page.getByRole("button", { name: "Add item" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Add property item" });
+  await dialog.getByLabel("Nomenclature").fill("Validation radio");
+  await dialog.getByRole("button", { name: "Create item" }).click();
+  await expect(
+    dialog.getByText(
+      "Add an ECN, serial number, or generated Field Ledger ID.",
+    ),
+  ).toBeVisible();
+
+  await dialog.getByLabel("ECN").fill("ECN-VALIDATION");
+  await dialog.getByRole("button", { name: "Create item" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(
+    page.getByRole("link", { name: "Open Validation radio" }),
+  ).toBeVisible();
+});
+
+test("empty states describe active 2062 and requirement state", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await signInLocalUser(page);
+
+  await page.goto("/app/active-2062s");
+  await expect(
+    page.getByRole("heading", { name: "No active 2062s" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Formal 2062 assignments will appear here after you upload a private document and link it to property.",
+    ),
+  ).toBeVisible();
+
+  await page.goto("/app/hand-receipts");
+  await page.getByRole("button", { name: "New hand receipt" }).click();
+  await page.getByLabel("Name").fill("Empty state receipt");
+  await page.getByRole("button", { name: "Create" }).click();
+  await page.getByRole("link", { name: "Open Empty state receipt" }).click();
+  await page.getByRole("button", { name: "Add item" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Add property item" });
+  await dialog.getByLabel("Nomenclature").fill("Empty state radio");
+  await dialog.getByLabel("ECN").fill("ECN-EMPTY");
+  await dialog.getByRole("button", { name: "Create item" }).click();
+  await page.getByRole("link", { name: "Open Empty state radio" }).click();
+
+  await expect(
+    page.getByRole("heading", { name: "No active requirements" }),
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      "Add the first recurring obligation for this item when there is a maintenance, inspection, calibration, or replacement cadence to track.",
+    ),
+  ).toBeVisible();
+});

--- a/tests/e2e/hand-receipts.spec.ts
+++ b/tests/e2e/hand-receipts.spec.ts
@@ -259,7 +259,7 @@ test("users can create multi-item formal 2062 coverage from hand receipt detail"
   });
   await removeDialog.getByLabel("Remove date").fill(dateOnlyFromOffset(1));
   await expect(
-    removeDialog.getByText("Close date cannot be in the future."),
+    removeDialog.getByText("Remove date cannot be in the future."),
   ).toBeVisible();
   await removeDialog.getByLabel("Remove date").fill(dateOnlyFromOffset(-1));
   await removeDialog.getByRole("button", { name: "Remove item" }).click();

--- a/tests/e2e/hand-receipts.spec.ts
+++ b/tests/e2e/hand-receipts.spec.ts
@@ -1,4 +1,6 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
+
+import { expectDialogContained } from "./helpers/dialog";
 
 async function signInLocalUser(page: Page) {
   const suffix = `${Date.now()}-${test.info().workerIndex}-${Math.random().toString(36).slice(2)}`;
@@ -33,24 +35,6 @@ function dateOnlyFromOffset(daysFromToday: number) {
   const day = String(date.getDate()).padStart(2, "0");
 
   return `${year}-${month}-${day}`;
-}
-
-async function expectDialogContained(page: Page, dialog: Locator) {
-  const [box, viewport, scrollState] = await Promise.all([
-    dialog.boundingBox(),
-    page.viewportSize(),
-    dialog.evaluate((element) => ({
-      clientHeight: element.clientHeight,
-      overflowY: getComputedStyle(element).overflowY,
-      scrollHeight: element.scrollHeight,
-    })),
-  ]);
-
-  expect(box?.height ?? 0).toBeLessThanOrEqual((viewport?.height ?? 0) - 16);
-
-  if (scrollState.scrollHeight > scrollState.clientHeight) {
-    expect(scrollState.overflowY).toMatch(/auto|scroll/);
-  }
 }
 
 test("users can create and see an active hand receipt on mobile", async ({

--- a/tests/e2e/hand-receipts.spec.ts
+++ b/tests/e2e/hand-receipts.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 async function signInLocalUser(page: Page) {
   const suffix = `${Date.now()}-${test.info().workerIndex}-${Math.random().toString(36).slice(2)}`;
@@ -33,6 +33,24 @@ function dateOnlyFromOffset(daysFromToday: number) {
   const day = String(date.getDate()).padStart(2, "0");
 
   return `${year}-${month}-${day}`;
+}
+
+async function expectDialogContained(page: Page, dialog: Locator) {
+  const [box, viewport, scrollState] = await Promise.all([
+    dialog.boundingBox(),
+    page.viewportSize(),
+    dialog.evaluate((element) => ({
+      clientHeight: element.clientHeight,
+      overflowY: getComputedStyle(element).overflowY,
+      scrollHeight: element.scrollHeight,
+    })),
+  ]);
+
+  expect(box?.height ?? 0).toBeLessThanOrEqual((viewport?.height ?? 0) - 16);
+
+  if (scrollState.scrollHeight > scrollState.clientHeight) {
+    expect(scrollState.overflowY).toMatch(/auto|scroll/);
+  }
 }
 
 test("users can create and see an active hand receipt on mobile", async ({
@@ -138,6 +156,7 @@ test("users can open and edit item details from a hand receipt", async ({
   const createDialog = page.getByRole("dialog", {
     name: "Add property item",
   });
+  await expectDialogContained(page, createDialog);
   await createDialog.getByLabel("Nomenclature").fill("M4 carbine");
   await createDialog.getByLabel("ECN").fill("ECN-101");
   await createDialog.getByLabel("Location").fill("Arms room");

--- a/tests/e2e/helpers/dialog.ts
+++ b/tests/e2e/helpers/dialog.ts
@@ -1,0 +1,25 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+export async function expectDialogContained(page: Page, dialog: Locator) {
+  await expect(dialog).toBeVisible();
+
+  const [box, viewport, scrollState] = await Promise.all([
+    dialog.boundingBox(),
+    page.viewportSize(),
+    dialog.evaluate((element) => ({
+      clientHeight: element.clientHeight,
+      overflowY: getComputedStyle(element).overflowY,
+      scrollHeight: element.scrollHeight,
+    })),
+  ]);
+
+  expect(
+    box,
+    "dialog bounding box must be available before measuring containment",
+  ).not.toBeNull();
+  expect(box!.height).toBeLessThanOrEqual((viewport?.height ?? 0) - 16);
+
+  if (scrollState.scrollHeight > scrollState.clientHeight) {
+    expect(scrollState.overflowY).toMatch(/auto|scroll/);
+  }
+}

--- a/tests/e2e/items.spec.ts
+++ b/tests/e2e/items.spec.ts
@@ -109,7 +109,7 @@ test("users can create and see an item requirement from item detail", async ({
   await page.getByRole("link", { name: "Open Requirement radio" }).click();
 
   await expect(
-    page.getByRole("heading", { name: "Requirements" }),
+    page.getByRole("heading", { name: "Requirements", exact: true }),
   ).toBeVisible();
   await page.getByRole("button", { name: "Add requirement" }).click();
   const createRequirementDialog = page.getByRole("dialog", {

--- a/tests/e2e/items.spec.ts
+++ b/tests/e2e/items.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 
 async function signInLocalUser(page: Page) {
   const suffix = `${Date.now()}-${test.info().workerIndex}-${Math.random().toString(36).slice(2)}`;
@@ -17,6 +17,24 @@ async function signInLocalUser(page: Page) {
     .getByRole("dialog", { name: "Property accountability only" })
     .getByRole("button", { name: "I understand" })
     .click();
+}
+
+async function expectDialogContained(page: Page, dialog: Locator) {
+  const [box, viewport, scrollState] = await Promise.all([
+    dialog.boundingBox(),
+    page.viewportSize(),
+    dialog.evaluate((element) => ({
+      clientHeight: element.clientHeight,
+      overflowY: getComputedStyle(element).overflowY,
+      scrollHeight: element.scrollHeight,
+    })),
+  ]);
+
+  expect(box?.height ?? 0).toBeLessThanOrEqual((viewport?.height ?? 0) - 16);
+
+  if (scrollState.scrollHeight > scrollState.clientHeight) {
+    expect(scrollState.overflowY).toMatch(/auto|scroll/);
+  }
 }
 
 test("users can search items globally and open item detail on mobile", async ({
@@ -112,8 +130,15 @@ test("users can create and see an item requirement from item detail", async ({
   const completionDialog = page.getByRole("dialog", {
     name: "Complete requirement",
   });
+  await expectDialogContained(page, completionDialog);
   await completionDialog.getByLabel("Completion date").fill("2026-01-15");
   await completionDialog.getByLabel("Notes").fill("PMCS annotated in binder.");
+  await completionDialog
+    .getByRole("button", { name: "Record completion" })
+    .scrollIntoViewIfNeeded();
+  await expect(
+    completionDialog.getByRole("button", { name: "Record completion" }),
+  ).toBeVisible();
   await completionDialog
     .getByRole("button", { name: "Record completion" })
     .click();

--- a/tests/e2e/items.spec.ts
+++ b/tests/e2e/items.spec.ts
@@ -259,7 +259,9 @@ test("item workflows warn and block around active 2062 coverage", async ({
     archiveDialog.getByText("Archiving will close the active 2062 link"),
   ).toBeVisible();
   await expect(
-    archiveDialog.getByText("The linked document and item history stay preserved."),
+    archiveDialog.getByText(
+      "The linked document and item history stay preserved.",
+    ),
   ).toBeVisible();
   await expect(
     archiveDialog.getByText(

--- a/tests/e2e/items.spec.ts
+++ b/tests/e2e/items.spec.ts
@@ -222,6 +222,17 @@ test("users can create single-item formal 2062 coverage from item detail", async
   await expect(page.getByText("signed-2062.pdf")).toBeVisible();
   await expect(page.getByText("No 2062")).toBeHidden();
   await expect(page.getByText("Item linked to 2062")).toBeVisible();
+
+  const coveredItemUrl = page.url();
+  await page.goto(`${coveredItemUrl}/upload-2062`);
+  await expect(
+    page.getByRole("heading", {
+      name: "This item already has active 2062 coverage",
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Close the existing assignment before creating a new one."),
+  ).toBeVisible();
 });
 
 test("item workflows warn and block around active 2062 coverage", async ({

--- a/tests/e2e/items.spec.ts
+++ b/tests/e2e/items.spec.ts
@@ -1,4 +1,6 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
+
+import { expectDialogContained } from "./helpers/dialog";
 
 async function signInLocalUser(page: Page) {
   const suffix = `${Date.now()}-${test.info().workerIndex}-${Math.random().toString(36).slice(2)}`;
@@ -17,24 +19,6 @@ async function signInLocalUser(page: Page) {
     .getByRole("dialog", { name: "Property accountability only" })
     .getByRole("button", { name: "I understand" })
     .click();
-}
-
-async function expectDialogContained(page: Page, dialog: Locator) {
-  const [box, viewport, scrollState] = await Promise.all([
-    dialog.boundingBox(),
-    page.viewportSize(),
-    dialog.evaluate((element) => ({
-      clientHeight: element.clientHeight,
-      overflowY: getComputedStyle(element).overflowY,
-      scrollHeight: element.scrollHeight,
-    })),
-  ]);
-
-  expect(box?.height ?? 0).toBeLessThanOrEqual((viewport?.height ?? 0) - 16);
-
-  if (scrollState.scrollHeight > scrollState.clientHeight) {
-    expect(scrollState.overflowY).toMatch(/auto|scroll/);
-  }
 }
 
 test("users can search items globally and open item detail on mobile", async ({

--- a/tests/e2e/responsive-smoke.spec.ts
+++ b/tests/e2e/responsive-smoke.spec.ts
@@ -1,4 +1,6 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
+
+import { expectDialogContained } from "./helpers/dialog";
 
 async function signInLocalUser(page: Page) {
   const suffix = `${Date.now()}-${test.info().workerIndex}-${Math.random().toString(36).slice(2)}`;
@@ -29,24 +31,6 @@ async function expectNoHorizontalOverflow(page: Page) {
       ),
     )
     .toBeLessThanOrEqual(0);
-}
-
-async function expectDialogContained(page: Page, dialog: Locator) {
-  const [box, viewport, scrollState] = await Promise.all([
-    dialog.boundingBox(),
-    page.viewportSize(),
-    dialog.evaluate((element) => ({
-      clientHeight: element.clientHeight,
-      overflowY: getComputedStyle(element).overflowY,
-      scrollHeight: element.scrollHeight,
-    })),
-  ]);
-
-  expect(box?.height ?? 0).toBeLessThanOrEqual((viewport?.height ?? 0) - 16);
-
-  if (scrollState.scrollHeight > scrollState.clientHeight) {
-    expect(scrollState.overflowY).toMatch(/auto|scroll/);
-  }
 }
 
 test("tablet shell, item detail, and upload 2062 flow stay usable", async ({

--- a/tests/e2e/responsive-smoke.spec.ts
+++ b/tests/e2e/responsive-smoke.spec.ts
@@ -1,0 +1,106 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+
+async function signInLocalUser(page: Page) {
+  const suffix = `${Date.now()}-${test.info().workerIndex}-${Math.random().toString(36).slice(2)}`;
+  const email = `responsive-${suffix}@example.test`;
+
+  await page.goto("/auth/login?next=/app/dashboard");
+  await page.getByRole("tab", { name: "Register" }).click();
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill("password123");
+  await expect(
+    page.getByRole("button", { name: "Create account" }),
+  ).toBeEnabled();
+  await page.getByRole("button", { name: "Create account" }).click();
+  await expect(page).toHaveURL(/\/app\/dashboard$/);
+  await page
+    .getByRole("dialog", { name: "Property accountability only" })
+    .getByRole("button", { name: "I understand" })
+    .click();
+}
+
+async function expectNoHorizontalOverflow(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          document.documentElement.scrollWidth -
+          document.documentElement.clientWidth,
+      ),
+    )
+    .toBeLessThanOrEqual(0);
+}
+
+async function expectDialogContained(page: Page, dialog: Locator) {
+  const [box, viewport, scrollState] = await Promise.all([
+    dialog.boundingBox(),
+    page.viewportSize(),
+    dialog.evaluate((element) => ({
+      clientHeight: element.clientHeight,
+      overflowY: getComputedStyle(element).overflowY,
+      scrollHeight: element.scrollHeight,
+    })),
+  ]);
+
+  expect(box?.height ?? 0).toBeLessThanOrEqual((viewport?.height ?? 0) - 16);
+
+  if (scrollState.scrollHeight > scrollState.clientHeight) {
+    expect(scrollState.overflowY).toMatch(/auto|scroll/);
+  }
+}
+
+test("tablet shell, item detail, and upload 2062 flow stay usable", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 768, height: 1024 });
+  await signInLocalUser(page);
+
+  await expect(page.getByTestId("desktop-sidebar")).toBeVisible();
+  await expect(page.getByTestId("mobile-bottom-nav")).toBeHidden();
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+
+  await page.getByRole("link", { name: "Hand Receipts" }).click();
+  await page.getByRole("button", { name: "New hand receipt" }).click();
+  await page.getByLabel("Name").fill("Tablet smoke receipt");
+  await page.getByRole("button", { name: "Create" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Tablet smoke receipt" }),
+  ).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+
+  await page.getByRole("link", { name: "Open Tablet smoke receipt" }).click();
+  await page.getByRole("button", { name: "Add item" }).click();
+  const createDialog = page.getByRole("dialog", {
+    name: "Add property item",
+  });
+  await expectDialogContained(page, createDialog);
+  await createDialog.getByLabel("Nomenclature").fill("Tablet smoke radio");
+  await createDialog.getByLabel("ECN").fill("ECN-TABLET");
+  await createDialog.getByRole("button", { name: "Create item" }).click();
+
+  await page.getByRole("link", { name: "Open Tablet smoke radio" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Tablet smoke radio" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Hand Receipt Context" }),
+  ).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+
+  await page.getByRole("link", { name: "Back to hand receipt" }).click();
+  await expect(page).toHaveURL(/\/app\/hand-receipts\/[0-9a-f-]+$/);
+  await expect(
+    page.getByRole("heading", { name: "Tablet smoke receipt" }),
+  ).toBeVisible();
+  await page.getByRole("link", { name: "Upload 2062" }).first().click();
+  await expect(page).toHaveURL(
+    /\/app\/hand-receipts\/[0-9a-f-]+\/upload-2062$/,
+  );
+  const stepRail = page.locator("ol").filter({ hasText: "Summary" });
+  await expect(stepRail.getByText("Contact", { exact: true })).toBeVisible();
+  await expect(stepRail.getByText("Document", { exact: true })).toBeVisible();
+  await expect(stepRail.getByText("Items", { exact: true })).toBeVisible();
+  await expect(stepRail.getByText("Summary", { exact: true })).toBeVisible();
+  await expectNoHorizontalOverflow(page);
+});

--- a/tests/integration/trpc/accounts-router.test.ts
+++ b/tests/integration/trpc/accounts-router.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it } from "vitest";
 import { appRouter } from "@/server/trpc/router";
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
 import { InMemoryAccountRepository } from "../../support/account-repository";
-import { createEmptyAuditRepository } from "../../support/audit-repository";
+import {
+  createEmptyAuditRepository,
+  InMemoryAuditRepository,
+} from "../../support/audit-repository";
 import { createInMemoryAppUnitOfWork } from "../../support/app-unit-of-work";
 import { createEmptyContactRepository } from "../../support/contact-repository";
 import { createEmptyHandReceiptRepository } from "../../support/hand-receipt-repository";
@@ -26,20 +29,25 @@ function createAccount(): AccountRecord {
 describe("accountsRouter", () => {
   it("serves and completes onboarding through the typed tRPC boundary", async () => {
     const account = createAccount();
+    const accountRepository = new InMemoryAccountRepository([account]);
+    const auditRepository = createEmptyAuditRepository();
     const caller = appRouter.createCaller({
       session: {
         userId: "user-1",
         email: "owner@example.com",
       },
       account,
-      accountRepository: new InMemoryAccountRepository([account]),
-      auditRepository: createEmptyAuditRepository(),
+      accountRepository,
+      auditRepository,
       contactRepository: createEmptyContactRepository(),
       handReceiptRepository: createEmptyHandReceiptRepository(),
       itemRepository: createEmptyItemRepository(),
       locationRepository: createEmptyLocationRepository(),
       requirementRepository: createEmptyRequirementRepository(),
-      unitOfWork: createInMemoryAppUnitOfWork(),
+      unitOfWork: createInMemoryAppUnitOfWork({
+        accountRepository,
+        auditRepository,
+      }),
     });
 
     await expect(caller.accounts.getOnboardingStatus()).resolves.toMatchObject({
@@ -53,5 +61,45 @@ describe("accountsRouter", () => {
       accessState: "active",
       isReadOnly: false,
     });
+    expect(auditRepository.events).toMatchObject([
+      {
+        action: "account.onboarding_completed",
+        accountId: account.id,
+      },
+    ]);
+  });
+
+  it("rolls back onboarding completion when audit recording fails", async () => {
+    const account = createAccount();
+    const accountRepository = new InMemoryAccountRepository([account]);
+    const auditRepository = new InMemoryAuditRepository();
+    auditRepository.failRecording = true;
+    const caller = appRouter.createCaller({
+      session: {
+        userId: "user-1",
+        email: "owner@example.com",
+      },
+      account,
+      accountRepository,
+      auditRepository,
+      contactRepository: createEmptyContactRepository(),
+      handReceiptRepository: createEmptyHandReceiptRepository(),
+      itemRepository: createEmptyItemRepository(),
+      locationRepository: createEmptyLocationRepository(),
+      requirementRepository: createEmptyRequirementRepository(),
+      unitOfWork: createInMemoryAppUnitOfWork({
+        accountRepository,
+        auditRepository,
+      }),
+    });
+
+    await expect(caller.accounts.completeOnboarding()).rejects.toThrow(
+      "Audit event was not recorded.",
+    );
+
+    await expect(
+      accountRepository.findByUserId(account.userId),
+    ).resolves.toEqual(account);
+    expect(auditRepository.events).toEqual([]);
   });
 });

--- a/tests/integration/trpc/assignments-2062-router.test.ts
+++ b/tests/integration/trpc/assignments-2062-router.test.ts
@@ -201,6 +201,85 @@ function createCaller(account = createAccount()) {
   };
 }
 
+function seedExistingAssignmentFixture({
+  assignmentItemLinkRepository,
+  assignmentRepository,
+  includeClosedHistory = false,
+}: {
+  assignmentItemLinkRepository: InMemoryAssignmentItemLinkRepository;
+  assignmentRepository: InMemoryAssignmentRepository;
+  includeClosedHistory?: boolean;
+}) {
+  const activeAssignmentId = "11111111-1111-4111-8111-111111111111";
+  const activeLinkId = "22222222-2222-4222-8222-222222222222";
+  const closedAssignmentId = "33333333-3333-4333-8333-333333333333";
+  const closedLinkId = "44444444-4444-4444-8444-444444444444";
+
+  assignmentRepository.assignments.push({
+    id: activeAssignmentId,
+    accountId: "account-1",
+    handReceiptId: "88888888-8888-4888-8888-888888888888",
+    contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+    contactName: "SPC Rivera",
+    documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+    documentFilename: "signed-2062.pdf",
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+  });
+  assignmentItemLinkRepository.links.push({
+    id: activeLinkId,
+    accountId: "account-1",
+    assignmentId: activeAssignmentId,
+    itemId: "dddddddd-dddd-4ddd-9ddd-dddddddddddd",
+    status: "active",
+    closedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  if (includeClosedHistory) {
+    assignmentRepository.assignments.push({
+      id: closedAssignmentId,
+      accountId: "account-1",
+      handReceiptId: "88888888-8888-4888-8888-888888888888",
+      contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      contactName: "SPC Rivera",
+      documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+      documentFilename: "closed-2062.pdf",
+      status: "closed",
+      createdAt: new Date("2026-04-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-02T12:00:00.000Z"),
+    });
+    assignmentItemLinkRepository.links.push({
+      id: closedLinkId,
+      accountId: "account-1",
+      assignmentId: closedAssignmentId,
+      itemId: "dddddddd-dddd-4ddd-9ddd-dddddddddddd",
+      status: "closed",
+      closedAt: new Date("2026-04-02T12:00:00.000Z"),
+      createdAt: new Date("2026-04-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-02T12:00:00.000Z"),
+    });
+    assignmentItemLinkRepository.assignmentContexts.push({
+      assignmentId: closedAssignmentId,
+      handReceiptId: "88888888-8888-4888-8888-888888888888",
+      handReceiptName: "Primary receipt",
+      contactId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      contactName: "SPC Rivera",
+      documentId: "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb",
+      documentFilename: "closed-2062.pdf",
+    });
+  }
+
+  return {
+    activeAssignmentId,
+    activeLinkId,
+    closedAssignmentId,
+    closedLinkId,
+  };
+}
+
 describe("assignments2062Router", () => {
   it("creates a single-item 2062 through the typed procedure", async () => {
     const { caller, assignmentRepository, assignmentItemLinkRepository } =
@@ -514,6 +593,36 @@ describe("assignments2062Router", () => {
     );
   });
 
+  it("maps read-only assignment close to FORBIDDEN without changing records", async () => {
+    const {
+      caller,
+      assignmentRepository,
+      assignmentItemLinkRepository,
+      auditRepository,
+    } = createCaller(createAccount({ accessState: "paused_read_only" }));
+    const { activeAssignmentId } = seedExistingAssignmentFixture({
+      assignmentItemLinkRepository,
+      assignmentRepository,
+    });
+
+    await expect(
+      caller.assignments2062.close({
+        assignmentId: activeAssignmentId,
+        closedOn: "2026-05-01",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "This account is read-only.",
+    });
+    expect(assignmentRepository.assignments[0]).toMatchObject({
+      status: "active",
+    });
+    expect(assignmentItemLinkRepository.links[0]).toMatchObject({
+      status: "active",
+    });
+    expect(auditRepository.events).toEqual([]);
+  });
+
   it("removes one item link while leaving other active links in place", async () => {
     const { caller, assignmentRepository, assignmentItemLinkRepository } =
       createCaller();
@@ -549,6 +658,36 @@ describe("assignments2062Router", () => {
       expect.objectContaining({ id: link.id, status: "closed" }),
       expect.objectContaining({ status: "active" }),
     ]);
+  });
+
+  it("maps read-only item-link removal to FORBIDDEN without changing records", async () => {
+    const {
+      caller,
+      assignmentRepository,
+      assignmentItemLinkRepository,
+      auditRepository,
+    } = createCaller(createAccount({ accessState: "paused_read_only" }));
+    const { activeLinkId } = seedExistingAssignmentFixture({
+      assignmentItemLinkRepository,
+      assignmentRepository,
+    });
+
+    await expect(
+      caller.assignments2062.removeItemLink({
+        itemLinkId: activeLinkId,
+        closedOn: "2026-05-01",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "This account is read-only.",
+    });
+    expect(assignmentRepository.assignments[0]).toMatchObject({
+      status: "active",
+    });
+    expect(assignmentItemLinkRepository.links[0]).toMatchObject({
+      status: "active",
+    });
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("auto-closes the assignment when the final item link is removed", async () => {
@@ -698,6 +837,51 @@ describe("assignments2062Router", () => {
         {
           assignmentId: "33333333-3333-4333-8333-333333333333",
           linkId: "44444444-4444-4444-8444-444444444444",
+        },
+      ],
+    });
+  });
+
+  it("keeps 2062 list and coverage reads available for read-only accounts", async () => {
+    const { caller, assignmentItemLinkRepository, assignmentRepository } =
+      createCaller(createAccount({ accessState: "paused_read_only" }));
+    const { activeAssignmentId, closedAssignmentId, closedLinkId } =
+      seedExistingAssignmentFixture({
+        assignmentItemLinkRepository,
+        assignmentRepository,
+        includeClosedHistory: true,
+      });
+
+    await expect(caller.assignments2062.list()).resolves.toMatchObject([
+      {
+        id: activeAssignmentId,
+        contactName: "SPC Rivera",
+        itemCount: 1,
+      },
+    ]);
+    await expect(
+      caller.assignments2062.getHandReceiptAssignments({
+        handReceiptId: "88888888-8888-4888-8888-888888888888",
+      }),
+    ).resolves.toMatchObject([
+      {
+        id: activeAssignmentId,
+        handReceiptName: "Primary receipt",
+      },
+    ]);
+    await expect(
+      caller.assignments2062.getItemCoverage({
+        itemId: "dddddddd-dddd-4ddd-9ddd-dddddddddddd",
+      }),
+    ).resolves.toMatchObject({
+      current: {
+        id: activeAssignmentId,
+        contactName: "SPC Rivera",
+      },
+      history: [
+        {
+          assignmentId: closedAssignmentId,
+          linkId: closedLinkId,
         },
       ],
     });

--- a/tests/integration/trpc/documents-router.test.ts
+++ b/tests/integration/trpc/documents-router.test.ts
@@ -157,6 +157,34 @@ describe("documentsRouter", () => {
     });
   });
 
+  it("maps read-only upload completion to FORBIDDEN before storage verification", async () => {
+    const documentRepository = new InMemoryDocumentRepository();
+    const storagePort = new MockStoragePort({
+      existingPaths: ["account-1/7f9fedcf-58cb-4651-96d8-ea0cb8fc68b1"],
+    });
+    const caller = createCaller({
+      account: createAccount({ accessState: "paused_read_only" }),
+      documentRepository,
+      storagePort,
+    });
+
+    await expect(
+      caller.documents.completeUpload({
+        documentId: "7f9fedcf-58cb-4651-96d8-ea0cb8fc68b1",
+        filename: "signed-2062.pdf",
+        handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+        mimeType: "application/pdf",
+        sizeBytes: 1024,
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "This account is read-only.",
+    });
+
+    expect(storagePort.existsCalls).toEqual([]);
+    expect(documentRepository.documents).toEqual([]);
+  });
+
   it("rejects invalid MIME types before the procedure runs", async () => {
     await expect(
       createCaller().documents.initiateUpload({
@@ -185,6 +213,45 @@ describe("documentsRouter", () => {
     ]);
     const caller = createCaller({ documentRepository });
 
+    await expect(
+      caller.documents.getById({
+        id: "4d39229c-f714-4e3f-9ea1-77c9bfdca76c",
+      }),
+    ).resolves.toMatchObject({
+      document: {
+        filename: "signed-2062.pdf",
+      },
+      downloadUrl:
+        "https://storage.test/download/account-1/4d39229c-f714-4e3f-9ea1-77c9bfdca76c",
+    });
+  });
+
+  it("keeps document list and download access available for read-only accounts", async () => {
+    const documentRepository = new InMemoryDocumentRepository([
+      {
+        id: "4d39229c-f714-4e3f-9ea1-77c9bfdca76c",
+        accountId: "account-1",
+        handReceiptId: "8d899b9d-ee59-4f5a-a587-934a750fce48",
+        filename: "signed-2062.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 1024,
+        storagePath: "account-1/4d39229c-f714-4e3f-9ea1-77c9bfdca76c",
+        uploadedAt: new Date("2026-05-02T12:00:00.000Z"),
+        createdAt: new Date("2026-05-02T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-02T12:00:00.000Z"),
+      },
+    ]);
+    const caller = createCaller({
+      account: createAccount({ accessState: "paused_read_only" }),
+      documentRepository,
+    });
+
+    await expect(caller.documents.list()).resolves.toMatchObject([
+      {
+        id: "4d39229c-f714-4e3f-9ea1-77c9bfdca76c",
+        filename: "signed-2062.pdf",
+      },
+    ]);
     await expect(
       caller.documents.getById({
         id: "4d39229c-f714-4e3f-9ea1-77c9bfdca76c",

--- a/tests/integration/trpc/hand-receipts-router.test.ts
+++ b/tests/integration/trpc/hand-receipts-router.test.ts
@@ -226,6 +226,48 @@ describe("handReceiptsRouter", () => {
     });
   });
 
+  it("maps read-only hand receipt creation to FORBIDDEN while keeping reads available", async () => {
+    const repository = new InMemoryHandReceiptRepository([
+      {
+        id: "78d65dcc-c47b-475c-9c5b-6cb1fbfd0f42",
+        accountId: "account-1",
+        name: "Readable receipt",
+        notes: null,
+        handReceiptNumber: null,
+        holderName: null,
+        unitName: null,
+        uic: null,
+        effectiveDate: null,
+        status: "active",
+        createdAt: new Date("2026-04-30T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-30T12:00:00.000Z"),
+      },
+    ]);
+    const caller = createCaller({
+      account: createAccount({
+        accessState: "paused_read_only",
+        subscriptionTier: "pro",
+      }),
+      handReceiptRepository: repository,
+    });
+
+    await expect(caller.handReceipts.list()).resolves.toMatchObject([
+      {
+        id: "78d65dcc-c47b-475c-9c5b-6cb1fbfd0f42",
+        name: "Readable receipt",
+      },
+    ]);
+    await expect(
+      caller.handReceipts.create({
+        name: "Blocked receipt",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "This account is read-only.",
+    });
+    expect(repository.handReceipts).toHaveLength(1);
+  });
+
   it("returns a single hand receipt through the typed detail procedure", async () => {
     const handReceiptId = "2c4d5d97-1610-493d-baa5-8bc80b2dce01";
     const repository = new InMemoryHandReceiptRepository([

--- a/tests/integration/trpc/hand-receipts-router.test.ts
+++ b/tests/integration/trpc/hand-receipts-router.test.ts
@@ -243,12 +243,14 @@ describe("handReceiptsRouter", () => {
         updatedAt: new Date("2026-04-30T12:00:00.000Z"),
       },
     ]);
+    const auditRepository = new InMemoryAuditRepository();
     const caller = createCaller({
       account: createAccount({
         accessState: "paused_read_only",
         subscriptionTier: "pro",
       }),
       handReceiptRepository: repository,
+      auditRepository,
     });
 
     await expect(caller.handReceipts.list()).resolves.toMatchObject([
@@ -265,6 +267,7 @@ describe("handReceiptsRouter", () => {
       code: "FORBIDDEN",
       message: "This account is read-only.",
     });
+    expect(auditRepository.events).toEqual([]);
     expect(repository.handReceipts).toHaveLength(1);
   });
 

--- a/tests/integration/trpc/hand-receipts-router.test.ts
+++ b/tests/integration/trpc/hand-receipts-router.test.ts
@@ -371,6 +371,7 @@ describe("handReceiptsRouter", () => {
         targetType: "hand_receipt",
         targetId: handReceiptId,
         metadata: {
+          name: "Updated receipt",
           changedFields: ["name", "notes", "holderName"],
         },
       },

--- a/tests/integration/trpc/items-router.test.ts
+++ b/tests/integration/trpc/items-router.test.ts
@@ -764,6 +764,76 @@ describe("itemsRouter", () => {
     expect(auditRepository.events).toEqual([]);
   });
 
+  it("maps read-only manual signed-to changes to FORBIDDEN", async () => {
+    const auditRepository = new InMemoryAuditRepository();
+    const contactRepository = new InMemoryContactRepository([
+      {
+        id: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+        accountId: "account-1",
+        displayName: "SSG Rivera",
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+    ]);
+    const itemRepository = new InMemoryItemRepository([
+      {
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        nomenclature: "Read-only signed radio",
+        ecn: "ECN-703",
+        serialNumber: null,
+        generatedId: null,
+        notes: null,
+        status: "active",
+        signedToContactId: null,
+        createdAt: new Date("2026-04-29T12:00:00.000Z"),
+        updatedAt: new Date("2026-04-29T12:00:00.000Z"),
+      },
+    ]);
+    const caller = createCaller({
+      account: createAccount({
+        accessState: "paused_read_only",
+        subscriptionTier: "pro",
+      }),
+      auditRepository,
+      contactRepository,
+      itemRepository,
+    });
+
+    await expect(
+      caller.items.assignSignedTo({
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+        contactId: "2e6e25b2-7ffd-4fb5-82ac-d61a52b7f6a3",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "This account is read-only.",
+    });
+    await expect(
+      caller.items.assignSignedToWithNewContact({
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+        contactDisplayName: "CPL Nguyen",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "This account is read-only.",
+    });
+    await expect(
+      caller.items.clearSignedTo({
+        id: "6f5f7e36-bb0a-47ec-8d2a-13f29d7ef94c",
+      }),
+    ).rejects.toMatchObject({
+      code: "FORBIDDEN",
+      message: "This account is read-only.",
+    });
+    expect(contactRepository.contacts).toHaveLength(1);
+    expect(itemRepository.items[0]).toMatchObject({
+      signedToContactId: null,
+    });
+    expect(auditRepository.events).toEqual([]);
+  });
+
   it("blocks moves with active 2062 coverage and exposes move preflight state", async () => {
     const assignmentItemLinkRepository =
       new InMemoryAssignmentItemLinkRepository([
@@ -1068,8 +1138,9 @@ describe("itemsRouter", () => {
         updatedAt: new Date("2026-04-29T12:00:00.000Z"),
       },
     ]);
-    const originalFindById =
-      assignmentItemLinkRepository.findById.bind(assignmentItemLinkRepository);
+    const originalFindById = assignmentItemLinkRepository.findById.bind(
+      assignmentItemLinkRepository,
+    );
     assignmentItemLinkRepository.findById = async (...args) => {
       const link = await originalFindById(...args);
 

--- a/tests/integration/trpc/requirements-router.test.ts
+++ b/tests/integration/trpc/requirements-router.test.ts
@@ -397,6 +397,64 @@ describe("requirementsRouter", () => {
     });
   });
 
+  it("keeps requirement list and completion history available for read-only accounts", async () => {
+    const requirementId = "6e08300d-d56f-454d-a093-1b7c8657f796";
+    const requirementCompletionRepository =
+      new InMemoryRequirementCompletionRepository([
+        {
+          id: "completion-1",
+          accountId: "account-1",
+          requirementId,
+          completedOn: "2026-05-01",
+          notes: "Completed before pause.",
+          createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        },
+      ]);
+    const requirementRepository = new InMemoryRequirementRepository([
+      {
+        id: requirementId,
+        accountId: "account-1",
+        itemId: itemOneId,
+        name: "Monthly function check",
+        notes: null,
+        intervalType: "monthly",
+        intervalValue: null,
+        nextDueDate: "2026-05-15",
+        status: "active",
+        pausedAt: null,
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+    ]);
+    const caller = createCaller({
+      account: createAccount({
+        accessState: "paused_read_only",
+        subscriptionTier: "pro",
+      }),
+      requirementCompletionRepository,
+      requirementRepository,
+    });
+
+    await expect(
+      caller.requirements.list({ itemId: itemOneId }),
+    ).resolves.toMatchObject([
+      {
+        id: requirementId,
+        name: "Monthly function check",
+      },
+    ]);
+    await expect(
+      caller.requirements.listCompletionHistory({
+        requirementId,
+      }),
+    ).resolves.toMatchObject([
+      {
+        completedOn: "2026-05-01",
+        notes: "Completed before pause.",
+      },
+    ]);
+  });
+
   it("keeps requirement lists scoped to the selected item", async () => {
     const requirementRepository = new InMemoryRequirementRepository([
       {

--- a/tests/rls/README.md
+++ b/tests/rls/README.md
@@ -1,15 +1,47 @@
 # RLS Tests
 
-Field Ledger's first account-owned production table is `accounts`.
+RLS tests connect to local Supabase Postgres, seed two owners as the privileged
+migration user, then run read/write probes as the `authenticated` role with
+`app.current_auth_subject` set to one opaque Better Auth subject.
 
-The account RLS tests connect to local Supabase Postgres, seed two account rows
-as the privileged migration user, then run read/write probes as the
-`authenticated` role with `app.current_auth_subject` set to one opaque auth
-subject. That proves an owner can see their own account row and cannot read or
-update another owner account row without relying on Supabase Auth UUIDs.
+That pattern proves account ownership is enforced by the app-owned session
+context instead of Supabase Auth UUIDs. Each table-level test proves one account
+cannot read or write another account's rows. Repository-level tests prove
+runtime adapters execute through the authenticated database-session boundary
+instead of privileged database access.
 
-The audit and hand receipt RLS tests use the same pattern for account-owned
-tables. Each table-level test proves one account cannot read or write another
-account's rows, and each repository-level test proves runtime adapters execute
-through the authenticated database-session boundary instead of privileged
-database access.
+## Coverage
+
+- `accounts`: owner row read/update isolation for the login-to-account mapping.
+- `audit`: audit event table isolation plus audit repository isolation.
+- `hand-receipts`: hand receipt table isolation plus repository isolation for
+  create/update/archive/restore behavior.
+- `items`: item table isolation, owner-scoped insert/update, archived reads,
+  signed-to contact links, location links, and hand receipt links.
+- `contacts`: contact table read/insert/update isolation.
+- `locations`: location table read/insert/update isolation.
+- `requirements`: requirement table isolation, requirement-completion table
+  isolation, and repository isolation for requirement and completion adapters.
+- `documents`: document table isolation, hand receipt/document relationship
+  checks, storage path ownership, and repository isolation.
+- `assignments-2062`: formal 2062 assignment and assignment-item-link
+  isolation, close-state constraints, same-hand-receipt link checks, and
+  cross-account relationship blocking.
+
+Repository-level RLS tests currently exist for audit events, hand receipts,
+documents, requirements, and requirement completions.
+
+## Relationship Protection
+
+Field Ledger uses two database patterns to prevent cross-account relationships:
+
+- RESTRICTIVE RLS policies add extra insert/update checks on a table. `items`
+  uses this for `signed_to_contact_id` and `location_id`. Item hand receipt
+  ownership is checked in the item owner insert/update policies.
+- Composite foreign keys include `account_id` in the referenced key.
+  `assignments` and `assignment_item_links` use this for hand receipt, contact,
+  document, assignment, and item relationships.
+
+Both patterns keep linked records inside the same owner account. Tests should
+cover the user-visible result, whether the database rejects the write through an
+RLS policy or a foreign key constraint.

--- a/tests/rls/assignments-2062/assignments-2062-rls.test.ts
+++ b/tests/rls/assignments-2062/assignments-2062-rls.test.ts
@@ -24,6 +24,10 @@ const ownerTwoAssignmentId = "271c82d4-b3bc-4f82-af72-f15f614b1a9b";
 const ownerOneLinkId = "092b4804-6c02-4968-a78a-4667a298e37c";
 const ownerTwoLinkId = "8310d384-4e92-4e12-ac71-e25353fa36b5";
 const ownerOneInsertAssignmentId = "15d0422a-9912-45cf-927e-6a49df7a7105";
+const ownerOneCrossAccountContactAssignmentId =
+  "a63117c5-74a0-4ac9-b87f-a2444ac778f1";
+const ownerOneCrossAccountDocumentAssignmentId =
+  "733a8df6-77b9-4cb8-80f7-acfe7ca49f9d";
 const ownerOneInsertLinkId = "5f483d29-f0c3-4867-bd2e-47b67e16fb5b";
 const ownerTwoBlockedLinkId = "1c5e5430-2e21-45b2-bbd9-b58113b7c4b8";
 const ownerOneConstraintItemId = "e048fd65-5df6-4cc9-b71a-5041668284f5";
@@ -176,7 +180,7 @@ describe("assignments-2062 RLS", () => {
 
   afterAll(async () => {
     await sql`delete from assignment_item_links where id in (${ownerOneLinkId}, ${ownerTwoLinkId}, ${ownerOneInsertLinkId}, ${ownerOneConstraintLinkId}, ${ownerOneCrossReceiptLinkId})`;
-    await sql`delete from assignments where id in (${ownerOneAssignmentId}, ${ownerTwoAssignmentId}, ${ownerOneInsertAssignmentId}, ${ownerOneConstraintAssignmentId})`;
+    await sql`delete from assignments where id in (${ownerOneAssignmentId}, ${ownerTwoAssignmentId}, ${ownerOneInsertAssignmentId}, ${ownerOneCrossAccountContactAssignmentId}, ${ownerOneCrossAccountDocumentAssignmentId}, ${ownerOneConstraintAssignmentId})`;
     await sql`delete from items where id in (${ownerOneItemId}, ${ownerTwoItemId}, ${ownerOneInsertItemId}, ${ownerOneConstraintItemId}, ${ownerOneCrossReceiptItemId})`;
     await sql`delete from documents where id in (${ownerOneDocumentId}, ${ownerTwoDocumentId})`;
     await sql`delete from contacts where id in (${ownerOneContactId}, ${ownerTwoContactId})`;
@@ -255,6 +259,50 @@ describe("assignments-2062 RLS", () => {
           )`,
       ),
     ).rejects.toThrow();
+  });
+
+  it("prevents an assignment from linking another account's contact", async () => {
+    await expect(
+      asAuthenticatedOwner(
+        ownerOneId,
+        async (transaction) =>
+          transaction`insert into assignments (
+            id,
+            account_id,
+            hand_receipt_id,
+            contact_id,
+            document_id
+          ) values (
+            ${ownerOneCrossAccountContactAssignmentId},
+            ${ownerOneAccountId},
+            ${ownerOneHandReceiptId},
+            ${ownerTwoContactId},
+            ${ownerOneDocumentId}
+          )`,
+      ),
+    ).rejects.toThrow(/foreign key constraint/);
+  });
+
+  it("prevents an assignment from linking another account's document", async () => {
+    await expect(
+      asAuthenticatedOwner(
+        ownerOneId,
+        async (transaction) =>
+          transaction`insert into assignments (
+            id,
+            account_id,
+            hand_receipt_id,
+            contact_id,
+            document_id
+          ) values (
+            ${ownerOneCrossAccountDocumentAssignmentId},
+            ${ownerOneAccountId},
+            ${ownerOneHandReceiptId},
+            ${ownerOneContactId},
+            ${ownerTwoDocumentId}
+          )`,
+      ),
+    ).rejects.toThrow(/foreign key constraint/);
   });
 
   it("prevents an owner from inserting item links for another account", async () => {

--- a/tests/support/account-repository.ts
+++ b/tests/support/account-repository.ts
@@ -35,13 +35,17 @@ export class InMemoryAccountRepository implements AccountRepository {
       return null;
     }
 
+    const completedNow = !account.onboardingCompletedAt;
     const updatedAccount = {
       ...account,
       onboardingCompletedAt: account.onboardingCompletedAt ?? completedAt,
     };
 
     this.accounts.set(account.userId, updatedAccount);
-    return updatedAccount;
+    return {
+      account: updatedAccount,
+      completedNow,
+    };
   }
 
   async incrementAndGetNextItemSequence(accountId: string) {

--- a/tests/unit/accounts/onboarding.test.ts
+++ b/tests/unit/accounts/onboarding.test.ts
@@ -6,6 +6,7 @@ import {
   type AccountRecord,
 } from "@/modules/accounts/application/ensure-account";
 import { InMemoryAccountRepository } from "../../support/account-repository";
+import { InMemoryAuditRepository } from "../../support/audit-repository";
 
 const trialAccount: AccountRecord = {
   id: "6a9b6ae8-ed65-4f5a-b8c3-585cf141abce",
@@ -50,6 +51,7 @@ describe("account onboarding", () => {
 
   it("marks onboarding complete idempotently", async () => {
     const repository = new InMemoryAccountRepository([trialAccount]);
+    const auditRepository = new InMemoryAuditRepository();
     const completedAt = new Date("2026-04-30T12:00:00.000Z");
 
     await expect(
@@ -57,11 +59,25 @@ describe("account onboarding", () => {
         account: trialAccount,
         completedAt,
         repository,
+        auditRepository,
       }),
     ).resolves.toMatchObject({
       completed: true,
       completedAt,
     });
+    expect(auditRepository.events).toMatchObject([
+      {
+        accountId: trialAccount.id,
+        actorId: trialAccount.userId,
+        action: "account.onboarding_completed",
+        targetType: "account",
+        targetId: trialAccount.id,
+        occurredAt: completedAt,
+        metadata: {
+          acknowledgedBoundaryNotice: true,
+        },
+      },
+    ]);
 
     await expect(
       completeOnboarding({
@@ -71,10 +87,12 @@ describe("account onboarding", () => {
         },
         completedAt: new Date("2026-05-01T12:00:00.000Z"),
         repository,
+        auditRepository,
       }),
     ).resolves.toMatchObject({
       completed: true,
       completedAt,
     });
+    expect(auditRepository.events).toHaveLength(1);
   });
 });

--- a/tests/unit/accounts/onboarding.test.ts
+++ b/tests/unit/accounts/onboarding.test.ts
@@ -94,5 +94,18 @@ describe("account onboarding", () => {
       completedAt,
     });
     expect(auditRepository.events).toHaveLength(1);
+
+    await expect(
+      completeOnboarding({
+        account: trialAccount,
+        completedAt: new Date("2026-05-02T12:00:00.000Z"),
+        repository,
+        auditRepository,
+      }),
+    ).resolves.toMatchObject({
+      completed: true,
+      completedAt,
+    });
+    expect(auditRepository.events).toHaveLength(1);
   });
 });

--- a/tests/unit/assignments-2062/close-remove-assignment.test.ts
+++ b/tests/unit/assignments-2062/close-remove-assignment.test.ts
@@ -224,6 +224,29 @@ describe("closeAssignment", () => {
 });
 
 describe("removeAssignmentItemLink", () => {
+  it("blocks read-only accounts before changing item links", async () => {
+    const repositories = createRepositories();
+
+    await expect(
+      removeAssignmentItemLink({
+        account: createAccount({ accessState: "paused_read_only" }),
+        actorId: "owner-1",
+        itemLinkId: "link-1",
+        ...repositories,
+        now,
+      }),
+    ).rejects.toBeInstanceOf(AccountReadOnlyError);
+
+    expect(repositories.assignmentRepository.assignments[0]).toMatchObject({
+      status: "active",
+    });
+    expect(repositories.assignmentItemLinkRepository.links).toEqual([
+      expect.objectContaining({ id: "link-1", status: "active" }),
+      expect.objectContaining({ id: "link-2", status: "active" }),
+    ]);
+    expect(repositories.auditRepository.events).toEqual([]);
+  });
+
   it("removes one item from a multi-item assignment without closing the assignment", async () => {
     const repositories = createRepositories();
 

--- a/tests/unit/audit/list-activity.test.ts
+++ b/tests/unit/audit/list-activity.test.ts
@@ -6,7 +6,7 @@ import {
   listTargetActivity,
   MAX_RECENT_ACTIVITY_LIMIT,
 } from "@/modules/audit";
-import type { AuditRepository } from "@/modules/audit";
+import type { AuditEventRecord, AuditRepository } from "@/modules/audit";
 
 function createRecordingRepository() {
   let receivedLimit: number | undefined;
@@ -40,6 +40,24 @@ function createRecordingRepository() {
     repository,
     getReceivedLimit: () => receivedLimit,
     getReceivedTarget: () => receivedTarget,
+  };
+}
+
+function createActivityRepository(event: AuditEventRecord): AuditRepository {
+  return {
+    async record(recordedEvent) {
+      return {
+        id: "event-1",
+        createdAt: recordedEvent.createdAt ?? recordedEvent.occurredAt,
+        ...recordedEvent,
+      };
+    },
+    async listByAccountId() {
+      return [event];
+    },
+    async listByTarget() {
+      return [];
+    },
   };
 }
 
@@ -266,6 +284,98 @@ describe("listRecentActivity", () => {
     ]);
   });
 
+  it("returns readable target context from contact, document, and location metadata", async () => {
+    await expect(
+      listRecentActivity({
+        accountId: "account-1",
+        repository: createActivityRepository({
+          id: "event-1",
+          accountId: "account-1",
+          actorId: "user-1",
+          action: "contact.created",
+          targetType: "contact",
+          targetId: "contact-1",
+          occurredAt: new Date("2026-05-01T12:00:00.000Z"),
+          metadata: { displayName: "SPC Rivera" },
+          createdAt: new Date("2026-05-01T12:00:01.000Z"),
+        }),
+      }),
+    ).resolves.toMatchObject([
+      {
+        label: "Contact created",
+        targetLabel: "SPC Rivera",
+      },
+    ]);
+
+    await expect(
+      listRecentActivity({
+        accountId: "account-1",
+        repository: createActivityRepository({
+          id: "event-2",
+          accountId: "account-1",
+          actorId: "user-1",
+          action: "document.uploaded",
+          targetType: "document",
+          targetId: "document-1",
+          occurredAt: new Date("2026-05-01T12:00:00.000Z"),
+          metadata: { filename: "signed-2062.pdf" },
+          createdAt: new Date("2026-05-01T12:00:01.000Z"),
+        }),
+      }),
+    ).resolves.toMatchObject([
+      {
+        label: "Document uploaded",
+        targetLabel: "signed-2062.pdf",
+      },
+    ]);
+
+    await expect(
+      listRecentActivity({
+        accountId: "account-1",
+        repository: createActivityRepository({
+          id: "event-3",
+          accountId: "account-1",
+          actorId: "user-1",
+          action: "location.created",
+          targetType: "location",
+          targetId: "location-1",
+          occurredAt: new Date("2026-05-01T12:00:00.000Z"),
+          metadata: { name: "Cage 2" },
+          createdAt: new Date("2026-05-01T12:00:01.000Z"),
+        }),
+      }),
+    ).resolves.toMatchObject([
+      {
+        label: "Location created",
+        targetLabel: "Cage 2",
+      },
+    ]);
+  });
+
+  it("falls back to readable target type labels without raw ids", async () => {
+    await expect(
+      listRecentActivity({
+        accountId: "account-1",
+        repository: createActivityRepository({
+          id: "event-1",
+          accountId: "account-1",
+          actorId: "user-1",
+          action: "document.uploaded",
+          targetType: "document",
+          targetId: "document-1",
+          occurredAt: new Date("2026-05-01T12:00:00.000Z"),
+          metadata: {},
+          createdAt: new Date("2026-05-01T12:00:01.000Z"),
+        }),
+      }),
+    ).resolves.toMatchObject([
+      {
+        label: "Document uploaded",
+        targetLabel: "Document",
+      },
+    ]);
+  });
+
   it("passes target filters to the repository for contextual activity", async () => {
     const { repository, getReceivedTarget } = createRecordingRepository();
 
@@ -280,5 +390,49 @@ describe("listRecentActivity", () => {
       targetId: "receipt-1",
       targetType: "hand_receipt",
     });
+  });
+
+  it("maps target-scoped activity to readable target labels", async () => {
+    const repository: AuditRepository = {
+      async record(event) {
+        return {
+          id: "event-1",
+          createdAt: event.createdAt ?? event.occurredAt,
+          ...event,
+        };
+      },
+      async listByAccountId() {
+        return [];
+      },
+      async listByTarget() {
+        return [
+          {
+            id: "event-1",
+            accountId: "account-1",
+            actorId: "user-1",
+            action: "hand_receipt.updated",
+            targetType: "hand_receipt",
+            targetId: "receipt-1",
+            occurredAt: new Date("2026-05-01T12:00:00.000Z"),
+            metadata: { name: "Alpha property book" },
+            createdAt: new Date("2026-05-01T12:00:01.000Z"),
+          },
+        ];
+      },
+    };
+
+    await expect(
+      listTargetActivity({
+        accountId: "account-1",
+        repository,
+        targetId: "receipt-1",
+        targetType: "hand_receipt",
+      }),
+    ).resolves.toMatchObject([
+      {
+        label: "Hand receipt updated",
+        targetLabel: "Alpha property book",
+      },
+    ]);
   });
 });

--- a/tests/unit/billing/account-capabilities.test.ts
+++ b/tests/unit/billing/account-capabilities.test.ts
@@ -2,25 +2,51 @@ import { describe, expect, it } from "vitest";
 
 import {
   canArchiveHandReceipt,
+  canClose2062Assignment,
   canCreateHandReceipt,
+  canCreateRequirement,
+  canEditRequirement,
+  canMoveItem,
+  canRemove2062ItemLink,
   canRestoreHandReceipt,
+  canUploadDocument,
   deriveAccountCapabilities,
   getActiveHandReceiptLimit,
   isAccountReadOnly,
 } from "@/modules/billing";
+import type { AccountAccessData, AccountCapabilities } from "@/modules/billing";
 
 const now = new Date("2026-04-29T12:00:00.000Z");
 
 describe("account billing capabilities", () => {
+  const activeTrial: AccountAccessData = {
+    accessState: "trialing",
+    subscriptionTier: null,
+    trialEndsAt: new Date("2026-05-29T12:00:00.000Z"),
+  };
+  const expiredTrial: AccountAccessData = {
+    accessState: "trialing",
+    subscriptionTier: null,
+    trialEndsAt: new Date("2026-04-28T12:00:00.000Z"),
+  };
+  const activeBase: AccountAccessData = {
+    accessState: "active",
+    subscriptionTier: "base",
+    trialEndsAt: new Date("2026-04-01T12:00:00.000Z"),
+  };
+  const activePro: AccountAccessData = {
+    accessState: "active",
+    subscriptionTier: "pro",
+    trialEndsAt: new Date("2026-04-01T12:00:00.000Z"),
+  };
+  const pausedReadOnly: AccountAccessData = {
+    accessState: "paused_read_only",
+    subscriptionTier: "pro",
+    trialEndsAt: new Date("2026-05-29T12:00:00.000Z"),
+  };
+
   it("gives non-expired trial accounts Pro-like capabilities", () => {
-    const capabilities = deriveAccountCapabilities(
-      {
-        accessState: "trialing",
-        subscriptionTier: null,
-        trialEndsAt: new Date("2026-05-29T12:00:00.000Z"),
-      },
-      now,
-    );
+    const capabilities = deriveAccountCapabilities(activeTrial, now);
 
     expect(isAccountReadOnly(capabilities)).toBe(false);
     expect(getActiveHandReceiptLimit(capabilities)).toBe(null);
@@ -29,11 +55,7 @@ describe("account billing capabilities", () => {
   });
 
   it("limits active Base accounts to three active hand receipts", () => {
-    const capabilities = deriveAccountCapabilities({
-      accessState: "active",
-      subscriptionTier: "base",
-      trialEndsAt: new Date("2026-04-01T12:00:00.000Z"),
-    });
+    const capabilities = deriveAccountCapabilities(activeBase);
 
     expect(isAccountReadOnly(capabilities)).toBe(false);
     expect(getActiveHandReceiptLimit(capabilities)).toBe(3);
@@ -44,11 +66,7 @@ describe("account billing capabilities", () => {
   });
 
   it("allows active Pro accounts unlimited active hand receipts", () => {
-    const capabilities = deriveAccountCapabilities({
-      accessState: "active",
-      subscriptionTier: "pro",
-      trialEndsAt: new Date("2026-04-01T12:00:00.000Z"),
-    });
+    const capabilities = deriveAccountCapabilities(activePro);
 
     expect(isAccountReadOnly(capabilities)).toBe(false);
     expect(getActiveHandReceiptLimit(capabilities)).toBe(null);
@@ -57,14 +75,7 @@ describe("account billing capabilities", () => {
   });
 
   it("resolves expired trials with no active plan to read-only", () => {
-    const capabilities = deriveAccountCapabilities(
-      {
-        accessState: "trialing",
-        subscriptionTier: null,
-        trialEndsAt: new Date("2026-04-28T12:00:00.000Z"),
-      },
-      now,
-    );
+    const capabilities = deriveAccountCapabilities(expiredTrial, now);
 
     expect(isAccountReadOnly(capabilities)).toBe(true);
     expect(canCreateHandReceipt(capabilities, 0)).toBe(false);
@@ -73,11 +84,7 @@ describe("account billing capabilities", () => {
   });
 
   it("keeps paused accounts read-only regardless of tier", () => {
-    const capabilities = deriveAccountCapabilities({
-      accessState: "paused_read_only",
-      subscriptionTier: "pro",
-      trialEndsAt: new Date("2026-05-29T12:00:00.000Z"),
-    });
+    const capabilities = deriveAccountCapabilities(pausedReadOnly);
 
     expect(isAccountReadOnly(capabilities)).toBe(true);
     expect(canCreateHandReceipt(capabilities, 0)).toBe(false);
@@ -86,12 +93,48 @@ describe("account billing capabilities", () => {
   });
 
   it("allows archive for writable accounts", () => {
-    const capabilities = deriveAccountCapabilities({
-      accessState: "active",
-      subscriptionTier: "base",
-      trialEndsAt: new Date("2026-04-01T12:00:00.000Z"),
-    });
+    const capabilities = deriveAccountCapabilities(activeBase);
 
     expect(canArchiveHandReceipt(capabilities)).toBe(true);
+  });
+
+  describe("write capability helpers", () => {
+    const helpers: Array<{
+      name: string;
+      check: (capabilities: AccountCapabilities) => boolean;
+    }> = [
+      { name: "canMoveItem", check: canMoveItem },
+      { name: "canCreateRequirement", check: canCreateRequirement },
+      { name: "canUploadDocument", check: canUploadDocument },
+      { name: "canClose2062Assignment", check: canClose2062Assignment },
+      { name: "canRemove2062ItemLink", check: canRemove2062ItemLink },
+      { name: "canEditRequirement", check: canEditRequirement },
+    ];
+
+    it.each(helpers)(
+      "$name follows the shared read-only capability rule",
+      ({ check }) => {
+        const activeTrialCapabilities = deriveAccountCapabilities(
+          activeTrial,
+          now,
+        );
+        const expiredTrialCapabilities = deriveAccountCapabilities(
+          expiredTrial,
+          now,
+        );
+        const baseCapabilities = deriveAccountCapabilities(activeBase, now);
+        const proCapabilities = deriveAccountCapabilities(activePro, now);
+        const pausedCapabilities = deriveAccountCapabilities(
+          pausedReadOnly,
+          now,
+        );
+
+        expect(check(activeTrialCapabilities)).toBe(true);
+        expect(check(baseCapabilities)).toBe(true);
+        expect(check(proCapabilities)).toBe(true);
+        expect(check(expiredTrialCapabilities)).toBe(false);
+        expect(check(pausedCapabilities)).toBe(false);
+      },
+    );
   });
 });

--- a/tests/unit/documents/upload-document.test.ts
+++ b/tests/unit/documents/upload-document.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
 import {
   completeDocumentUpload,
+  DocumentUploadReadOnlyError,
   initiateDocumentUpload,
 } from "@/modules/documents";
 import { InMemoryAuditRepository } from "../../support/audit-repository";
@@ -200,6 +201,39 @@ describe("completeDocumentUpload", () => {
       }),
     ).rejects.toThrow("This account is read-only.");
     expect(storagePort.uploadCalls).toEqual([]);
+  });
+
+  it("blocks read-only completion before storage verification", async () => {
+    const storagePort = new MockStoragePort({
+      existingPaths: ["account-1/document-1"],
+    });
+    const documentRepository = new InMemoryDocumentRepository();
+    const auditRepository = new InMemoryAuditRepository();
+
+    await expect(
+      completeDocumentUpload({
+        account: createAccount({ accessState: "paused_read_only" }),
+        actorId: "owner-1",
+        input: {
+          documentId: "document-1",
+          filename: "signed-2062.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 1234,
+          handReceiptId: "hand-receipt-1",
+        },
+        documentRepository,
+        handReceiptRepository: new InMemoryHandReceiptRepository([
+          createHandReceipt(),
+        ]),
+        auditRepository,
+        storagePort,
+        now: new Date("2026-05-02T12:00:00.000Z"),
+      }),
+    ).rejects.toBeInstanceOf(DocumentUploadReadOnlyError);
+
+    expect(storagePort.existsCalls).toEqual([]);
+    expect(documentRepository.documents).toEqual([]);
+    expect(auditRepository.events).toEqual([]);
   });
 
   it("rejects files over the application upload limit before storage is touched", async () => {

--- a/tests/unit/hand-receipts/update-hand-receipt.test.ts
+++ b/tests/unit/hand-receipts/update-hand-receipt.test.ts
@@ -79,6 +79,7 @@ describe("updateHandReceipt", () => {
         targetType: "hand_receipt",
         targetId: "receipt-1",
         metadata: {
+          name: "HQ hand receipt",
           changedFields: [
             "name",
             "notes",


### PR DESCRIPTION
## Summary

- Implements the Phase 6 MVP hardening slices across read-only behavior, RLS coverage, audit/activity polish, responsive UX, and release documentation.
- Fixes the architecture-audit finding by running onboarding completion and its audit event through the app unit-of-work transaction.
- Tightens the item requirements E2E locator that was failing under Playwright strict mode.

## Validation

- `pnpm exec vitest run tests/integration/trpc/accounts-router.test.ts`
- `pnpm exec playwright test tests/e2e/items.spec.ts --grep "users can create and see an item requirement from item detail"`
- `pnpm verify`

## Notes

Unrelated local files were left out of this PR: `.sandcastle/implement-prompt.md`, `.sandcastle/review-prompt.md`, and `docs/prd/field-ledger-phase-6-mvp-hardening-prd.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Release Notes: Phase 6 MVP Hardening Baseline

## Overview
Hardens the MVP across read-only enforcement, row-level security (RLS) coverage, audit/activity polish, responsive UX, and release documentation; closes multiple architecture and E2E hardening findings.

## Key Changes

### Architecture & Data Integrity
- Onboarding now runs inside the app unit-of-work and records `account.onboarding_completed` only when newly completed (includes actorId, occurredAt, and metadata.acknowledgedBoundaryNotice). Unit and integration tests verify idempotency and failure behavior.
- Documented cross-account relationship protection patterns (restrictive RLS vs composite foreign keys with account_id) and require RLS tests to validate protections.

### Read-Only Enforcement
- Read-only (paused) behavior enforced consistently:
  - tRPC routers return FORBIDDEN with message "This account is read-only."
  - Service-layer/command guards block writes for hand receipts, items, requirements, documents, and 2062 workflows.
  - UI hides/disables write controls and surfaces explanatory copy while preserving read capabilities.
- Added capability helper functions and broad integration/unit test coverage confirming write-blocking and continued read access where appropriate.

### Audit & Activity
- Onboarding audit event wired into unit-of-work and tested for recording and failure semantics.
- `hand_receipt.updated` audit metadata now includes the updated receipt name.
- Activity label formatter extended to produce readable labels for contacts, documents, and locations.
- Activity list accessibility improved (aria-label).

### UX / UI Improvements
- Dialogs: DialogContent gains scrollable prop for large forms; multiple dialogs updated to use it.
- Bottom-nav "More" sheet refactored into explicit "Records" and "Account" sections.
- Item upload and unavailable states: distinct ItemUnavailableReason handling for not-found, archived, and active-coverage.
- Requirements list: clearer empty/blocked copy, inline alert-style fetch-error panels with retry, and scrollable dialog content for several flows.
- Layout polishing: responsive button groups, truncation fixes (min-w-0), and other mobile/tablet refinements.

### Testing & E2E
- Expanded integration RLS/read-only tests across assignments-2062, documents, hand-receipts, items, and requirements to assert read vs write behavior and prevent cross-account writes.
- New and updated E2E specs:
  - tests/e2e/blocked-states.spec.ts — paused/read-only UX and behavior
  - tests/e2e/responsive-smoke.spec.ts — tablet responsive flows including 2062 upload
  - tests/e2e/items.spec.ts — stricter locators, coverage-check flow, dialog containment assertions
  - tests/e2e/app-shell.spec.ts — asserts “Records” and “Account” sections and onboarding state in Activity
- New Playwright helpers: expectDialogContained (dialog containment/scroll checks) and horizontal-overflow assertions used in responsive tests.
- Tests updated to run audit repositories within unit-of-work and to assert audit emission or absence on failures.

### Documentation
- README: clarifies tech stack (Better Auth separated), updates MVP baseline status, and local auth/setup guidance (service-role key note).
- Architecture, billing-capabilities, UI spec, testing guide, roadmap, and phase plans updated to reflect implemented behaviors, RLS strategy, and completed phase acceptance criteria.
- RLS test docs expanded with relationship-protection guidance and coverage matrix.

## Validation
Recommended validation commands used by the author:
- pnpm exec vitest run tests/integration/trpc/accounts-router.test.ts
- pnpm exec playwright test tests/e2e/items.spec.ts --grep "users can create and see an item requirement from item detail"
- pnpm verify
<!-- end of auto-generated comment: release notes by coderabbit.ai -->