### PR TITLE
[codex] Add privacy-safe in-app feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54331
 SUPABASE_SERVICE_ROLE_KEY=replace-with-local-service-role-key-from-supabase-status
 SUPABASE_STUDIO_URL=http://127.0.0.1:54333
 SUPABASE_INBUCKET_URL=http://127.0.0.1:54334
+
+# Optional: enables the in-app feedback button to file GitHub issues on
+# waffleflopper/field-ledger. The token needs issue write access.
+FIELD_LEDGER_GITHUB_TOKEN=replace-with-github-token

--- a/docs/adr/0002-provider-boundaries.md
+++ b/docs/adr/0002-provider-boundaries.md
@@ -22,9 +22,16 @@ Provider integrations must sit behind internal boundaries:
 - audit logging
 - notification
 - import/export
+- issue tracker feedback
 
 Domain modules and UI routes must call app-owned services/ports, not Better
 Auth, Supabase, or Stripe directly.
+
+In-app feedback may use GitHub Issues through an internal provider boundary.
+The feedback module sends only the user's feedback text and the current page
+URL. It must not publish account ids, auth provider ids, email addresses, or
+other private account metadata to GitHub, and the adapter must require an
+explicit Field Ledger token.
 
 ## Consequences
 
@@ -37,3 +44,4 @@ Auth, Supabase, or Stripe directly.
 
 - Direct Better Auth, Stripe, or Supabase calls from UI components.
 - A large fake billing simulation with invoices/webhooks/checkouts. MVP fake billing should stay minimal.
+- Falling back to generic GitHub tokens for an in-app write integration.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,7 @@ Required boundaries:
 - audit logger
 - notifications
 - import/export
+- issue tracker feedback
 
 Better Auth is the selected auth/session provider. Supabase Auth was used in
 the first Phase 1 implementation, but ADR 0005 replaces it as the intended auth
@@ -59,6 +60,12 @@ boundaries.
 The audit logger boundary is app-owned. Product modules emit meaningful events
 through audit application services and repository ports; routes, UI components,
 and future provider adapters must not insert audit records directly.
+
+The issue tracker feedback boundary is app-owned. In-app feedback may file
+triage issues through a GitHub provider adapter, but feedback bodies must not
+include account ids, auth provider ids, email addresses, document contents, or
+other private account metadata. The adapter must require an explicit
+Field-Ledger-specific token instead of falling back to generic runtime tokens.
 
 When a product workflow must persist domain state and audit history atomically,
 use the app-owned database unit-of-work boundary. The unit of work provides

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -68,6 +68,18 @@ local Supabase project can run at the same time.
    pnpm dev
    ```
 
+## Optional GitHub Feedback
+
+The protected app shell includes a feedback button that files GitHub issues on
+`waffleflopper/field-ledger` with the `needs-triage` and `feedback` labels.
+Set `FIELD_LEDGER_GITHUB_TOKEN` in `.env.local` with issue write access to
+enable it locally. A generic `GITHUB_TOKEN` is deliberately ignored so local
+tooling tokens are not reused by accident. Without the token, the app keeps
+running but feedback submissions return `Feedback is not configured.`
+
+Feedback issues include the submitted text and page URL only. They do not
+include account ids, auth provider ids, or email addresses.
+
 ## Drizzle Migrations
 
 Drizzle owns app schema and migrations.

--- a/src/components/shell/app-sidebar.tsx
+++ b/src/components/shell/app-sidebar.tsx
@@ -26,6 +26,7 @@ import {
   SidebarSeparator,
   SidebarTrigger,
 } from "@/components/ui/sidebar";
+import { FeedbackDialog } from "@/modules/feedback/ui/feedback-dialog";
 
 function SidebarNavItem({
   item,
@@ -110,6 +111,7 @@ export function AppSidebar() {
         </SidebarGroup>
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border">
+        <FeedbackDialog triggerClassName="h-8 w-full justify-start px-2 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:[&_span]:hidden" />
         <SidebarMenu>
           {footerNavItems.map((item) => (
             <SidebarNavItem item={item} key={item.href} pathname={pathname} />

--- a/src/components/shell/bottom-nav.tsx
+++ b/src/components/shell/bottom-nav.tsx
@@ -22,6 +22,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import { FeedbackDialog } from "@/modules/feedback/ui/feedback-dialog";
 
 function BottomNavLink({
   item,
@@ -125,6 +126,9 @@ export function BottomNav() {
             <div className="grid max-h-[70vh] gap-4 overflow-y-auto pr-1">
               <MoreSheetSection items={secondaryNavItems} title="Records" />
               <MoreSheetSection items={footerNavItems} title="Account" />
+              <div className="border-t pt-2">
+                <FeedbackDialog triggerClassName="h-10 w-full justify-start border border-border bg-card px-3" />
+              </div>
               <form
                 action="/auth/signout"
                 className="border-t pt-2"

--- a/src/modules/feedback/application/submit-feedback.ts
+++ b/src/modules/feedback/application/submit-feedback.ts
@@ -5,6 +5,11 @@ import type {
 
 const FEEDBACK_LABELS = ["needs-triage", "feedback"];
 const MAX_FEEDBACK_LENGTH = 5000;
+const EMAIL_PATTERN = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const UUID_PATTERN =
+  /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi;
+const FIELD_LEDGER_IDENTIFIER_PATTERN =
+  /\b(?:account|auth|auth-subject|provider|subject|user|owner)[-_][a-z0-9][a-z0-9_-]*\b/gi;
 
 export type SubmitFeedbackInput = {
   message: string;
@@ -17,6 +22,26 @@ function normalizeFeedbackMessage(message: string) {
   return message.trim();
 }
 
+function redactFeedbackText(text: string) {
+  return text
+    .replace(EMAIL_PATTERN, "[redacted email]")
+    .replace(UUID_PATTERN, "[redacted id]")
+    .replace(FIELD_LEDGER_IDENTIFIER_PATTERN, "[redacted id]");
+}
+
+function sanitizeFeedbackPageUrl(pageUrl: string | undefined) {
+  if (!pageUrl) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(pageUrl);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return undefined;
+  }
+}
+
 function buildFeedbackIssueBody({
   message,
   pageUrl,
@@ -24,15 +49,18 @@ function buildFeedbackIssueBody({
   message: string;
   pageUrl?: string;
 }) {
+  const redactedMessage = redactFeedbackText(message);
+  const safePageUrl = sanitizeFeedbackPageUrl(pageUrl);
+
   return [
     "## Feedback",
     "",
-    message,
+    redactedMessage,
     "",
     "## Filed from Field Ledger",
     "",
     "- Source: in-app feedback",
-    ...(pageUrl ? [`- Page: ${pageUrl}`] : []),
+    ...(safePageUrl ? [`- Page: ${safePageUrl}`] : []),
   ].join("\n");
 }
 

--- a/src/modules/feedback/application/submit-feedback.ts
+++ b/src/modules/feedback/application/submit-feedback.ts
@@ -1,0 +1,64 @@
+import type {
+  CreatedGitHubIssue,
+  GitHubIssuesPort,
+} from "@/modules/provider-boundaries/github/issues";
+
+const FEEDBACK_LABELS = ["needs-triage", "feedback"];
+const MAX_FEEDBACK_LENGTH = 5000;
+
+export type SubmitFeedbackInput = {
+  message: string;
+  pageUrl?: string;
+};
+
+export type SubmitFeedbackResult = CreatedGitHubIssue;
+
+function normalizeFeedbackMessage(message: string) {
+  return message.trim();
+}
+
+function buildFeedbackIssueBody({
+  message,
+  pageUrl,
+}: {
+  message: string;
+  pageUrl?: string;
+}) {
+  return [
+    "## Feedback",
+    "",
+    message,
+    "",
+    "## Filed from Field Ledger",
+    "",
+    "- Source: in-app feedback",
+    ...(pageUrl ? [`- Page: ${pageUrl}`] : []),
+  ].join("\n");
+}
+
+export async function submitFeedback({
+  feedbackPort,
+  input,
+}: {
+  feedbackPort: GitHubIssuesPort;
+  input: SubmitFeedbackInput;
+}): Promise<SubmitFeedbackResult> {
+  const message = normalizeFeedbackMessage(input.message);
+
+  if (!message) {
+    throw new Error("Feedback message is required.");
+  }
+
+  if (message.length > MAX_FEEDBACK_LENGTH) {
+    throw new Error("Feedback message must be 5,000 characters or fewer.");
+  }
+
+  return feedbackPort.createIssue({
+    body: buildFeedbackIssueBody({
+      message,
+      ...(input.pageUrl ? { pageUrl: input.pageUrl } : {}),
+    }),
+    labels: FEEDBACK_LABELS,
+    title: "Field Ledger feedback",
+  });
+}

--- a/src/modules/feedback/index.ts
+++ b/src/modules/feedback/index.ts
@@ -1,0 +1,4 @@
+export {
+  submitFeedback,
+  type SubmitFeedbackInput,
+} from "./application/submit-feedback";

--- a/src/modules/feedback/ui/feedback-dialog.tsx
+++ b/src/modules/feedback/ui/feedback-dialog.tsx
@@ -17,6 +17,10 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { trpc } from "@/trpc/react";
 
+function getFeedbackPageUrl() {
+  return `${window.location.origin}${window.location.pathname}`;
+}
+
 export function FeedbackDialog({
   triggerClassName,
   triggerLabel = "Feedback",
@@ -54,7 +58,7 @@ export function FeedbackDialog({
 
     submitFeedback.mutate({
       message: trimmedMessage,
-      pageUrl: window.location.href,
+      pageUrl: getFeedbackPageUrl(),
     });
   }
 

--- a/src/modules/feedback/ui/feedback-dialog.tsx
+++ b/src/modules/feedback/ui/feedback-dialog.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import { MessageSquare, Send } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { trpc } from "@/trpc/react";
+
+export function FeedbackDialog({
+  triggerClassName,
+  triggerLabel = "Feedback",
+}: {
+  triggerClassName?: string;
+  triggerLabel?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState("");
+  const [filedIssueUrl, setFiledIssueUrl] = useState<string | null>(null);
+  const submitFeedback = trpc.feedback.submit.useMutation({
+    onSuccess(issue) {
+      setFiledIssueUrl(issue.url);
+      setMessage("");
+    },
+  });
+  const trimmedMessage = message.trim();
+  const canSubmit = trimmedMessage.length > 0 && !submitFeedback.isPending;
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+
+    if (!nextOpen) {
+      submitFeedback.reset();
+      setFiledIssueUrl(null);
+    }
+  }
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!canSubmit) {
+      return;
+    }
+
+    submitFeedback.mutate({
+      message: trimmedMessage,
+      pageUrl: window.location.href,
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button
+          className={triggerClassName}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <MessageSquare aria-hidden="true" className="size-4" />
+          <span>{triggerLabel}</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <form className="grid gap-4" onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Send feedback</DialogTitle>
+            <DialogDescription>
+              Tell us what happened, what you expected, or what would make this
+              easier.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-2">
+            <Label htmlFor="feedback-message">Feedback</Label>
+            <Textarea
+              autoFocus
+              className="min-h-36 resize-y rounded-md bg-background"
+              id="feedback-message"
+              maxLength={5000}
+              onChange={(event) => setMessage(event.target.value)}
+              placeholder="Write the bug report, idea, or rough note here."
+              value={message}
+            />
+            <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span>
+                Filed as a GitHub issue with needs-triage and feedback labels.
+              </span>
+              <span className="font-mono">{message.length}/5000</span>
+            </div>
+          </div>
+          {submitFeedback.error ? (
+            <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {submitFeedback.error.message}
+            </p>
+          ) : null}
+          {filedIssueUrl ? (
+            <p className="rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
+              Feedback filed.{" "}
+              <a
+                className="font-medium text-primary underline-offset-4 hover:underline"
+                href={filedIssueUrl}
+                rel="noreferrer"
+                target="_blank"
+              >
+                View issue
+              </a>
+            </p>
+          ) : null}
+          <DialogFooter>
+            <Button disabled={!canSubmit} type="submit">
+              <Send aria-hidden="true" className="size-4" />
+              {submitFeedback.isPending ? "Sending" : "Submit"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/provider-boundaries/github/issues.ts
+++ b/src/modules/provider-boundaries/github/issues.ts
@@ -1,0 +1,93 @@
+export type CreateGitHubIssueInput = {
+  body: string;
+  labels: string[];
+  title: string;
+};
+
+export type CreatedGitHubIssue = {
+  number: number;
+  url: string;
+};
+
+export type GitHubIssuesPort = {
+  createIssue(input: CreateGitHubIssueInput): Promise<CreatedGitHubIssue>;
+};
+
+const FIELD_LEDGER_REPOSITORY = {
+  owner: "waffleflopper",
+  repo: "field-ledger",
+};
+
+function readGitHubToken() {
+  return process.env.FIELD_LEDGER_GITHUB_TOKEN;
+}
+
+function createUnavailableGitHubIssuesPort(): GitHubIssuesPort {
+  return {
+    async createIssue() {
+      throw new Error("A GitHub issue provider is required.");
+    },
+  };
+}
+
+export function createGitHubIssuesPortFromEnvironment(): GitHubIssuesPort {
+  const token = readGitHubToken();
+
+  if (!token) {
+    return createUnavailableGitHubIssuesPort();
+  }
+
+  return createGitHubIssuesPort({ token });
+}
+
+export function createGitHubIssuesPort({
+  token,
+}: {
+  token: string;
+}): GitHubIssuesPort {
+  return {
+    async createIssue(input) {
+      const response = await fetch(
+        `https://api.github.com/repos/${FIELD_LEDGER_REPOSITORY.owner}/${FIELD_LEDGER_REPOSITORY.repo}/issues`,
+        {
+          body: JSON.stringify({
+            title: input.title,
+            body: input.body,
+            labels: input.labels,
+          }),
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          method: "POST",
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`GitHub issue creation failed: ${response.status}`);
+      }
+
+      const data: unknown = await response.json();
+
+      if (
+        !data ||
+        typeof data !== "object" ||
+        !("number" in data) ||
+        !("html_url" in data) ||
+        typeof data.number !== "number" ||
+        typeof data.html_url !== "string"
+      ) {
+        throw new Error("GitHub returned an unexpected issue response.");
+      }
+
+      return {
+        number: data.number,
+        url: data.html_url,
+      };
+    },
+  };
+}
+
+export { createUnavailableGitHubIssuesPort };

--- a/src/modules/provider-boundaries/github/issues.ts
+++ b/src/modules/provider-boundaries/github/issues.ts
@@ -17,6 +17,7 @@ const FIELD_LEDGER_REPOSITORY = {
   owner: "waffleflopper",
   repo: "field-ledger",
 };
+const GITHUB_ISSUE_TIMEOUT_MS = 10_000;
 
 function readGitHubToken() {
   return process.env.FIELD_LEDGER_GITHUB_TOKEN;
@@ -42,50 +43,66 @@ export function createGitHubIssuesPortFromEnvironment(): GitHubIssuesPort {
 
 export function createGitHubIssuesPort({
   token,
+  timeoutMs = GITHUB_ISSUE_TIMEOUT_MS,
 }: {
   token: string;
+  timeoutMs?: number;
 }): GitHubIssuesPort {
   return {
     async createIssue(input) {
-      const response = await fetch(
-        `https://api.github.com/repos/${FIELD_LEDGER_REPOSITORY.owner}/${FIELD_LEDGER_REPOSITORY.repo}/issues`,
-        {
-          body: JSON.stringify({
-            title: input.title,
-            body: input.body,
-            labels: input.labels,
-          }),
-          headers: {
-            Accept: "application/vnd.github+json",
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-            "X-GitHub-Api-Version": "2022-11-28",
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+      try {
+        const response = await fetch(
+          `https://api.github.com/repos/${FIELD_LEDGER_REPOSITORY.owner}/${FIELD_LEDGER_REPOSITORY.repo}/issues`,
+          {
+            body: JSON.stringify({
+              title: input.title,
+              body: input.body,
+              labels: input.labels,
+            }),
+            headers: {
+              Accept: "application/vnd.github+json",
+              Authorization: `Bearer ${token}`,
+              "Content-Type": "application/json",
+              "X-GitHub-Api-Version": "2022-11-28",
+            },
+            method: "POST",
+            signal: controller.signal,
           },
-          method: "POST",
-        },
-      );
+        );
 
-      if (!response.ok) {
-        throw new Error(`GitHub issue creation failed: ${response.status}`);
+        if (!response.ok) {
+          throw new Error(`GitHub issue creation failed: ${response.status}`);
+        }
+
+        const data: unknown = await response.json();
+
+        if (
+          !data ||
+          typeof data !== "object" ||
+          !("number" in data) ||
+          !("html_url" in data) ||
+          typeof data.number !== "number" ||
+          typeof data.html_url !== "string"
+        ) {
+          throw new Error("GitHub returned an unexpected issue response.");
+        }
+
+        return {
+          number: data.number,
+          url: data.html_url,
+        };
+      } catch (error) {
+        if (controller.signal.aborted) {
+          throw new Error("GitHub issue creation timed out.");
+        }
+
+        throw error;
+      } finally {
+        clearTimeout(timeout);
       }
-
-      const data: unknown = await response.json();
-
-      if (
-        !data ||
-        typeof data !== "object" ||
-        !("number" in data) ||
-        !("html_url" in data) ||
-        typeof data.number !== "number" ||
-        typeof data.html_url !== "string"
-      ) {
-        throw new Error("GitHub returned an unexpected issue response.");
-      }
-
-      return {
-        number: data.number,
-        url: data.html_url,
-      };
     },
   };
 }

--- a/src/server/trpc/context.ts
+++ b/src/server/trpc/context.ts
@@ -58,6 +58,11 @@ import {
 } from "@/modules/provider-boundaries/database/app-unit-of-work";
 import { getDrizzleClient } from "@/modules/provider-boundaries/database/drizzle";
 import {
+  createGitHubIssuesPortFromEnvironment,
+  createUnavailableGitHubIssuesPort,
+  type GitHubIssuesPort,
+} from "@/modules/provider-boundaries/github/issues";
+import {
   createStoragePortFromEnvironment,
   createUnavailableStoragePort,
   type StoragePort,
@@ -75,6 +80,7 @@ export async function createTRPCContext(): Promise<{
   handReceiptRepository: HandReceiptRepository;
   itemRepository: ItemRepository;
   locationRepository: LocationRepository;
+  githubIssuesPort?: GitHubIssuesPort;
   requirementCompletionRepository?: RequirementCompletionRepository;
   requirementRepository: RequirementRepository;
   unitOfWork: AppUnitOfWork;
@@ -98,6 +104,7 @@ export async function createTRPCContext(): Promise<{
       handReceiptRepository: createUnavailableHandReceiptRepository(),
       itemRepository: createUnavailableItemRepository(),
       locationRepository: createUnavailableLocationRepository(),
+      githubIssuesPort: createUnavailableGitHubIssuesPort(),
       requirementCompletionRepository:
         createUnavailableRequirementCompletionRepository(),
       requirementRepository: createUnavailableRequirementRepository(),
@@ -142,6 +149,7 @@ export async function createTRPCContext(): Promise<{
     locationRepository: createDrizzleLocationRepository(db, {
       authSubject: session.userId,
     }),
+    githubIssuesPort: createGitHubIssuesPortFromEnvironment(),
     requirementCompletionRepository:
       createDrizzleRequirementCompletionRepository(db, {
         authSubject: session.userId,

--- a/src/server/trpc/init.ts
+++ b/src/server/trpc/init.ts
@@ -12,6 +12,7 @@ import {
 } from "@/modules/requirements";
 import { createUnavailableDocumentRepository } from "@/modules/documents";
 import { createUnavailableStoragePort } from "@/modules/provider-boundaries/storage";
+import { createUnavailableGitHubIssuesPort } from "@/modules/provider-boundaries/github/issues";
 import type { TRPCContext } from "@/server/trpc/context";
 
 const t = initTRPC.context<TRPCContext>().create({
@@ -45,6 +46,8 @@ export const protectedProcedure = t.procedure.use(({ ctx, next }) => {
       handReceiptRepository: ctx.handReceiptRepository,
       itemRepository: ctx.itemRepository,
       locationRepository: ctx.locationRepository,
+      githubIssuesPort:
+        ctx.githubIssuesPort ?? createUnavailableGitHubIssuesPort(),
       requirementCompletionRepository:
         ctx.requirementCompletionRepository ??
         createUnavailableRequirementCompletionRepository(),

--- a/src/server/trpc/router.ts
+++ b/src/server/trpc/router.ts
@@ -5,6 +5,7 @@ import { auditRouter } from "@/server/trpc/routers/audit";
 import { billingRouter } from "@/server/trpc/routers/billing";
 import { contactsRouter } from "@/server/trpc/routers/contacts";
 import { documentsRouter } from "@/server/trpc/routers/documents";
+import { feedbackRouter } from "@/server/trpc/routers/feedback";
 import { foundationRouter } from "@/server/trpc/routers/foundation";
 import { handReceiptsRouter } from "@/server/trpc/routers/hand-receipts";
 import { itemsRouter } from "@/server/trpc/routers/items";
@@ -18,6 +19,7 @@ export const appRouter = createTRPCRouter({
   billing: billingRouter,
   contacts: contactsRouter,
   documents: documentsRouter,
+  feedback: feedbackRouter,
   foundation: foundationRouter,
   handReceipts: handReceiptsRouter,
   items: itemsRouter,

--- a/src/server/trpc/routers/feedback.ts
+++ b/src/server/trpc/routers/feedback.ts
@@ -1,0 +1,62 @@
+import { TRPCError } from "@trpc/server";
+import { z } from "zod";
+
+import { submitFeedback } from "@/modules/feedback";
+import { createTRPCRouter, protectedProcedure } from "@/server/trpc/init";
+
+const submitFeedbackInput = z.object({
+  message: z.string().trim().min(1, "Feedback message is required.").max(5000),
+  pageUrl: z.url().optional(),
+});
+
+function toTRPCError(
+  error: unknown,
+  context: { accountId: string; operation: string; userId: string },
+): never {
+  const message =
+    error instanceof Error ? error.message : "Unable to send feedback.";
+
+  switch (message) {
+    case "Feedback message is required.":
+    case "Feedback message must be 5,000 characters or fewer.":
+      throw new TRPCError({ code: "BAD_REQUEST", message });
+    case "A GitHub issue provider is required.":
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Feedback is not configured.",
+      });
+    default:
+      console.error("Unexpected feedback tRPC error.", {
+        accountId: context.accountId,
+        operation: context.operation,
+        userId: context.userId,
+        error,
+      });
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Unable to send feedback.",
+      });
+  }
+}
+
+export const feedbackRouter = createTRPCRouter({
+  submit: protectedProcedure
+    .input(submitFeedbackInput)
+    .mutation(async ({ ctx, input }) => {
+      try {
+        return await submitFeedback({
+          feedbackPort: ctx.githubIssuesPort,
+          input: {
+            message: input.message,
+            ...(input.pageUrl ? { pageUrl: input.pageUrl } : {}),
+          },
+        });
+      } catch (error) {
+        toTRPCError(error, {
+          accountId: ctx.account.id,
+          operation: "feedback.submit",
+          userId: ctx.session.userId,
+        });
+      }
+    }),
+});

--- a/tests/integration/trpc/feedback-router.test.ts
+++ b/tests/integration/trpc/feedback-router.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AccountRecord } from "@/modules/accounts/application/ensure-account";
+import type { GitHubIssuesPort } from "@/modules/provider-boundaries/github/issues";
+import { appRouter } from "@/server/trpc/router";
+import { InMemoryAccountRepository } from "../../support/account-repository";
+import { createEmptyAuditRepository } from "../../support/audit-repository";
+import { createInMemoryAppUnitOfWork } from "../../support/app-unit-of-work";
+import { createEmptyContactRepository } from "../../support/contact-repository";
+import { createEmptyHandReceiptRepository } from "../../support/hand-receipt-repository";
+import { createEmptyItemRepository } from "../../support/item-repository";
+import { createEmptyLocationRepository } from "../../support/location-repository";
+import { createEmptyRequirementRepository } from "../../support/requirement-repository";
+
+function createAccount(overrides: Partial<AccountRecord> = {}): AccountRecord {
+  return {
+    id: "account-1",
+    userId: "owner-1",
+    accessState: "active",
+    subscriptionTier: "base",
+    trialStartsAt: new Date("2026-04-01T12:00:00.000Z"),
+    trialEndsAt: new Date("2100-01-01T00:00:00.000Z"),
+    onboardingCompletedAt: null,
+    ...overrides,
+  };
+}
+
+function createFeedbackPort(): GitHubIssuesPort & {
+  createIssue: ReturnType<typeof vi.fn<GitHubIssuesPort["createIssue"]>>;
+} {
+  return {
+    createIssue: vi.fn(async () => ({
+      number: 42,
+      url: "https://github.com/waffleflopper/field-ledger/issues/42",
+    })),
+  };
+}
+
+function createCaller({
+  feedbackPort = createFeedbackPort(),
+}: {
+  feedbackPort?: GitHubIssuesPort;
+} = {}) {
+  const account = createAccount();
+  const accountRepository = new InMemoryAccountRepository([account]);
+
+  return appRouter.createCaller({
+    session: {
+      userId: account.userId,
+      email: "owner@example.com",
+    },
+    account,
+    accountRepository,
+    auditRepository: createEmptyAuditRepository(),
+    contactRepository: createEmptyContactRepository(),
+    githubIssuesPort: feedbackPort,
+    handReceiptRepository: createEmptyHandReceiptRepository(),
+    itemRepository: createEmptyItemRepository(),
+    locationRepository: createEmptyLocationRepository(),
+    requirementRepository: createEmptyRequirementRepository(),
+    unitOfWork: createInMemoryAppUnitOfWork({
+      accountRepository,
+    }),
+  });
+}
+
+describe("feedbackRouter", () => {
+  it("submits feedback through the GitHub issue provider", async () => {
+    const feedbackPort = createFeedbackPort();
+    const caller = createCaller({ feedbackPort });
+
+    await expect(
+      caller.feedback.submit({
+        message: "The dashboard count looked wrong.",
+        pageUrl: "https://field-ledger.test/app/dashboard",
+      }),
+    ).resolves.toEqual({
+      number: 42,
+      url: "https://github.com/waffleflopper/field-ledger/issues/42",
+    });
+
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: ["needs-triage", "feedback"],
+        title: "Field Ledger feedback",
+      }),
+    );
+  });
+
+  it("maps missing GitHub configuration to a setup error", async () => {
+    const caller = createCaller({
+      feedbackPort: {
+        async createIssue() {
+          throw new Error("A GitHub issue provider is required.");
+        },
+      },
+    });
+
+    await expect(
+      caller.feedback.submit({
+        message: "Nothing happens when I tap archive.",
+      }),
+    ).rejects.toMatchObject({
+      code: "PRECONDITION_FAILED",
+      message: "Feedback is not configured.",
+    });
+  });
+});

--- a/tests/unit/feedback/submit-feedback.test.ts
+++ b/tests/unit/feedback/submit-feedback.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { submitFeedback } from "@/modules/feedback";
+import type { GitHubIssuesPort } from "@/modules/provider-boundaries/github/issues";
+
+function createFeedbackPort(): GitHubIssuesPort & {
+  createIssue: ReturnType<typeof vi.fn<GitHubIssuesPort["createIssue"]>>;
+} {
+  return {
+    createIssue: vi.fn(async () => ({
+      number: 42,
+      url: "https://github.com/waffleflopper/field-ledger/issues/42",
+    })),
+  };
+}
+
+describe("submitFeedback", () => {
+  it("files feedback as a triage GitHub issue", async () => {
+    const feedbackPort = createFeedbackPort();
+
+    await expect(
+      submitFeedback({
+        feedbackPort,
+        input: {
+          message: "The item page save button got stuck.",
+          pageUrl: "https://field-ledger.test/app/items/item-1",
+        },
+      }),
+    ).resolves.toEqual({
+      number: 42,
+      url: "https://github.com/waffleflopper/field-ledger/issues/42",
+    });
+
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith({
+      title: "Field Ledger feedback",
+      labels: ["needs-triage", "feedback"],
+      body: expect.stringContaining("The item page save button got stuck."),
+    });
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "Page: https://field-ledger.test/app/items/item-1",
+        ),
+      }),
+    );
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining("owner@example.com"),
+      }),
+    );
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining("account-1"),
+      }),
+    );
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining("owner-1"),
+      }),
+    );
+  });
+
+  it("rejects empty feedback", async () => {
+    const feedbackPort = createFeedbackPort();
+
+    await expect(
+      submitFeedback({
+        feedbackPort,
+        input: { message: "   " },
+      }),
+    ).rejects.toThrow("Feedback message is required.");
+    expect(feedbackPort.createIssue).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/feedback/submit-feedback.test.ts
+++ b/tests/unit/feedback/submit-feedback.test.ts
@@ -60,6 +60,77 @@ describe("submitFeedback", () => {
     );
   });
 
+  it("strips query strings and hashes from the filed page URL", async () => {
+    const feedbackPort = createFeedbackPort();
+
+    await submitFeedback({
+      feedbackPort,
+      input: {
+        message: "The dashboard count looked wrong.",
+        pageUrl:
+          "https://field-ledger.test/app/dashboard?token=secret#private-note",
+      },
+    });
+
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "Page: https://field-ledger.test/app/dashboard",
+        ),
+      }),
+    );
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining("token=secret"),
+      }),
+    );
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining("private-note"),
+      }),
+    );
+  });
+
+  it("redacts sensitive identifiers from feedback text", async () => {
+    const feedbackPort = createFeedbackPort();
+
+    await submitFeedback({
+      feedbackPort,
+      input: {
+        message:
+          "owner@example.com hit an error on account-1 for auth-subject_abc and 123e4567-e89b-12d3-a456-426614174000.",
+      },
+    });
+
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining("[redacted email]"),
+      }),
+    );
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining("owner@example.com"),
+      }),
+    );
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining("account-1"),
+      }),
+    );
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining("auth-subject_abc"),
+      }),
+    );
+    expect(feedbackPort.createIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.not.stringContaining(
+          "123e4567-e89b-12d3-a456-426614174000",
+        ),
+      }),
+    );
+  });
+
   it("rejects empty feedback", async () => {
     const feedbackPort = createFeedbackPort();
 

--- a/tests/unit/provider-boundaries/github-issues.test.ts
+++ b/tests/unit/provider-boundaries/github-issues.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createGitHubIssuesPort } from "@/modules/provider-boundaries/github/issues";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("createGitHubIssuesPort", () => {
+  it("creates a GitHub issue through the configured repository endpoint", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          html_url: "https://github.com/waffleflopper/field-ledger/issues/42",
+          number: 42,
+        }),
+        { status: 201 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const port = createGitHubIssuesPort({ token: "field-ledger-token" });
+
+    await expect(
+      port.createIssue({
+        body: "Feedback body",
+        labels: ["needs-triage", "feedback"],
+        title: "Field Ledger feedback",
+      }),
+    ).resolves.toEqual({
+      number: 42,
+      url: "https://github.com/waffleflopper/field-ledger/issues/42",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/waffleflopper/field-ledger/issues",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer field-ledger-token",
+        }),
+        method: "POST",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("times out slow GitHub issue creation requests", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(
+      (_url: string | URL | Request, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const port = createGitHubIssuesPort({
+      timeoutMs: 25,
+      token: "field-ledger-token",
+    });
+    const createIssue = port.createIssue({
+      body: "Feedback body",
+      labels: ["needs-triage", "feedback"],
+      title: "Field Ledger feedback",
+    });
+    const expectation = expect(createIssue).rejects.toThrow(
+      "GitHub issue creation timed out.",
+    );
+
+    await vi.advanceTimersByTimeAsync(25);
+    await expectation;
+  });
+});


### PR DESCRIPTION
## Summary

- add an in-app feedback dialog in the authenticated shell that files GitHub issues through a provider boundary
- keep feedback issue bodies privacy-safe by excluding account ids, auth provider ids, and email addresses
- require the explicit `FIELD_LEDGER_GITHUB_TOKEN` for GitHub issue creation and document the feedback boundary

## Validation

- `pnpm test tests/unit/feedback/submit-feedback.test.ts tests/integration/trpc/feedback-router.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Release Notes: Privacy-Safe In-App Feedback

## ✨ New Features

### In-App Feedback Dialog
- Added a feedback dialog accessible from the authenticated app shell (sidebar footer and bottom navigation menu)
- Users can submit feedback directly from the application, which creates GitHub issues for triage
- Dialog provides real-time feedback on submission status and displays the created issue link

### Privacy-Safe Implementation
- Feedback issue bodies include only the user's message and current page URL
- Automatically excludes sensitive account metadata (account IDs, auth provider IDs, email addresses) from GitHub issues
- Requires explicit `FIELD_LEDGER_GITHUB_TOKEN` environment variable—generic GitHub tokens are ignored
- Issues are filed to the `waffleflopper/field-ledger` repository with `needs-triage` and `feedback` labels

## 🔧 Configuration

### Environment Variable
Add the following optional configuration to `.env.example` and your local environment:

```
FIELD_LEDGER_GITHUB_TOKEN=<token>  # Enables in-app feedback; requires GitHub issue write access
```

Without this token, the feedback feature is unavailable but does not break the application.

## 📚 Documentation

Updated architecture documentation to define the new "issue tracker feedback" provider boundary, including:
- Privacy constraints on feedback data (no account/auth metadata)
- GitHub token requirements (Field Ledger-specific, not generic)
- Integration details and local development setup

## 🏗️ Technical Details

- **Application Layer**: `submitFeedback` validates message length (1–5000 characters) and constructs privacy-safe GitHub issue bodies
- **Provider Boundary**: `GitHubIssuesPort` abstraction with environment-based initialization
- **tRPC Integration**: Protected `feedback.submit` mutation with Zod input validation and error mapping
- **Comprehensive Tests**: Unit and integration test coverage for feedback submission and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->