### PR TITLE
Replace billing and settings placeholders

### DIFF
--- a/docs/billing-capabilities.md
+++ b/docs/billing-capabilities.md
@@ -39,6 +39,25 @@ UI workflows should use the typed tRPC boundary, currently
 `billing.capabilities`, so client code does not need to know how access state or
 tier data is stored.
 
+`billing.status` is the display query for `/app/billing`. It returns the same
+capability result plus the account trial window so the UI can explain the
+current state without duplicating capability rules or reading billing storage
+directly. `billing.capabilities` remains the enforcement query for operational
+feature gating.
+
+## MVP Account Surfaces
+
+`/app/billing` is a read-only account-access surface. It shows the current access
+state, subscription tier when present, active/read-only trial status, and hand
+receipt capability context. It must not add Stripe checkout, invoices, customer
+portal links, webhooks, or fake billing automation.
+
+`/app/settings` exposes the signed-in owner email, access/read-only state,
+session sign-out, and product-boundary messaging. The settings surface reminds
+users that Field Ledger is personal property-accountability assistance, not an
+official Army system of record, and that classified information, PHI, and
+sensitive operational details do not belong in the app.
+
 ## Read-Only Enforcement Pattern
 
 Read-only behavior is enforced in three layers:

--- a/src/app/(protected)/app/billing/page.tsx
+++ b/src/app/(protected)/app/billing/page.tsx
@@ -1,14 +1,27 @@
-import { CreditCard } from "lucide-react";
+import { BillingStatus } from "@/modules/billing";
+import { createTRPCContext } from "@/server/trpc/context";
+import { appRouter } from "@/server/trpc/router";
 
-import { PlaceholderPage } from "@/components/shell/placeholder-page";
+export default async function BillingPage() {
+  const caller = appRouter.createCaller(await createTRPCContext());
+  const status = await caller.billing.status();
 
-export default function BillingPage() {
   return (
-    <PlaceholderPage
-      description="Billing will expose subscription status and plan capability context through the app-owned billing boundary."
-      icon={CreditCard}
-      sections={["Subscription status", "Plan capability", "Read-only states"]}
-      title="Billing"
-    />
+    <section className="space-y-6">
+      <div className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+          Account access
+        </p>
+        <h1 className="text-2xl font-semibold tracking-normal md:text-3xl">
+          Billing
+        </h1>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          Review your MVP access state, plan capability, and read-only status.
+          Billing actions are not connected to Stripe yet.
+        </p>
+      </div>
+
+      <BillingStatus {...status} />
+    </section>
   );
 }

--- a/src/app/(protected)/app/settings/page.tsx
+++ b/src/app/(protected)/app/settings/page.tsx
@@ -1,18 +1,27 @@
-import { Settings } from "lucide-react";
+import { SettingsPanel } from "@/modules/accounts";
+import { createTRPCContext } from "@/server/trpc/context";
+import { appRouter } from "@/server/trpc/router";
 
-import { PlaceholderPage } from "@/components/shell/placeholder-page";
+export default async function SettingsPage() {
+  const caller = appRouter.createCaller(await createTRPCContext());
+  const account = await caller.accounts.me();
 
-export default function SettingsPage() {
   return (
-    <PlaceholderPage
-      description="Settings will contain account preferences and compliance-facing product boundaries for the individual owner account."
-      icon={Settings}
-      sections={[
-        "Account preferences",
-        "Product boundaries",
-        "Session actions",
-      ]}
-      title="Settings"
-    />
+    <section className="space-y-6">
+      <div className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+          Owner account
+        </p>
+        <h1 className="text-2xl font-semibold tracking-normal md:text-3xl">
+          Settings
+        </h1>
+        <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+          Review your session and the product boundaries that keep Field Ledger
+          personal, accountable, and separate from official recordkeeping.
+        </p>
+      </div>
+
+      <SettingsPanel {...account} />
+    </section>
   );
 }

--- a/src/modules/accounts/application/ensure-account.ts
+++ b/src/modules/accounts/application/ensure-account.ts
@@ -108,6 +108,20 @@ export function getOnboardingStatus({
   };
 }
 
+export function getAccountSessionSummary({
+  account,
+  email,
+  now = new Date(),
+}: GetOnboardingStatusInput & { email: string | null }) {
+  const capabilities = deriveAccountCapabilities(account, now);
+
+  return {
+    email,
+    accessState: capabilities.accessState,
+    isReadOnly: capabilities.isReadOnly,
+  };
+}
+
 export async function completeOnboarding({
   account,
   repository,

--- a/src/modules/accounts/index.ts
+++ b/src/modules/accounts/index.ts
@@ -1,0 +1,13 @@
+export {
+  completeOnboarding,
+  ensureAccount,
+  getAccountSessionSummary,
+  getOnboardingStatus,
+} from "@/modules/accounts/application/ensure-account";
+export { SettingsPanel } from "@/modules/accounts/ui/settings-panel";
+export type {
+  AccessState,
+  AccountRecord,
+  AccountRepository,
+  SubscriptionTier,
+} from "@/modules/accounts/application/ensure-account";

--- a/src/modules/accounts/ui/settings-panel.tsx
+++ b/src/modules/accounts/ui/settings-panel.tsx
@@ -1,0 +1,130 @@
+import { AlertTriangle, LogOut, ShieldCheck, UserRound } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import type { AccessState } from "@/modules/accounts/application/ensure-account";
+
+type SettingsPanelProps = {
+  email: string | null;
+  accessState: AccessState;
+  isReadOnly: boolean;
+};
+
+const accessStateLabels: Record<AccessState, string> = {
+  active: "Active",
+  paused_read_only: "Read-only",
+  trialing: "Trialing",
+};
+
+export function SettingsPanel({
+  accessState,
+  email,
+  isReadOnly,
+}: SettingsPanelProps) {
+  return (
+    <div className="space-y-4">
+      {isReadOnly ? (
+        <div className="flex gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-destructive">
+          <AlertTriangle
+            aria-hidden="true"
+            className="mt-0.5 size-4 shrink-0"
+          />
+          <p className="text-sm leading-6 text-foreground">
+            Your account is read-only. You can still review existing property
+            records, but new changes are unavailable until access is restored.
+          </p>
+        </div>
+      ) : null}
+
+      <section className="grid gap-3 lg:grid-cols-[1.2fr_0.8fr]">
+        <article className="rounded-lg border bg-card p-4 text-card-foreground">
+          <div className="flex items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+              <UserRound aria-hidden="true" className="size-4" />
+            </span>
+            <div className="min-w-0 space-y-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                  Owner account
+                </p>
+                <h2 className="mt-1 break-words text-lg font-semibold tracking-normal">
+                  {email ?? "No email on session"}
+                </h2>
+              </div>
+              <dl className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-md bg-muted/70 p-3">
+                  <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                    Access state
+                  </dt>
+                  <dd className="mt-1 text-sm font-semibold">
+                    {accessStateLabels[accessState]}
+                  </dd>
+                </div>
+                <div className="rounded-md bg-muted/70 p-3">
+                  <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                    Account shape
+                  </dt>
+                  <dd className="mt-1 text-sm font-semibold">
+                    One owner account
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        </article>
+
+        <article className="rounded-lg border bg-card p-4 text-card-foreground">
+          <div className="flex items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+              <LogOut aria-hidden="true" className="size-4" />
+            </span>
+            <div className="space-y-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                  Session
+                </p>
+                <h2 className="mt-1 text-lg font-semibold tracking-normal">
+                  Signed in
+                </h2>
+              </div>
+              <form action="/auth/signout" method="post">
+                <Button type="submit" variant="outline">
+                  <LogOut aria-hidden="true" data-icon="inline-start" />
+                  Sign out
+                </Button>
+              </form>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section className="rounded-lg border bg-card p-4 text-card-foreground">
+        <div className="flex items-start gap-3">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+            <ShieldCheck aria-hidden="true" className="size-4" />
+          </span>
+          <div className="space-y-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                Product boundaries
+              </p>
+              <h2 className="mt-1 text-lg font-semibold tracking-normal">
+                Personal property-accountability assistance
+              </h2>
+            </div>
+            <ul className="space-y-2 text-sm leading-6 text-muted-foreground">
+              <li>Field Ledger is not an official Army system of record.</li>
+              <li>
+                Do not store classified information, PHI, or sensitive
+                operational details.
+              </li>
+              <li>
+                Field Ledger is for one owner account, not a team, unit, or
+                organization workspace.
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/modules/billing/application/billing-status-display.ts
+++ b/src/modules/billing/application/billing-status-display.ts
@@ -1,0 +1,106 @@
+import type {
+  AccessState,
+  SubscriptionTier,
+} from "@/modules/billing/application/types";
+
+export type BillingStatusDisplayInput = {
+  accessState: AccessState;
+  subscriptionTier: SubscriptionTier | null;
+  isReadOnly: boolean;
+  activeHandReceiptLimit: number | null;
+  trialEndsAt: Date;
+};
+
+export function getBillingStatusDisplay(
+  status: BillingStatusDisplayInput,
+  now = new Date(),
+) {
+  const planLabel = getPlanLabel(status);
+
+  return {
+    planLabel,
+    stateLabel: getStateLabel(status),
+    stateDescription: getStateDescription(status),
+    accessWindowLabel: getAccessWindowLabel(status, now),
+    handReceiptLimitLabel: getHandReceiptLimitLabel(status),
+  };
+}
+
+function getPlanLabel(status: BillingStatusDisplayInput) {
+  if (status.accessState === "trialing" && !status.subscriptionTier) {
+    return "Trial access";
+  }
+
+  if (status.subscriptionTier === "base") {
+    return "Base";
+  }
+
+  if (status.subscriptionTier === "pro") {
+    return "Pro";
+  }
+
+  return "No active plan";
+}
+
+function getStateLabel(status: BillingStatusDisplayInput) {
+  if (status.isReadOnly || status.accessState === "paused_read_only") {
+    return "Read-only";
+  }
+
+  if (status.accessState === "trialing") {
+    return "Trial active";
+  }
+
+  return "Active";
+}
+
+function getStateDescription(status: BillingStatusDisplayInput) {
+  if (status.isReadOnly || status.accessState === "paused_read_only") {
+    return "You can review existing records, documents, activity, and 2062 history. New accountable-record work waits until access is restored.";
+  }
+
+  if (status.accessState === "trialing") {
+    return "Your trial has Pro-like access while it is active.";
+  }
+
+  return "Your account can continue normal property-accountability work.";
+}
+
+function getAccessWindowLabel(status: BillingStatusDisplayInput, now: Date) {
+  if (status.accessState !== "trialing") {
+    return "Plan-backed access";
+  }
+
+  if (status.trialEndsAt <= now || status.isReadOnly) {
+    return `Trial ended ${formatDisplayDate(status.trialEndsAt)}`;
+  }
+
+  const daysRemaining = Math.max(
+    1,
+    Math.ceil(
+      (status.trialEndsAt.getTime() - now.getTime()) / (24 * 60 * 60 * 1000),
+    ),
+  );
+
+  return `${daysRemaining} day${daysRemaining === 1 ? "" : "s"} left in trial`;
+}
+
+function getHandReceiptLimitLabel(status: BillingStatusDisplayInput) {
+  if (status.activeHandReceiptLimit === null) {
+    return "Unlimited active hand receipts";
+  }
+
+  if (status.activeHandReceiptLimit === 0) {
+    return "New hand receipts unavailable in read-only mode";
+  }
+
+  return `${status.activeHandReceiptLimit} active hand receipts`;
+}
+
+export function formatDisplayDate(date: Date) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}

--- a/src/modules/billing/index.ts
+++ b/src/modules/billing/index.ts
@@ -12,6 +12,12 @@ export {
   isAccountReadOnly,
 } from "@/modules/billing/application/capabilities";
 export { deriveAccountCapabilities } from "@/modules/billing/application/derive-account-capabilities";
+export {
+  formatDisplayDate,
+  getBillingStatusDisplay,
+} from "@/modules/billing/application/billing-status-display";
+export { BillingStatus } from "@/modules/billing/ui/billing-status";
+export type { BillingStatusDisplayInput } from "@/modules/billing/application/billing-status-display";
 export type {
   AccountAccessData,
   AccountCapabilities,

--- a/src/modules/billing/ui/billing-status.tsx
+++ b/src/modules/billing/ui/billing-status.tsx
@@ -1,0 +1,117 @@
+import {
+  AlertTriangle,
+  CreditCard,
+  LockKeyhole,
+  ReceiptText,
+} from "lucide-react";
+
+import {
+  getBillingStatusDisplay,
+  type BillingStatusDisplayInput,
+} from "@/modules/billing/application/billing-status-display";
+
+type BillingStatusProps = BillingStatusDisplayInput & {
+  trialStartsAt: Date;
+};
+
+export function BillingStatus(status: BillingStatusProps) {
+  const display = getBillingStatusDisplay(status);
+
+  return (
+    <div className="space-y-4">
+      {status.isReadOnly ? (
+        <div className="flex gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-destructive">
+          <LockKeyhole aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+          <div className="space-y-1">
+            <h2 className="text-sm font-semibold tracking-normal">
+              Account is read-only
+            </h2>
+            <p className="text-sm leading-6 text-foreground">
+              {display.stateDescription}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      <section className="grid gap-3 lg:grid-cols-[1.3fr_1fr]">
+        <article className="rounded-lg border bg-card p-4 text-card-foreground">
+          <div className="flex items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+              <CreditCard aria-hidden="true" className="size-4" />
+            </span>
+            <div className="min-w-0 space-y-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                  Current access
+                </p>
+                <h2 className="mt-1 text-lg font-semibold tracking-normal">
+                  {display.stateLabel}
+                </h2>
+              </div>
+              <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+                {display.stateDescription}
+              </p>
+              <dl className="grid gap-3 sm:grid-cols-2">
+                <div className="rounded-md bg-muted/70 p-3">
+                  <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                    Plan
+                  </dt>
+                  <dd className="mt-1 text-sm font-semibold">
+                    {display.planLabel}
+                  </dd>
+                </div>
+                <div className="rounded-md bg-muted/70 p-3">
+                  <dt className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                    Access window
+                  </dt>
+                  <dd className="mt-1 text-sm font-semibold">
+                    {display.accessWindowLabel}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        </article>
+
+        <article className="rounded-lg border bg-card p-4 text-card-foreground">
+          <div className="flex items-start gap-3">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-secondary text-primary">
+              <ReceiptText aria-hidden="true" className="size-4" />
+            </span>
+            <div className="space-y-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+                  Hand receipt capability
+                </p>
+                <h2 className="mt-1 text-lg font-semibold tracking-normal">
+                  {display.handReceiptLimitLabel}
+                </h2>
+              </div>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Base allows up to 3 active hand receipts. Pro and active trial
+                access are unlimited for MVP account work.
+              </p>
+            </div>
+          </div>
+        </article>
+      </section>
+
+      <section className="flex gap-3 rounded-lg border bg-muted/60 p-4">
+        <AlertTriangle
+          aria-hidden="true"
+          className="mt-0.5 size-4 shrink-0 text-amber-700"
+        />
+        <div className="space-y-1">
+          <h2 className="text-sm font-semibold tracking-normal">
+            Billing management coming soon
+          </h2>
+          <p className="text-sm leading-6 text-muted-foreground">
+            This page is read-only status context. Field Ledger does not have
+            Stripe checkout, invoices, customer portal, or webhook behavior in
+            this MVP slice.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/server/trpc/routers/accounts.ts
+++ b/src/server/trpc/routers/accounts.ts
@@ -1,10 +1,17 @@
 import {
   completeOnboarding,
+  getAccountSessionSummary,
   getOnboardingStatus,
 } from "@/modules/accounts/application/ensure-account";
 import { createTRPCRouter, protectedProcedure } from "@/server/trpc/init";
 
 export const accountsRouter = createTRPCRouter({
+  me: protectedProcedure.query(({ ctx }) =>
+    getAccountSessionSummary({
+      account: ctx.account,
+      email: ctx.session.email,
+    }),
+  ),
   getOnboardingStatus: protectedProcedure.query(({ ctx }) =>
     getOnboardingStatus({ account: ctx.account }),
   ),

--- a/src/server/trpc/routers/billing.ts
+++ b/src/server/trpc/routers/billing.ts
@@ -5,4 +5,9 @@ export const billingRouter = createTRPCRouter({
   capabilities: protectedProcedure.query(({ ctx }) =>
     deriveAccountCapabilities(ctx.account),
   ),
+  status: protectedProcedure.query(({ ctx }) => ({
+    ...deriveAccountCapabilities(ctx.account),
+    trialStartsAt: ctx.account.trialStartsAt,
+    trialEndsAt: ctx.account.trialEndsAt,
+  })),
 });

--- a/tests/integration/trpc/accounts-router.test.ts
+++ b/tests/integration/trpc/accounts-router.test.ts
@@ -56,6 +56,12 @@ describe("accountsRouter", () => {
       isReadOnly: false,
     });
 
+    await expect(caller.accounts.me()).resolves.toEqual({
+      email: "owner@example.com",
+      accessState: "active",
+      isReadOnly: false,
+    });
+
     await expect(caller.accounts.completeOnboarding()).resolves.toMatchObject({
       completed: true,
       accessState: "active",

--- a/tests/integration/trpc/billing-router.test.ts
+++ b/tests/integration/trpc/billing-router.test.ts
@@ -41,5 +41,13 @@ describe("billingRouter", () => {
       activeHandReceiptLimit: 3,
       subscriptionTier: "base",
     });
+
+    await expect(caller.billing.status()).resolves.toMatchObject({
+      isReadOnly: false,
+      activeHandReceiptLimit: 3,
+      subscriptionTier: "base",
+      trialStartsAt: expect.any(Date),
+      trialEndsAt: expect.any(Date),
+    });
   });
 });

--- a/tests/unit/billing/billing-status-display.test.ts
+++ b/tests/unit/billing/billing-status-display.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getBillingStatusDisplay,
+  type BillingStatusDisplayInput,
+} from "@/modules/billing";
+
+const now = new Date("2026-05-05T12:00:00.000Z");
+
+function createStatus(
+  overrides: Partial<BillingStatusDisplayInput> = {},
+): BillingStatusDisplayInput {
+  return {
+    accessState: "trialing",
+    subscriptionTier: null,
+    isReadOnly: false,
+    activeHandReceiptLimit: null,
+    trialEndsAt: new Date("2026-05-15T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("getBillingStatusDisplay", () => {
+  it("describes an active trial as Pro-like with unlimited hand receipts", () => {
+    const display = getBillingStatusDisplay(createStatus(), now);
+
+    expect(display).toMatchObject({
+      planLabel: "Trial access",
+      stateLabel: "Trial active",
+      accessWindowLabel: "10 days left in trial",
+      handReceiptLimitLabel: "Unlimited active hand receipts",
+    });
+  });
+
+  it("describes an expired trial as read-only", () => {
+    const display = getBillingStatusDisplay(
+      createStatus({
+        accessState: "trialing",
+        isReadOnly: true,
+        activeHandReceiptLimit: 0,
+        trialEndsAt: new Date("2026-05-01T12:00:00.000Z"),
+      }),
+      now,
+    );
+
+    expect(display.stateLabel).toBe("Read-only");
+    expect(display.accessWindowLabel).toBe("Trial ended May 1, 2026");
+    expect(display.handReceiptLimitLabel).toBe(
+      "New hand receipts unavailable in read-only mode",
+    );
+  });
+
+  it("describes Base plan limits", () => {
+    const display = getBillingStatusDisplay(
+      createStatus({
+        accessState: "active",
+        subscriptionTier: "base",
+        activeHandReceiptLimit: 3,
+      }),
+      now,
+    );
+
+    expect(display.planLabel).toBe("Base");
+    expect(display.stateLabel).toBe("Active");
+    expect(display.accessWindowLabel).toBe("Plan-backed access");
+    expect(display.handReceiptLimitLabel).toBe("3 active hand receipts");
+  });
+
+  it("describes Pro plan limits", () => {
+    const display = getBillingStatusDisplay(
+      createStatus({
+        accessState: "active",
+        subscriptionTier: "pro",
+        activeHandReceiptLimit: null,
+      }),
+      now,
+    );
+
+    expect(display.planLabel).toBe("Pro");
+    expect(display.accessWindowLabel).toBe("Plan-backed access");
+    expect(display.handReceiptLimitLabel).toBe(
+      "Unlimited active hand receipts",
+    );
+  });
+
+  it("describes paused accounts in plain language", () => {
+    const display = getBillingStatusDisplay(
+      createStatus({
+        accessState: "paused_read_only",
+        subscriptionTier: "base",
+        isReadOnly: true,
+        activeHandReceiptLimit: 0,
+      }),
+      now,
+    );
+
+    expect(display.planLabel).toBe("Base");
+    expect(display.stateLabel).toBe("Read-only");
+    expect(display.stateDescription).toContain("review existing records");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace /app/billing and /app/settings placeholders with real MVP account surfaces
- Add display-oriented billing status and account session tRPC queries behind module helpers
- Document billing/settings route responsibilities and add display/status coverage
- Address review finding by making active Base/Pro access show plan-backed access instead of a false ended-trial message

## Tests
- pnpm vitest run tests/unit/billing/billing-status-display.test.ts tests/integration/trpc/billing-router.test.ts tests/integration/trpc/accounts-router.test.ts
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm test:unit

Closes #85