### PR TITLE
[codex] Replace dashboard quick-action and signed-out placeholders

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,7 @@ src/modules/app-foundation/
 src/modules/audit/
 src/modules/billing/
 src/modules/contacts/
+src/modules/dashboard/
 src/modules/documents/
 src/modules/hand-receipts/
 src/modules/items/

--- a/src/app/(protected)/app/dashboard/page.tsx
+++ b/src/app/(protected)/app/dashboard/page.tsx
@@ -18,9 +18,6 @@ export default async function DashboardPage() {
   return (
     <section className="space-y-6">
       <div className="space-y-3">
-        <p className="text-xs font-semibold uppercase tracking-[0.06em] text-muted-foreground">
-          Authenticated home
-        </p>
         <h1 className="text-2xl font-semibold tracking-normal md:text-3xl">
           Dashboard
         </h1>

--- a/src/app/(protected)/app/dashboard/page.tsx
+++ b/src/app/(protected)/app/dashboard/page.tsx
@@ -1,30 +1,17 @@
-import { ClipboardList, Search } from "lucide-react";
 import Link from "next/link";
 
 import { ActivityList } from "@/modules/audit/ui/activity-list";
+import { DashboardQuickActions } from "@/modules/dashboard/ui/dashboard-quick-actions";
+import { DashboardSignedOut } from "@/modules/dashboard/ui/dashboard-signed-out";
 import { DashboardRequirements } from "@/modules/requirements/ui/dashboard-requirements";
 import { createTRPCContext } from "@/server/trpc/context";
 import { appRouter } from "@/server/trpc/router";
 
-const dashboardSections = [
-  {
-    description:
-      "Fast entry points will support adding items, reviewing hand receipts, and uploading 2062s.",
-    icon: Search,
-    label: "Quick actions",
-  },
-  {
-    description:
-      "Formal 2062 assignments and manual signed-to items will both be visible, with clear labels.",
-    icon: ClipboardList,
-    label: "Signed-out items",
-  },
-];
-
 export default async function DashboardPage() {
   const caller = appRouter.createCaller(await createTRPCContext());
-  const [dashboardWork, activity] = await Promise.all([
+  const [dashboardWork, signedOut, activity] = await Promise.all([
     caller.requirements.dashboardWork(),
+    caller.items.dashboardSignedOut(),
     caller.audit.listRecentActivity({ limit: 5 }),
   ]);
 
@@ -38,45 +25,22 @@ export default async function DashboardPage() {
           Dashboard
         </h1>
         <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
-          This surface will prioritize requirements, quick actions, and
-          signed-out property without inventing records before those slices
-          exist.
+          Requirements, common property workflows, signed-out state, and recent
+          activity in operational priority order.
         </p>
       </div>
 
       <DashboardRequirements {...dashboardWork} />
 
-      <div className="grid gap-3 lg:grid-cols-2">
-        {dashboardSections.map(({ description, icon: Icon, label }) => (
-          <article
-            className="rounded-lg border bg-card p-4 text-card-foreground"
-            key={label}
-          >
-            <div className="flex items-center gap-3">
-              <span className="flex size-9 items-center justify-center rounded-md bg-secondary text-primary">
-                <Icon aria-hidden="true" className="size-4" />
-              </span>
-              <h2 className="text-base font-semibold tracking-normal">
-                {label}
-              </h2>
-            </div>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground">
-              {description}
-            </p>
-          </article>
-        ))}
-      </div>
+      <DashboardQuickActions isReadOnly={signedOut.isReadOnly} />
+
+      <DashboardSignedOut {...signedOut} />
 
       <section className="space-y-3">
         <div className="flex items-center justify-between gap-3">
-          <div>
-            <h2 className="text-base font-semibold tracking-normal">
-              Recent Activity
-            </h2>
-            <p className="text-sm text-muted-foreground">
-              Account changes, kept below the operational queue.
-            </p>
-          </div>
+          <h2 className="text-base font-semibold tracking-normal">
+            Recent Activity
+          </h2>
           <Link
             className="text-sm font-medium text-primary underline-offset-4 hover:underline"
             href="/app/activity"

--- a/src/modules/dashboard/ui/dashboard-quick-actions.tsx
+++ b/src/modules/dashboard/ui/dashboard-quick-actions.tsx
@@ -1,0 +1,46 @@
+import { PackagePlus, ReceiptText } from "lucide-react";
+import Link from "next/link";
+
+const actionIconClasses =
+  "flex size-8 shrink-0 items-center justify-center rounded-md bg-secondary text-primary";
+
+const writeActions = [
+  {
+    href: "/app/hand-receipts",
+    icon: PackagePlus,
+    label: "Add item",
+  },
+  {
+    href: "/app/hand-receipts",
+    icon: ReceiptText,
+    label: "Upload 2062",
+  },
+];
+
+export function DashboardQuickActions({ isReadOnly }: { isReadOnly: boolean }) {
+  if (isReadOnly) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-2">
+      <h2 className="text-base font-semibold tracking-normal">Quick Actions</h2>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {writeActions.map(({ href, icon: Icon, label }) => (
+          <Link
+            className="flex min-h-14 items-center gap-3 rounded-lg border border-primary/30 bg-primary/5 px-3 py-2 text-card-foreground transition-colors hover:bg-secondary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            href={href}
+            key={label}
+          >
+            <span className={actionIconClasses}>
+              <Icon aria-hidden="true" className="size-4" />
+            </span>
+            <span className="text-sm font-semibold tracking-normal">
+              {label}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/modules/dashboard/ui/dashboard-quick-actions.tsx
+++ b/src/modules/dashboard/ui/dashboard-quick-actions.tsx
@@ -1,19 +1,29 @@
-import { PackagePlus, ReceiptText } from "lucide-react";
+import { ClipboardList, PackagePlus, ReceiptText, Search } from "lucide-react";
 import Link from "next/link";
 
 const actionIconClasses =
   "flex size-8 shrink-0 items-center justify-center rounded-md bg-secondary text-primary";
 
-const writeActions = [
+const dashboardActions = [
   {
     href: "/app/hand-receipts",
     icon: PackagePlus,
     label: "Add item",
   },
   {
-    href: "/app/hand-receipts",
+    href: "/app/items",
+    icon: Search,
+    label: "Search items",
+  },
+  {
     icon: ReceiptText,
-    label: "Upload 2062",
+    href: "/app/active-2062s",
+    label: "Review 2062s",
+  },
+  {
+    href: "/app/hand-receipts?view=archived",
+    icon: ClipboardList,
+    label: "Review archived receipts",
   },
 ];
 
@@ -26,7 +36,7 @@ export function DashboardQuickActions({ isReadOnly }: { isReadOnly: boolean }) {
     <section className="space-y-2">
       <h2 className="text-base font-semibold tracking-normal">Quick Actions</h2>
       <div className="grid gap-2 sm:grid-cols-2">
-        {writeActions.map(({ href, icon: Icon, label }) => (
+        {dashboardActions.map(({ href, icon: Icon, label }) => (
           <Link
             className="flex min-h-14 items-center gap-3 rounded-lg border border-primary/30 bg-primary/5 px-3 py-2 text-card-foreground transition-colors hover:bg-secondary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             href={href}

--- a/src/modules/dashboard/ui/dashboard-signed-out.tsx
+++ b/src/modules/dashboard/ui/dashboard-signed-out.tsx
@@ -138,7 +138,9 @@ export function DashboardSignedOut(props: DashboardSignedOutProps) {
           </Link>
         ) : null}
       </div>
-      {props.isReadOnly ? <DashboardSignedOutReadOnlyNotice /> : null}
+      {props.isReadOnly && hasSignedOut ? (
+        <DashboardSignedOutReadOnlyNotice />
+      ) : null}
       {hasSignedOut ? (
         <div className="grid gap-4 lg:grid-cols-2">
           {props.coveredItems.length > 0 ? (

--- a/src/modules/dashboard/ui/dashboard-signed-out.tsx
+++ b/src/modules/dashboard/ui/dashboard-signed-out.tsx
@@ -1,0 +1,164 @@
+import { ClipboardList, ReceiptText } from "lucide-react";
+import Link from "next/link";
+
+import type {
+  DashboardSignedOutResult,
+  DashboardSignedOutRow,
+} from "@/modules/items";
+import { cn } from "@/lib/utils";
+
+type DashboardSignedOutProps = DashboardSignedOutResult & {
+  isReadOnly: boolean;
+};
+
+function coverageBadgeClasses(
+  coverageType: DashboardSignedOutRow["coverageType"],
+) {
+  return cn(
+    "rounded-[3px] border px-2 py-1 text-[0.6875rem] font-bold uppercase tracking-[0.06em]",
+    coverageType === "da2062"
+      ? "border-emerald-900/30 bg-emerald-900/5 text-emerald-900"
+      : "border-amber-800/30 bg-amber-800/5 text-amber-900",
+  );
+}
+
+function DashboardSignedOutRowView({ row }: { row: DashboardSignedOutRow }) {
+  const label = row.coverageType === "da2062" ? "DA 2062" : "No 2062";
+
+  return (
+    <li>
+      <Link
+        className="grid min-h-20 gap-2 rounded-md border bg-card px-3 py-3 text-card-foreground transition-colors hover:bg-secondary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:grid-cols-[1fr_auto]"
+        href={`/app/items/${row.itemId}`}
+      >
+        <span className="min-w-0 space-y-1">
+          <span className="block truncate text-sm font-semibold tracking-normal">
+            {row.nomenclature}
+          </span>
+          <span className="block truncate text-sm text-muted-foreground">
+            Signed to {row.signedToName}
+          </span>
+          <span className="block truncate text-xs font-medium text-muted-foreground">
+            {row.handReceiptName} · {row.identifier}
+          </span>
+        </span>
+        <span className="flex items-center gap-2 sm:flex-col sm:items-end sm:justify-center">
+          <span className={coverageBadgeClasses(row.coverageType)}>
+            {label}
+          </span>
+          {row.documentFilename ? (
+            <span className="max-w-36 truncate text-[0.6875rem] text-muted-foreground">
+              {row.documentFilename}
+            </span>
+          ) : null}
+        </span>
+      </Link>
+    </li>
+  );
+}
+
+function DashboardSignedOutSection({
+  icon: Icon,
+  rows,
+  title,
+}: {
+  icon: typeof ReceiptText;
+  rows: DashboardSignedOutRow[];
+  title: string;
+}) {
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="flex items-center gap-2 text-sm font-semibold tracking-normal">
+            <Icon aria-hidden="true" className="size-4 text-primary" />
+            {title}
+          </h3>
+        </div>
+        <span className="rounded-[3px] border bg-secondary px-2 py-0.5 font-mono text-[0.6875rem] text-muted-foreground">
+          {rows.length}
+        </span>
+      </div>
+      <ul className="space-y-2">
+        {rows.map((row) => (
+          <DashboardSignedOutRowView key={row.itemId} row={row} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function DashboardSignedOutEmpty({ isReadOnly }: { isReadOnly: boolean }) {
+  return (
+    <div className="rounded-lg border bg-card p-4 text-card-foreground">
+      <h3 className="text-base font-semibold tracking-normal">
+        No signed-out property
+      </h3>
+      <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+        Items assigned by DA 2062 or manual signed-to state will appear here.
+        {isReadOnly
+          ? " This account is read-only, so this is review-only."
+          : ""}
+      </p>
+    </div>
+  );
+}
+
+function DashboardSignedOutReadOnlyNotice() {
+  return (
+    <div className="rounded-lg border border-amber-800/30 bg-amber-800/5 p-4 text-card-foreground">
+      <h3 className="text-base font-semibold tracking-normal">
+        Review-only signed-out state
+      </h3>
+      <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+        This account can still review formal 2062 coverage and manual signed-to
+        property, but the dashboard is not showing write actions.
+      </p>
+    </div>
+  );
+}
+
+export function DashboardSignedOut(props: DashboardSignedOutProps) {
+  const hasSignedOut = props.manualItems.length + props.coveredItems.length > 0;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-base font-semibold tracking-normal">
+            Signed-Out Property
+          </h2>
+        </div>
+        {hasSignedOut ? (
+          <Link
+            className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+            href="/app/items"
+          >
+            View all
+          </Link>
+        ) : null}
+      </div>
+      {props.isReadOnly ? <DashboardSignedOutReadOnlyNotice /> : null}
+      {hasSignedOut ? (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {props.coveredItems.length > 0 ? (
+            <DashboardSignedOutSection
+              icon={ReceiptText}
+              rows={props.coveredItems}
+              title="DA 2062"
+            />
+          ) : null}
+          {props.manualItems.length > 0 ? (
+            <DashboardSignedOutSection
+              icon={ClipboardList}
+              rows={props.manualItems}
+              title="Manual"
+            />
+          ) : null}
+        </div>
+      ) : (
+        <DashboardSignedOutEmpty isReadOnly={props.isReadOnly} />
+      )}
+    </section>
+  );
+}

--- a/src/modules/items/application/list-dashboard-signed-out.ts
+++ b/src/modules/items/application/list-dashboard-signed-out.ts
@@ -1,0 +1,104 @@
+import type { HandReceiptRepository } from "@/modules/hand-receipts";
+
+import type { ItemRepository } from "./item-repository";
+import type {
+  DashboardSignedOutResult,
+  DashboardSignedOutRow,
+  ItemRecord,
+} from "./types";
+
+const DASHBOARD_SIGNED_OUT_LIMIT = 10;
+
+export type ListDashboardSignedOutInput = {
+  accountId: string;
+  handReceiptRepository: HandReceiptRepository;
+  itemRepository: ItemRepository;
+  limitPerGroup?: number;
+};
+
+function getItemIdentifier(item: ItemRecord) {
+  return item.ecn ?? item.serialNumber ?? item.generatedId ?? "No identifier";
+}
+
+function mapManualItem(
+  item: ItemRecord,
+  handReceiptNameById: Map<string, string>,
+): DashboardSignedOutRow {
+  return {
+    itemId: item.id,
+    nomenclature: item.nomenclature,
+    identifier: getItemIdentifier(item),
+    handReceiptId: item.handReceiptId,
+    handReceiptName:
+      handReceiptNameById.get(item.handReceiptId) ?? "Unknown hand receipt",
+    signedToName: item.signedToContactName ?? "Unknown contact",
+    coverageType: "manual",
+    assignmentId: null,
+    documentFilename: null,
+  };
+}
+
+function mapCoveredItem(
+  item: ItemRecord,
+  handReceiptNameById: Map<string, string>,
+): DashboardSignedOutRow {
+  const coverage = item.active2062Coverage;
+
+  return {
+    itemId: item.id,
+    nomenclature: item.nomenclature,
+    identifier: getItemIdentifier(item),
+    handReceiptId: item.handReceiptId,
+    handReceiptName:
+      handReceiptNameById.get(item.handReceiptId) ?? "Unknown hand receipt",
+    signedToName: coverage?.contactName ?? "Unknown contact",
+    coverageType: "da2062",
+    assignmentId: coverage?.assignmentId ?? null,
+    documentFilename: coverage?.documentFilename ?? null,
+  };
+}
+
+export async function listDashboardSignedOut({
+  accountId,
+  handReceiptRepository,
+  itemRepository,
+  limitPerGroup = DASHBOARD_SIGNED_OUT_LIMIT,
+}: ListDashboardSignedOutInput): Promise<DashboardSignedOutResult> {
+  const items = await itemRepository.findByAccountId(accountId, {
+    status: "active",
+  });
+  const signedOutItems = items.filter(
+    (item) => item.signedToContactId || item.active2062Coverage,
+  );
+  const handReceiptIds = [
+    ...new Set(signedOutItems.map((item) => item.handReceiptId)),
+  ];
+  const handReceipts =
+    handReceiptIds.length > 0
+      ? await handReceiptRepository.findManyByIds(accountId, handReceiptIds)
+      : [];
+  const handReceiptNameById = new Map(
+    handReceipts.map((handReceipt) => [handReceipt.id, handReceipt.name]),
+  );
+  const result: DashboardSignedOutResult = {
+    manualItems: [],
+    coveredItems: [],
+  };
+
+  for (const item of signedOutItems) {
+    if (item.active2062Coverage && result.coveredItems.length < limitPerGroup) {
+      result.coveredItems.push(mapCoveredItem(item, handReceiptNameById));
+      continue;
+    }
+
+    if (
+      item.signedToContactId &&
+      !item.active2062Coverage &&
+      result.manualItems.length < limitPerGroup
+    ) {
+      result.manualItems.push(mapManualItem(item, handReceiptNameById));
+    }
+  }
+
+  return result;
+}

--- a/src/modules/items/application/list-dashboard-signed-out.ts
+++ b/src/modules/items/application/list-dashboard-signed-out.ts
@@ -2,8 +2,9 @@ import type { HandReceiptRepository } from "@/modules/hand-receipts";
 
 import type { ItemRepository } from "./item-repository";
 import type {
+  Dashboard2062SignedOutRow,
+  DashboardManualSignedOutRow,
   DashboardSignedOutResult,
-  DashboardSignedOutRow,
   ItemRecord,
 } from "./types";
 
@@ -23,7 +24,7 @@ function getItemIdentifier(item: ItemRecord) {
 function mapManualItem(
   item: ItemRecord,
   handReceiptNameById: Map<string, string>,
-): DashboardSignedOutRow {
+): DashboardManualSignedOutRow {
   return {
     itemId: item.id,
     nomenclature: item.nomenclature,
@@ -41,8 +42,14 @@ function mapManualItem(
 function mapCoveredItem(
   item: ItemRecord,
   handReceiptNameById: Map<string, string>,
-): DashboardSignedOutRow {
+): Dashboard2062SignedOutRow {
   const coverage = item.active2062Coverage;
+
+  if (!coverage) {
+    throw new Error(
+      "Active 2062 coverage is required for covered dashboard rows.",
+    );
+  }
 
   return {
     itemId: item.id,
@@ -51,10 +58,10 @@ function mapCoveredItem(
     handReceiptId: item.handReceiptId,
     handReceiptName:
       handReceiptNameById.get(item.handReceiptId) ?? "Unknown hand receipt",
-    signedToName: coverage?.contactName ?? "Unknown contact",
+    signedToName: coverage.contactName,
     coverageType: "da2062",
-    assignmentId: coverage?.assignmentId ?? null,
-    documentFilename: coverage?.documentFilename ?? null,
+    assignmentId: coverage.assignmentId,
+    documentFilename: coverage.documentFilename,
   };
 }
 

--- a/src/modules/items/application/types.ts
+++ b/src/modules/items/application/types.ts
@@ -105,3 +105,20 @@ export type ItemSearchResult = {
   } | null;
   matchedFields: SearchableItemField[];
 };
+
+export type DashboardSignedOutRow = {
+  itemId: string;
+  nomenclature: string;
+  identifier: string;
+  handReceiptId: string;
+  handReceiptName: string;
+  signedToName: string;
+  coverageType: "manual" | "da2062";
+  assignmentId: string | null;
+  documentFilename: string | null;
+};
+
+export type DashboardSignedOutResult = {
+  manualItems: DashboardSignedOutRow[];
+  coveredItems: DashboardSignedOutRow[];
+};

--- a/src/modules/items/application/types.ts
+++ b/src/modules/items/application/types.ts
@@ -106,19 +106,32 @@ export type ItemSearchResult = {
   matchedFields: SearchableItemField[];
 };
 
-export type DashboardSignedOutRow = {
+type DashboardSignedOutRowBase = {
   itemId: string;
   nomenclature: string;
   identifier: string;
   handReceiptId: string;
   handReceiptName: string;
   signedToName: string;
-  coverageType: "manual" | "da2062";
-  assignmentId: string | null;
-  documentFilename: string | null;
 };
 
+export type DashboardManualSignedOutRow = DashboardSignedOutRowBase & {
+  coverageType: "manual";
+  assignmentId: null;
+  documentFilename: null;
+};
+
+export type Dashboard2062SignedOutRow = DashboardSignedOutRowBase & {
+  coverageType: "da2062";
+  assignmentId: string;
+  documentFilename: string;
+};
+
+export type DashboardSignedOutRow =
+  | DashboardManualSignedOutRow
+  | Dashboard2062SignedOutRow;
+
 export type DashboardSignedOutResult = {
-  manualItems: DashboardSignedOutRow[];
-  coveredItems: DashboardSignedOutRow[];
+  manualItems: DashboardManualSignedOutRow[];
+  coveredItems: Dashboard2062SignedOutRow[];
 };

--- a/src/modules/items/index.ts
+++ b/src/modules/items/index.ts
@@ -5,6 +5,7 @@ export * from "./application/create-item";
 export * from "./application/generated-id";
 export * from "./application/get-item";
 export * from "./application/item-repository";
+export * from "./application/list-dashboard-signed-out";
 export * from "./application/list-items";
 export * from "./application/move-item";
 export * from "./application/search-fields";

--- a/src/modules/requirements/ui/dashboard-requirements.tsx
+++ b/src/modules/requirements/ui/dashboard-requirements.tsx
@@ -165,14 +165,7 @@ export function DashboardRequirements(props: DashboardRequirementsProps) {
 
   return (
     <section className="space-y-3">
-      <div>
-        <h2 className="text-base font-semibold tracking-normal">
-          Requirements
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          Overdue, due soon, then upcoming item work.
-        </p>
-      </div>
+      <h2 className="text-base font-semibold tracking-normal">Requirements</h2>
       {props.isReadOnly ? (
         <DashboardReadOnlyNotice />
       ) : hasRequirements ? (

--- a/src/server/trpc/routers/items.ts
+++ b/src/server/trpc/routers/items.ts
@@ -16,6 +16,7 @@ import {
   clearSignedTo,
   createItem,
   getItem,
+  listDashboardSignedOut,
   listActiveItemsByHandReceipt,
   listArchivedItemsByHandReceipt,
   listItems,
@@ -28,6 +29,7 @@ import type {
   AppUnitOfWork,
   AppUnitOfWorkRepositories,
 } from "@/modules/provider-boundaries/database/app-unit-of-work";
+import { deriveAccountCapabilities } from "@/modules/billing";
 import { createTRPCRouter, protectedProcedure } from "@/server/trpc/init";
 
 const optionalText = z
@@ -218,6 +220,18 @@ async function runInUnitOfWork<T>(
 }
 
 export const itemsRouter = createTRPCRouter({
+  dashboardSignedOut: protectedProcedure.query(({ ctx }) => {
+    const capabilities = deriveAccountCapabilities(ctx.account);
+
+    return listDashboardSignedOut({
+      accountId: ctx.account.id,
+      handReceiptRepository: ctx.handReceiptRepository,
+      itemRepository: ctx.itemRepository,
+    }).then((signedOut) => ({
+      isReadOnly: capabilities.isReadOnly,
+      ...signedOut,
+    }));
+  }),
   list: protectedProcedure.input(listItemsInput).query(({ ctx, input }) =>
     listItems({
       accountId: ctx.account.id,

--- a/tests/e2e/dashboard-requirements.spec.ts
+++ b/tests/e2e/dashboard-requirements.spec.ts
@@ -109,6 +109,10 @@ test("dashboard shows requirement work in priority order on mobile", async ({
     page.getByRole("link").filter({ hasText: "Beyond window PMCS" }),
   ).toBeHidden();
   await expect(page.getByText("Dashboard receipt")).toHaveCount(3);
+  await expect(page.getByRole("link", { name: "Add item" })).toHaveAttribute(
+    "href",
+    "/app/hand-receipts",
+  );
 
   const sectionOrder = await page
     .getByRole("heading", { name: /^(Overdue|Due Soon|Upcoming)$/ })
@@ -122,6 +126,10 @@ test("dashboard shows requirement work in priority order on mobile", async ({
   await expect(
     page.getByRole("heading", { name: "Dashboard radio" }),
   ).toBeVisible();
+
+  await page.goto("/app/dashboard");
+  await page.getByRole("link", { name: "Add item" }).click();
+  await expect(page).toHaveURL(/\/app\/hand-receipts$/);
 });
 
 test("dashboard requirements use desktop width without horizontal overflow", async ({

--- a/tests/integration/trpc/items-router.test.ts
+++ b/tests/integration/trpc/items-router.test.ts
@@ -132,6 +132,45 @@ function createCaller({
 }
 
 describe("itemsRouter", () => {
+  it("returns signed-out dashboard rows for read-only accounts", async () => {
+    const itemRepository = new InMemoryItemRepository([
+      {
+        id: "6339644c-268c-4291-a625-dbe449d1fcf6",
+        accountId: "account-1",
+        handReceiptId: "7db2eba2-c7d5-4ca6-a0d5-7c1e763c7082",
+        nomenclature: "Dashboard radio",
+        ecn: "DASH-001",
+        serialNumber: null,
+        generatedId: null,
+        notes: null,
+        status: "active",
+        signedToContactId: "a3ef961e-1e78-4970-a2f8-17802b6d552d",
+        signedToContactName: "SSG Miller",
+        createdAt: new Date("2026-05-01T12:00:00.000Z"),
+        updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+      },
+    ]);
+
+    await expect(
+      createCaller({
+        account: createAccount({
+          accessState: "paused_read_only",
+          subscriptionTier: "pro",
+        }),
+        itemRepository,
+      }).items.dashboardSignedOut(),
+    ).resolves.toMatchObject({
+      isReadOnly: true,
+      manualItems: [
+        {
+          itemId: "6339644c-268c-4291-a625-dbe449d1fcf6",
+          signedToName: "SSG Miller",
+        },
+      ],
+      coveredItems: [],
+    });
+  });
+
   it("creates an item inside a hand receipt and returns it from that receipt list", async () => {
     const itemRepository = new InMemoryItemRepository();
     const caller = createCaller({ itemRepository });

--- a/tests/unit/dashboard/dashboard-quick-actions.test.ts
+++ b/tests/unit/dashboard/dashboard-quick-actions.test.ts
@@ -4,6 +4,19 @@ import { describe, expect, it } from "vitest";
 
 import { DashboardQuickActions } from "@/modules/dashboard/ui/dashboard-quick-actions";
 
+function hrefFor(markup: string, label: string) {
+  const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const anchors = markup.matchAll(/<a[^>]*href="([^"]+)"[^>]*>[\s\S]*?<\/a>/g);
+
+  for (const anchor of anchors) {
+    if (new RegExp(escapedLabel).test(anchor[0])) {
+      return anchor[1];
+    }
+  }
+
+  return "";
+}
+
 describe("DashboardQuickActions", () => {
   it("renders write-oriented quick actions for active accounts", () => {
     const markup = renderToStaticMarkup(
@@ -12,8 +25,15 @@ describe("DashboardQuickActions", () => {
 
     expect(markup).toContain("Quick Actions");
     expect(markup).toContain("Add item");
-    expect(markup).toContain("Upload 2062");
-    expect(markup).toContain("/app/hand-receipts");
+    expect(markup).toContain("Search items");
+    expect(markup).toContain("Review 2062s");
+    expect(markup).toContain("Review archived receipts");
+    expect(hrefFor(markup, "Add item")).toBe("/app/hand-receipts");
+    expect(hrefFor(markup, "Search items")).toBe("/app/items");
+    expect(hrefFor(markup, "Review 2062s")).toBe("/app/active-2062s");
+    expect(hrefFor(markup, "Review archived receipts")).toBe(
+      "/app/hand-receipts?view=archived",
+    );
   });
 
   it("hides write-oriented quick actions for read-only accounts", () => {
@@ -23,6 +43,8 @@ describe("DashboardQuickActions", () => {
 
     expect(markup).not.toContain("Quick Actions");
     expect(markup).not.toContain("Add item");
-    expect(markup).not.toContain("Upload 2062");
+    expect(markup).not.toContain("Search items");
+    expect(markup).not.toContain("Review 2062s");
+    expect(markup).not.toContain("Review archived receipts");
   });
 });

--- a/tests/unit/dashboard/dashboard-quick-actions.test.ts
+++ b/tests/unit/dashboard/dashboard-quick-actions.test.ts
@@ -1,0 +1,28 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { DashboardQuickActions } from "@/modules/dashboard/ui/dashboard-quick-actions";
+
+describe("DashboardQuickActions", () => {
+  it("renders write-oriented quick actions for active accounts", () => {
+    const markup = renderToStaticMarkup(
+      createElement(DashboardQuickActions, { isReadOnly: false }),
+    );
+
+    expect(markup).toContain("Quick Actions");
+    expect(markup).toContain("Add item");
+    expect(markup).toContain("Upload 2062");
+    expect(markup).toContain("/app/hand-receipts");
+  });
+
+  it("hides write-oriented quick actions for read-only accounts", () => {
+    const markup = renderToStaticMarkup(
+      createElement(DashboardQuickActions, { isReadOnly: true }),
+    );
+
+    expect(markup).not.toContain("Quick Actions");
+    expect(markup).not.toContain("Add item");
+    expect(markup).not.toContain("Upload 2062");
+  });
+});

--- a/tests/unit/dashboard/dashboard-signed-out.test.ts
+++ b/tests/unit/dashboard/dashboard-signed-out.test.ts
@@ -1,0 +1,51 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { DashboardSignedOut } from "@/modules/dashboard/ui/dashboard-signed-out";
+import type { DashboardSignedOutResult } from "@/modules/items";
+
+const emptySignedOut: DashboardSignedOutResult = {
+  coveredItems: [],
+  manualItems: [],
+};
+
+describe("DashboardSignedOut", () => {
+  it("uses only the empty-state read-only message when no property is signed out", () => {
+    const markup = renderToStaticMarkup(
+      createElement(DashboardSignedOut, {
+        ...emptySignedOut,
+        isReadOnly: true,
+      }),
+    );
+
+    expect(markup).toContain("No signed-out property");
+    expect(markup).toContain("This account is read-only");
+    expect(markup).not.toContain("Review-only signed-out state");
+  });
+
+  it("shows the read-only notice when signed-out property exists", () => {
+    const markup = renderToStaticMarkup(
+      createElement(DashboardSignedOut, {
+        coveredItems: [
+          {
+            assignmentId: "assignment-1",
+            coverageType: "da2062",
+            documentFilename: "signed-da-2062.pdf",
+            handReceiptId: "receipt-1",
+            handReceiptName: "Primary receipt",
+            identifier: "FL-000123",
+            itemId: "item-1",
+            nomenclature: "Radio set",
+            signedToName: "SSG Carter",
+          },
+        ],
+        isReadOnly: true,
+        manualItems: [],
+      }),
+    );
+
+    expect(markup).toContain("Review-only signed-out state");
+    expect(markup).toContain("Radio set");
+  });
+});

--- a/tests/unit/items/list-dashboard-signed-out.test.ts
+++ b/tests/unit/items/list-dashboard-signed-out.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { listDashboardSignedOut } from "@/modules/items";
+import type { ItemRecord } from "@/modules/items";
+import { InMemoryHandReceiptRepository } from "../../support/hand-receipt-repository";
+import { InMemoryItemRepository } from "../../support/item-repository";
+
+function item(overrides: Partial<ItemRecord> = {}): ItemRecord {
+  return {
+    id: "item-1",
+    accountId: "account-1",
+    handReceiptId: "hand-receipt-1",
+    nomenclature: "M4 carbine",
+    ecn: "ECN-001",
+    serialNumber: null,
+    generatedId: null,
+    notes: null,
+    status: "active",
+    signedToContactId: null,
+    signedToContactName: null,
+    locationId: null,
+    locationName: null,
+    active2062Coverage: null,
+    createdAt: new Date("2026-05-01T12:00:00.000Z"),
+    updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function handReceiptRepository() {
+  return new InMemoryHandReceiptRepository([
+    {
+      id: "hand-receipt-1",
+      accountId: "account-1",
+      name: "Primary receipt",
+      notes: null,
+      handReceiptNumber: null,
+      holderName: null,
+      unitName: null,
+      uic: null,
+      effectiveDate: null,
+      status: "active",
+      createdAt: new Date("2026-05-01T12:00:00.000Z"),
+      updatedAt: new Date("2026-05-01T12:00:00.000Z"),
+    },
+  ]);
+}
+
+describe("listDashboardSignedOut", () => {
+  it("categorizes manual and formal signed-out items for the dashboard", async () => {
+    const itemRepository = new InMemoryItemRepository([
+      item({
+        id: "manual-item",
+        nomenclature: "Manual radio",
+        signedToContactId: "contact-1",
+        signedToContactName: "SSG Miller",
+      }),
+      item({
+        id: "covered-item",
+        nomenclature: "2062 laptop",
+        ecn: null,
+        serialNumber: "SER-2062",
+        active2062Coverage: {
+          assignmentId: "assignment-1",
+          contactId: "contact-2",
+          contactName: "CPL Nguyen",
+          documentId: "document-1",
+          documentFilename: "da-2062.pdf",
+        },
+      }),
+      item({
+        id: "available-item",
+        nomenclature: "Available optic",
+      }),
+    ]);
+
+    await expect(
+      listDashboardSignedOut({
+        accountId: "account-1",
+        handReceiptRepository: handReceiptRepository(),
+        itemRepository,
+      }),
+    ).resolves.toEqual({
+      manualItems: [
+        expect.objectContaining({
+          itemId: "manual-item",
+          coverageType: "manual",
+          handReceiptName: "Primary receipt",
+          signedToName: "SSG Miller",
+        }),
+      ],
+      coveredItems: [
+        expect.objectContaining({
+          itemId: "covered-item",
+          coverageType: "da2062",
+          documentFilename: "da-2062.pdf",
+          identifier: "SER-2062",
+          signedToName: "CPL Nguyen",
+        }),
+      ],
+    });
+  });
+
+  it("treats formal 2062 coverage as primary when both assignment states exist", async () => {
+    const itemRepository = new InMemoryItemRepository([
+      item({
+        id: "covered-over-manual",
+        signedToContactId: "contact-1",
+        signedToContactName: "Manual contact",
+        active2062Coverage: {
+          assignmentId: "assignment-1",
+          contactId: "contact-2",
+          contactName: "Formal contact",
+          documentId: "document-1",
+          documentFilename: "formal.pdf",
+        },
+      }),
+    ]);
+
+    await expect(
+      listDashboardSignedOut({
+        accountId: "account-1",
+        handReceiptRepository: handReceiptRepository(),
+        itemRepository,
+      }),
+    ).resolves.toMatchObject({
+      manualItems: [],
+      coveredItems: [
+        {
+          itemId: "covered-over-manual",
+          coverageType: "da2062",
+          signedToName: "Formal contact",
+        },
+      ],
+    });
+  });
+
+  it("returns empty groups when no active items are signed out", async () => {
+    await expect(
+      listDashboardSignedOut({
+        accountId: "account-1",
+        handReceiptRepository: handReceiptRepository(),
+        itemRepository: new InMemoryItemRepository([
+          item(),
+          item({
+            id: "archived-manual",
+            status: "archived",
+            signedToContactId: "contact-1",
+            signedToContactName: "SSG Miller",
+          }),
+        ]),
+      }),
+    ).resolves.toEqual({
+      manualItems: [],
+      coveredItems: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces dashboard placeholder cards with real quick actions and signed-out property sections.
- Adds an item application query and `items.dashboardSignedOut` tRPC procedure for formal DA 2062 and manual signed-to dashboard rows.
- Keeps read-only accounts able to review signed-out state while hiding write-oriented quick actions.
- Documents the new dashboard UI module boundary and adds coverage for read-only quick-action hiding.

## Review findings addressed

- Documented `src/modules/dashboard/` in `docs/architecture.md`.
- Added `DashboardQuickActions` unit coverage for active vs read-only accounts.

## Validation

- `pnpm vitest run tests/unit/dashboard/dashboard-quick-actions.test.ts tests/unit/items/list-dashboard-signed-out.test.ts tests/integration/trpc/items-router.test.ts`
- `pnpm typecheck`
- `mkdir -p test-results && pnpm lint`
- `pnpm test:e2e tests/e2e/dashboard-requirements.spec.ts`

Closes #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes: Dashboard Quick Actions & Signed-Out Section

### New Features

**Dashboard Quick Actions**
- Added quick action links on the dashboard for common workflows:
  - Add Item
  - Upload DA 2062
- Quick actions are hidden for read-only accounts

**Dashboard Signed-Out Section**
- New section displaying items currently assigned out (signed-out)
- Items grouped by coverage type:
  - **DA 2062**: Formally covered signed-out items with assignment details
  - **Manual**: Manually signed-to items without formal 2062 coverage
- Each item shows nomenclature, assignee info, hand receipt name, and identifier
- Link to full signed-out items view ("View all")
- Empty state message when no items are signed-out

### Account Behavior

- **Write-enabled accounts**: Full access to quick actions and signed-out review
- **Read-only accounts**: Can view signed-out items but quick actions are hidden; read-only notice displayed in signed-out section

### Technical Changes

- New tRPC query procedure: `items.dashboardSignedOut()`
- New application module: `listDashboardSignedOut` with configurable per-group limits
- New dashboard module boundary: `src/modules/dashboard/`
- Updated dashboard page composition with dedicated components: `DashboardRequirements`, `DashboardQuickActions`, `DashboardSignedOut`

### Tests & Validation

- Added unit tests for quick-action visibility based on read-only status
- Added integration test for `items.dashboardSignedOut()` query
- Added E2E test coverage for Add Item action
- Unit tests covering manual vs. formal DA 2062 categorization and empty states

**Closes:** #86

<!-- end of auto-generated comment: release notes by coderabbit.ai -->