### PR TITLE
Add theme mode toggle to app shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^1.12.0",
     "next": "16.2.4",
+    "next-themes": "^0.4.6",
     "postgres": "^3.4.9",
     "radix-ui": "^1.4.3",
     "react": "19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -4262,6 +4265,12 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next@16.2.4:
     resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
@@ -9178,6 +9187,11 @@ snapshots:
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
+
+  next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   next@16.2.4(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,7 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${interTight.variable} ${jetBrainsMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
       <body className="flex min-h-full flex-col">
         <Providers>{children}</Providers>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,7 +1,17 @@
 import type { ReactNode } from "react";
 
+import { ThemeProvider } from "@/components/theme-provider";
 import { TRPCReactProvider } from "@/trpc/client";
 
 export function Providers({ children }: { children: ReactNode }) {
-  return <TRPCReactProvider>{children}</TRPCReactProvider>;
+  return (
+    <ThemeProvider
+      attribute="class"
+      defaultTheme="system"
+      disableTransitionOnChange
+      enableSystem
+    >
+      <TRPCReactProvider>{children}</TRPCReactProvider>
+    </ThemeProvider>
+  );
 }

--- a/src/components/mode-toggle.tsx
+++ b/src/components/mode-toggle.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Monitor, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+const themeOptions = [
+  { label: "Light", value: "light" },
+  { label: "Dark", value: "dark" },
+  { label: "System", value: "system" },
+] as const;
+
+type ModeToggleProps = {
+  className?: string;
+  contentAlign?: "start" | "center" | "end";
+  labelClassName?: string;
+};
+
+function ThemeIcon({ resolvedTheme }: { resolvedTheme: string | undefined }) {
+  if (resolvedTheme === "dark") {
+    return <Moon aria-hidden="true" className="size-4 shrink-0" />;
+  }
+
+  if (resolvedTheme === "light") {
+    return <Sun aria-hidden="true" className="size-4 shrink-0" />;
+  }
+
+  return <Monitor aria-hidden="true" className="size-4 shrink-0" />;
+}
+
+export function ModeToggle({
+  className,
+  contentAlign = "start",
+  labelClassName,
+}: ModeToggleProps) {
+  const [mounted, setMounted] = useState(false);
+  const { resolvedTheme, setTheme, theme } = useTheme();
+
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      setMounted(true);
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button
+        aria-hidden="true"
+        className={cn("pointer-events-none", className)}
+        size="sm"
+        tabIndex={-1}
+        type="button"
+        variant="ghost"
+      >
+        <Monitor aria-hidden="true" className="size-4 shrink-0" />
+        <span className={labelClassName}>Theme</span>
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label={`Theme: ${theme ?? "system"}`}
+          className={className}
+          data-testid="mode-toggle"
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <ThemeIcon resolvedTheme={resolvedTheme} />
+          <span className={labelClassName}>Theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={contentAlign} className="min-w-36">
+        <DropdownMenuRadioGroup
+          onValueChange={(value) => setTheme(value)}
+          value={theme ?? "system"}
+        >
+          {themeOptions.map((option) => (
+            <DropdownMenuRadioItem key={option.value} value={option.value}>
+              {option.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/shell/app-sidebar.tsx
+++ b/src/components/shell/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   secondaryNavItems,
   type ShellNavItem,
 } from "@/components/shell/navigation-config";
+import { ModeToggle } from "@/components/mode-toggle";
 import {
   Sidebar,
   SidebarContent,
@@ -111,6 +112,10 @@ export function AppSidebar() {
         </SidebarGroup>
       </SidebarContent>
       <SidebarFooter className="border-t border-sidebar-border">
+        <ModeToggle
+          className="h-8 w-full justify-start px-2 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:justify-center"
+          labelClassName="group-data-[collapsible=icon]:hidden"
+        />
         <FeedbackDialog triggerClassName="h-8 w-full justify-start px-2 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:[&_span]:hidden" />
         <SidebarMenu>
           {footerNavItems.map((item) => (

--- a/src/components/shell/bottom-nav.tsx
+++ b/src/components/shell/bottom-nav.tsx
@@ -11,6 +11,7 @@ import {
   secondaryNavItems,
   type ShellNavItem,
 } from "@/components/shell/navigation-config";
+import { ModeToggle } from "@/components/mode-toggle";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -128,6 +129,12 @@ export function BottomNav() {
               <MoreSheetSection items={footerNavItems} title="Account" />
               <div className="border-t pt-2">
                 <FeedbackDialog triggerClassName="h-10 w-full justify-start border border-border bg-card px-3" />
+              </div>
+              <div className="border-t pt-2">
+                <ModeToggle
+                  className="h-10 w-full justify-start border border-border bg-card px-3"
+                  contentAlign="start"
+                />
               </div>
               <form
                 action="/auth/signout"

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import type * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/tests/e2e/app-shell.spec.ts
+++ b/tests/e2e/app-shell.spec.ts
@@ -52,6 +52,7 @@ test("mobile shell uses bottom navigation and exposes More surfaces", async ({
   await expect(page.getByRole("dialog", { name: "More" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Records" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Account" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /Theme:/ })).toBeVisible();
   await page.getByRole("link", { name: "Active 2062s" }).click();
   await expect(page).toHaveURL(/\/app\/active-2062s$/);
   await expect(
@@ -93,6 +94,47 @@ test("desktop shell uses a collapsible sidebar for app navigation", async ({
       return signOutBox?.width ?? 0;
     })
     .toBeLessThanOrEqual(48);
+  await expect
+    .poll(async () => {
+      const themeBox = await page.getByTestId("mode-toggle").boundingBox();
+
+      return themeBox?.width ?? 0;
+    })
+    .toBeLessThanOrEqual(48);
+});
+
+test("users can choose light, dark, and system theme modes", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await signInLocalUser(page);
+
+  await page.getByRole("button", { name: /Theme:/ }).click();
+  await page.getByRole("menuitemradio", { name: "Dark" }).click();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("theme")))
+    .toBe("dark");
+
+  await page.reload();
+  await expect(page.locator("html")).toHaveClass(/dark/);
+
+  await page.getByRole("button", { name: /Theme:/ }).click();
+  await page.getByRole("menuitemradio", { name: "Light" }).click();
+  await expect(page.locator("html")).not.toHaveClass(/dark/);
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("theme")))
+    .toBe("light");
+
+  await page.getByRole("button", { name: /Theme:/ }).click();
+  await page.getByRole("menuitemradio", { name: "System" }).click();
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem("theme")))
+    .toBe("system");
+  await page.emulateMedia({ colorScheme: "dark" });
+  await expect(page.locator("html")).toHaveClass(/dark/);
+  await page.emulateMedia({ colorScheme: "light" });
+  await expect(page.locator("html")).not.toHaveClass(/dark/);
 });
 
 test("signed-in users can open the Activity route with onboarding activity", async ({


### PR DESCRIPTION
## Summary
- add next-themes provider support for the existing light/dark CSS tokens
- add a reusable Light/Dark/System mode toggle in desktop and mobile shell navigation
- cover theme selection, persistence, system mode, and collapsed sidebar layout in the app-shell smoke spec

## Verification
- pnpm typecheck
- mkdir -p test-results && pnpm lint
- pnpm exec playwright test tests/e2e/app-shell.spec.ts
- git diff --check

Closes #95